### PR TITLE
Flake8 support

### DIFF
--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
@@ -20,12 +20,16 @@
 package org.sonar.plugins.python;
 
 import com.google.common.collect.ImmutableList;
+
 import org.sonar.api.SonarPlugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
 import org.sonar.plugins.python.colorizer.PythonColorizer;
 import org.sonar.plugins.python.coverage.PythonCoverageSensor;
 import org.sonar.plugins.python.cpd.PythonCpdMapping;
+import org.sonar.plugins.python.flake8.Flake8Configuration;
+import org.sonar.plugins.python.flake8.Flake8RuleRepository;
+import org.sonar.plugins.python.flake8.Flake8Sensor;
 import org.sonar.plugins.python.pylint.PylintConfiguration;
 import org.sonar.plugins.python.pylint.PylintRuleRepository;
 import org.sonar.plugins.python.pylint.PylintSensor;
@@ -63,6 +67,10 @@ public class PythonPlugin extends SonarPlugin {
         PylintConfiguration.class,
         PylintSensor.class,
         PylintRuleRepository.class,
+
+        Flake8Configuration.class,
+        Flake8Sensor.class,
+        Flake8RuleRepository.class,
 
         PythonXunitSensor.class,
         PythonCoverageSensor.class);

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/CommandStreamConsumer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/CommandStreamConsumer.java
@@ -1,0 +1,37 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+import org.sonar.api.utils.command.StreamConsumer;
+
+import java.util.LinkedList;
+import java.util.List;
+
+class CommandStreamConsumer implements StreamConsumer {
+  private List<String> data = new LinkedList<String>();
+
+  public void consumeLine(String line) {
+    data.add(line);
+  }
+
+  public List<String> getData() {
+    return data;
+  }
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Configuration.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Configuration.java
@@ -1,0 +1,75 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+import org.apache.commons.lang.StringUtils;
+import org.sonar.api.BatchExtension;
+import org.sonar.api.Properties;
+import org.sonar.api.Property;
+import org.sonar.api.config.Settings;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+
+import java.io.File;
+
+@Properties({
+  @Property(
+    key = Flake8Configuration.FLAKE8_CONFIG_KEY,
+    defaultValue = "",
+    name = "flake8 configuration",
+    description = "Path to the flake8 configuration file to use in flake8 analysis. Set to empty to use the default.",
+    global = false,
+    project = true),
+  @Property(
+    key = Flake8Configuration.FLAKE8_KEY,
+    defaultValue = "",
+    name = "flake8 executable",
+    description = "Path to the flake8 executable to use in flake8 analysis. Set to empty to use the default one.",
+    global = true,
+    project = false)
+})
+public class Flake8Configuration implements BatchExtension {
+
+  public static final String FLAKE8_CONFIG_KEY = "sonar.python.flake8_config";
+  public static final String FLAKE8_KEY = "sonar.python.flake8";
+
+  private final Settings conf;
+
+  public Flake8Configuration(Settings conf) {
+    this.conf = conf;
+  }
+
+  public String getPylintConfigPath(ModuleFileSystem fileSystem) {
+    String configPath = conf.getString(Flake8Configuration.FLAKE8_CONFIG_KEY);
+    if (StringUtils.isEmpty(configPath)) {
+      return null;
+    }
+    File configFile = new File(configPath);
+    if (!configFile.isAbsolute()) {
+      File projectRoot = fileSystem.baseDir();
+      configFile = new File(projectRoot.getPath(), configPath);
+    }
+    return configFile.getAbsolutePath();
+  }
+
+  public String getPylintPath() {
+    return conf.getString(Flake8Configuration.FLAKE8_KEY);
+  }
+
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Configuration.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Configuration.java
@@ -55,7 +55,7 @@ public class Flake8Configuration implements BatchExtension {
     this.conf = conf;
   }
 
-  public String getPylintConfigPath(ModuleFileSystem fileSystem) {
+  public String getFlake8ConfigPath(ModuleFileSystem fileSystem) {
     String configPath = conf.getString(Flake8Configuration.FLAKE8_CONFIG_KEY);
     if (StringUtils.isEmpty(configPath)) {
       return null;
@@ -68,7 +68,7 @@ public class Flake8Configuration implements BatchExtension {
     return configFile.getAbsolutePath();
   }
 
-  public String getPylintPath() {
+  public String getFlake8Path() {
     return conf.getString(Flake8Configuration.FLAKE8_KEY);
   }
 

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8IssuesAnalyzer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8IssuesAnalyzer.java
@@ -1,0 +1,132 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.utils.SonarException;
+import org.sonar.api.utils.command.Command;
+import org.sonar.api.utils.command.CommandExecutor;
+
+import com.google.common.io.Files;
+
+public class Flake8IssuesAnalyzer {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Flake8Sensor.class);
+
+
+  private static final String FALLBACK_COMMAND = "flake8";
+  private static final Pattern PATTERN = Pattern.compile("([^:]+):([0-9]+):([0-9]+): (\\S+) (.*)");
+
+  private String flake8 = null;
+  private String flake8ConfigParam = null;
+
+  Flake8IssuesAnalyzer(String flake8Path, String flake8ConfigPath) {
+    flake8 = flake8PathWithDefault(flake8Path);
+
+    if (flake8ConfigPath != null) {
+      if (!new File(flake8ConfigPath).exists()) {
+        throw new SonarException("Cannot find the flake8 configuration file: " + flake8ConfigPath);
+      }
+      flake8ConfigParam = "--config=" + flake8ConfigPath;
+    }
+    
+  }
+
+  private static String flake8PathWithDefault(String flake8Path) {
+    if (flake8Path != null) {
+      if (!new File(flake8Path).exists()) {
+        throw new SonarException("Cannot find the flake8 executable: " + flake8Path);
+      }
+      return flake8Path;
+    }
+    return FALLBACK_COMMAND;
+  }
+
+  public List<Issue> analyze(String path, Charset charset, File out) throws IOException {
+    Command command = Command.create(flake8).addArgument(path);
+
+    if (flake8ConfigParam != null) {
+      command.addArgument(flake8ConfigParam);
+    }
+
+    LOG.debug("Calling command: '{}'", command.toString());
+
+    long timeoutMS = 300000; // =5min
+    CommandStreamConsumer stdOut = new CommandStreamConsumer();
+    CommandStreamConsumer stdErr = new CommandStreamConsumer();
+    CommandExecutor.create().execute(command, stdOut, stdErr, timeoutMS);
+
+    // the error stream can contain a line like 'no custom config found, using default'
+    // any bigger output on the error stream is likely a flake8 malfunction
+    if (stdErr.getData().size() > 1) {
+      LOG.warn("Output on the error channel detected: this is probably due to a problem on flake8's side.");
+      LOG.warn("Content of the error stream: \n\"{}\"", StringUtils.join(stdErr.getData(), "\n"));
+    }
+
+    Files.write(StringUtils.join(stdOut.getData(), "\n"), out, charset);
+
+    return parseOutput(stdOut.getData());
+  }
+
+  protected List<Issue> parseOutput(List<String> lines) {
+    // Parse the output of flake8. Example of the format:
+    //
+    // complexity/code_chunks.py:62:32: W0104 Statement seems to have no effect
+
+    List<Issue> issues = new LinkedList<Issue>();
+
+    int linenr;
+    String filename = null;
+    String ruleid = null;
+    String descr = null;
+
+    if (!lines.isEmpty()) {
+      for (String line : lines) {
+        if (line.length() > 0) {
+            Matcher m = PATTERN.matcher(line);
+            if (m.matches() && m.groupCount() == 5) {
+              filename = m.group(1);
+              linenr = Integer.valueOf(m.group(2));
+              ruleid = m.group(4);
+              descr = m.group(5);
+              issues.add(new Issue(filename, linenr, ruleid, descr));
+            } else {
+              LOG.debug("Cannot parse the line: {}", line);
+            }
+          } else {
+            LOG.trace("Classifying as detail and ignoring line '{}'", line);
+          }
+        }
+    }
+
+    return issues;
+  }
+
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8RuleRepository.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8RuleRepository.java
@@ -1,0 +1,52 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+import org.sonar.api.rules.Rule;
+import org.sonar.api.rules.RuleRepository;
+import org.sonar.api.rules.XMLRuleParser;
+import org.sonar.plugins.python.Python;
+
+import java.util.List;
+
+public class Flake8RuleRepository extends RuleRepository {
+
+  public static final String REPOSITORY_NAME = "Flake8";
+  public static final String REPOSITORY_KEY = REPOSITORY_NAME;
+
+  private static final String RULES_FILE = "/org/sonar/plugins/python/flake8/rules.xml";
+  private final XMLRuleParser ruleParser;
+
+  public Flake8RuleRepository(XMLRuleParser ruleParser) {
+    super(REPOSITORY_KEY, Python.KEY);
+    setName(REPOSITORY_NAME);
+    this.ruleParser = ruleParser;
+  }
+
+  @Override
+  public List<Rule> createRules() {
+    List<Rule> rules = ruleParser.parse(getClass().getResourceAsStream(RULES_FILE));
+    for (Rule r : rules) {
+      r.setRepositoryKey(REPOSITORY_KEY);
+    }
+    return rules;
+  }
+
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
@@ -92,7 +92,7 @@ public class Flake8Sensor implements Sensor {
     String flake8ConfigPath = conf.getPylintConfigPath(fileSystem);
     String flake8Path = conf.getPylintPath();
 
-    PylintIssuesAnalyzer analyzer = new PylintIssuesAnalyzer(flake8Path, flake8ConfigPath);
+    Flake8IssuesAnalyzer analyzer = new Flake8IssuesAnalyzer(flake8Path, flake8ConfigPath);
     List<Issue> issues = analyzer.analyze(file.getAbsolutePath(), fileSystem.sourceCharset(), out);
 
     for (Issue flake8Issue : issues) {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
@@ -1,0 +1,132 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.Sensor;
+import org.sonar.api.batch.SensorContext;
+import org.sonar.api.component.ResourcePerspectives;
+import org.sonar.api.issue.Issuable;
+import org.sonar.api.profiles.RulesProfile;
+import org.sonar.api.resources.Project;
+import org.sonar.api.rule.RuleKey;
+import org.sonar.api.rules.Rule;
+import org.sonar.api.rules.RuleFinder;
+import org.sonar.api.scan.filesystem.FileQuery;
+import org.sonar.api.scan.filesystem.ModuleFileSystem;
+import org.sonar.api.utils.SonarException;
+import org.sonar.plugins.python.Python;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+public class Flake8Sensor implements Sensor {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Flake8Sensor.class);
+
+  private RuleFinder ruleFinder;
+  private RulesProfile profile;
+  private PylintConfiguration conf;
+  private ModuleFileSystem fileSystem;
+  private ResourcePerspectives resourcePerspectives;
+
+
+  public Flake8Sensor(RuleFinder ruleFinder, PylintConfiguration conf, RulesProfile profile, ModuleFileSystem fileSystem, ResourcePerspectives resourcePerspectives) {
+    this.ruleFinder = ruleFinder;
+    this.conf = conf;
+    this.profile = profile;
+    this.fileSystem = fileSystem;
+    this.resourcePerspectives = resourcePerspectives;
+  }
+
+  public boolean shouldExecuteOnProject(Project project) {
+    return !fileSystem.files(FileQuery.onSource().onLanguage(Python.KEY)).isEmpty()
+        && !profile.getActiveRulesByRepository(PylintRuleRepository.REPOSITORY_KEY).isEmpty();
+  }
+
+  public void analyse(Project project, SensorContext sensorContext) {
+    File workdir = new File(fileSystem.workingDir(), "/flake8/");
+    prepareWorkDir(workdir);
+    int i = 0;
+    for (File file : fileSystem.files(FileQuery.onSource().onLanguage(Python.KEY))) {
+      try {
+        File out = new File(workdir, i + ".out");
+        analyzeFile(file, out, project, sensorContext);
+        i++;
+      } catch (Exception e) {
+        String msg = new StringBuilder()
+            .append("Cannot analyse the file '")
+            .append(file.getAbsolutePath())
+            .append("', details: '")
+            .append(e)
+            .append("'")
+            .toString();
+        throw new SonarException(msg, e);
+      }
+    }
+  }
+
+  protected void analyzeFile(File file, File out, Project project, SensorContext sensorContext) throws IOException {
+    org.sonar.api.resources.File pyfile = org.sonar.api.resources.File.fromIOFile(file, project);
+
+    String flake8ConfigPath = conf.getPylintConfigPath(fileSystem);
+    String flake8Path = conf.getPylintPath();
+
+    PylintIssuesAnalyzer analyzer = new PylintIssuesAnalyzer(flake8Path, flake8ConfigPath);
+    List<Issue> issues = analyzer.analyze(file.getAbsolutePath(), fileSystem.sourceCharset(), out);
+
+    for (Issue flake8Issue : issues) {
+      Rule rule = ruleFinder.findByKey(PylintRuleRepository.REPOSITORY_KEY, flake8Issue.getRuleId());
+
+      if (rule != null) {
+        if (rule.isEnabled()) {
+          Issuable issuable = resourcePerspectives.as(Issuable.class, pyfile);
+
+          if (issuable != null) {
+            org.sonar.api.issue.Issue issue = issuable.newIssueBuilder()
+              .ruleKey(RuleKey.of(rule.getRepositoryKey(), rule.getKey()))
+              .line(flake8Issue.getLine())
+              .message(flake8Issue.getDescr())
+              .build();
+            issuable.addIssue(issue);
+          }
+        } else {
+          LOG.debug("Pylint rule '{}' is disabled in Sonar", flake8Issue.getRuleId());
+        }
+      } else {
+        LOG.warn("Pylint rule '{}' is unknown in Sonar", flake8Issue.getRuleId());
+      }
+    }
+  }
+
+  private static void prepareWorkDir(File dir) {
+    try {
+      FileUtils.forceMkdir(dir);
+      // directory is cleaned, because Sonar 3.0 will not do this for us
+      FileUtils.cleanDirectory(dir);
+    } catch (IOException e) {
+      throw new SonarException("Cannot create directory: " + dir, e);
+    }
+  }
+
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
@@ -89,8 +89,8 @@ public class Flake8Sensor implements Sensor {
   protected void analyzeFile(File file, File out, Project project, SensorContext sensorContext) throws IOException {
     org.sonar.api.resources.File pyfile = org.sonar.api.resources.File.fromIOFile(file, project);
 
-    String flake8ConfigPath = conf.getPylintConfigPath(fileSystem);
-    String flake8Path = conf.getPylintPath();
+    String flake8ConfigPath = conf.getFlake8ConfigPath(fileSystem);
+    String flake8Path = conf.getFlake8Path();
 
     Flake8IssuesAnalyzer analyzer = new Flake8IssuesAnalyzer(flake8Path, flake8ConfigPath);
     List<Issue> issues = analyzer.analyze(file.getAbsolutePath(), fileSystem.sourceCharset(), out);
@@ -111,10 +111,10 @@ public class Flake8Sensor implements Sensor {
             issuable.addIssue(issue);
           }
         } else {
-          LOG.debug("Pylint rule '{}' is disabled in Sonar", flake8Issue.getRuleId());
+          LOG.debug("Flake8 rule '{}' is disabled in Sonar", flake8Issue.getRuleId());
         }
       } else {
-        LOG.warn("Pylint rule '{}' is unknown in Sonar", flake8Issue.getRuleId());
+        LOG.warn("Flake8 rule '{}' is unknown in Sonar", flake8Issue.getRuleId());
       }
     }
   }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
@@ -46,12 +46,12 @@ public class Flake8Sensor implements Sensor {
 
   private RuleFinder ruleFinder;
   private RulesProfile profile;
-  private PylintConfiguration conf;
+  private Flake8Configuration conf;
   private ModuleFileSystem fileSystem;
   private ResourcePerspectives resourcePerspectives;
 
 
-  public Flake8Sensor(RuleFinder ruleFinder, PylintConfiguration conf, RulesProfile profile, ModuleFileSystem fileSystem, ResourcePerspectives resourcePerspectives) {
+  public Flake8Sensor(RuleFinder ruleFinder, Flake8Configuration conf, RulesProfile profile, ModuleFileSystem fileSystem, ResourcePerspectives resourcePerspectives) {
     this.ruleFinder = ruleFinder;
     this.conf = conf;
     this.profile = profile;

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Flake8Sensor.java
@@ -61,7 +61,7 @@ public class Flake8Sensor implements Sensor {
 
   public boolean shouldExecuteOnProject(Project project) {
     return !fileSystem.files(FileQuery.onSource().onLanguage(Python.KEY)).isEmpty()
-        && !profile.getActiveRulesByRepository(PylintRuleRepository.REPOSITORY_KEY).isEmpty();
+        && !profile.getActiveRulesByRepository(Flake8RuleRepository.REPOSITORY_KEY).isEmpty();
   }
 
   public void analyse(Project project, SensorContext sensorContext) {
@@ -96,7 +96,7 @@ public class Flake8Sensor implements Sensor {
     List<Issue> issues = analyzer.analyze(file.getAbsolutePath(), fileSystem.sourceCharset(), out);
 
     for (Issue flake8Issue : issues) {
-      Rule rule = ruleFinder.findByKey(PylintRuleRepository.REPOSITORY_KEY, flake8Issue.getRuleId());
+      Rule rule = ruleFinder.findByKey(Flake8RuleRepository.REPOSITORY_KEY, flake8Issue.getRuleId());
 
       if (rule != null) {
         if (rule.isEnabled()) {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Issue.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/Issue.java
@@ -1,0 +1,56 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+package org.sonar.plugins.python.flake8;
+
+class Issue {
+
+  private final String filename;
+  private final int line;
+  private final String ruleId;
+  private final String descr;
+
+  Issue(String filename, int line, String ruleId, String descr) {
+    this.filename = filename;
+    this.line = line;
+    this.ruleId = ruleId;
+    this.descr = descr;
+  }
+
+  @Override
+  public String toString() {
+    return "(" + filename + ", " + line + ", " + ruleId + ", " + descr + ")";
+  }
+
+  String getFilename() {
+    return filename;
+  }
+
+  int getLine() {
+    return line;
+  }
+
+  String getRuleId() {
+    return ruleId;
+  }
+
+  String getDescr() {
+    return descr;
+  }
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/package-info.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/flake8/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011 SonarSource and Waleri Enns
+ * dev@sonar.codehaus.org
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02
+ */
+
+/**
+ * Integration with flake8
+ */
+@ParametersAreNonnullByDefault
+package org.sonar.plugins.python.flake8;
+
+import javax.annotation.ParametersAreNonnullByDefault;
+

--- a/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/convert.py
+++ b/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/convert.py
@@ -1,0 +1,32 @@
+import collections
+import sys
+
+Rule = collections.namedtuple("Rule", ['code', 'message'])
+    
+def parse_rule(line):
+    (code, message) = line.split(' ', 1)
+    assert code
+    assert message
+    return Rule(code, message.strip())
+
+def convert_rule_to_xml(rule):
+    xml = '\n'.join([
+        "  <rule>",
+        "      <key>{code}</key>",
+        "      <name><![CDATA[{message}]]></name>",
+        "      <configKey>{code}</configKey>",
+        "      <description>",
+        "          <![CDATA[{message}]]>",
+        "      </description>",
+        "  </rule>"])
+    return xml.format(code=rule.code, message=rule.message)
+
+
+xml = ('<?xml version="1.0" encoding="ASCII"?>\n'
+       '<rules>')
+for line in sys.stdin.readlines():
+    rule = parse_rule(line)
+    xml += "\n%s" % convert_rule_to_xml(rule)
+xml += '\n</rules>'
+
+sys.stdout.write(xml)

--- a/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/errors.txt
+++ b/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/errors.txt
@@ -68,3 +68,25 @@ W601 .has_key() is deprecated, use 'in'
 W602 deprecated form of raising exception
 W603 '<>' is deprecated, use '!='
 W604 backticks are deprecated, use 'repr()'
+F401 module imported but unused
+F402 import module from line N shadowed by loop variable
+F403 'from module import *' used; unable to detect undefined names
+F404 future import(s) name after other statements
+F811 redefinition of unused name from line N
+F812 list comprehension redefines name from line N
+F821 undefined name name
+F822 undefined name name in __all__
+F823 local variable name ... referenced before assignment
+F831 duplicate argument name in function definition
+F841 local variable name is assigned to but never used
+C901 %r is too complex (%d)
+N801 class names should use CapWords convention
+N802 function name should be lowercase
+N803 argument name should be lowercase
+N804 first argument of a classmethod should be named 'cls'
+N805 first argument of a method should be named 'self'
+N806 variable in function should be lowercase
+N811 constant imported as non constant
+N812 lowercase imported as non lowercase
+N813 camelcase imported as lowercase
+N814 camelcase imported as constant

--- a/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/errors.txt
+++ b/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/errors.txt
@@ -1,0 +1,70 @@
+E101 indentation contains mixed spaces and tabs
+E111 indentation is not a multiple of four
+E112 expected an indented block
+E113 unexpected indentation
+E114 indentation is not a multiple of four (comment)
+E115 expected an indented block (comment)
+E116 unexpected indentation (comment)
+E121 continuation line under-indented for hanging indent
+E122 continuation line missing indentation or outdented
+E123 closing bracket does not match indentation of opening bracket's line
+E124 closing bracket does not match visual indentation
+E125 continuation line with same indent as next logical line
+E126 continuation line over-indented for hanging indent
+E127 continuation line over-indented for visual indent
+E128 continuation line under-indented for visual indent
+E129 visually indented line with same indent as next logical line
+E131 continuation line unaligned for hanging indent
+E133 closing bracket is missing indentation
+E201 whitespace after '('
+E202 whitespace before ')'
+E203 whitespace before ':'
+E211 whitespace before '('
+E221 multiple spaces before operator
+E222 multiple spaces after operator
+E223 tab before operator
+E224 tab after operator
+E225 missing whitespace around operator
+E226 missing whitespace around arithmetic operator
+E227 missing whitespace around bitwise or shift operator
+E228 missing whitespace around modulo operator
+E231 missing whitespace after ','
+E241 multiple spaces after ','
+E242 tab after ','
+E251 unexpected spaces around keyword / parameter equals
+E261 at least two spaces before inline comment
+E262 inline comment should start with '# '
+E265 block comment should start with '# '
+E266 too many leading '#' for block comment
+E271 multiple spaces after keyword
+E272 multiple spaces before keyword
+E273 tab after keyword
+E274 tab before keyword
+E301 expected 1 blank line, found 0
+E302 expected 2 blank lines, found 0
+E303 too many blank lines (3)
+E304 blank lines found after function decorator
+E401 multiple imports on one line
+E501 line too long (82 > 79 characters)
+E502 the backslash is redundant between brackets
+E701 multiple statements on one line (colon)
+E702 multiple statements on one line (semicolon)
+E703 statement ends with a semicolon
+E704 multiple statements on one line (def)
+E711 comparison to None should be 'if cond is None:'
+E712 comparison to True should be 'if cond is True:' or 'if cond:'
+E713 test for membership should be 'not in'
+E714 test for object identity should be 'is not'
+E721 do not compare types, use 'isinstance()'
+E731 do not assign a lambda expression, use a def
+E901 SyntaxError or IndentationError
+E902 IOError
+W191 indentation contains tabs
+W291 trailing whitespace
+W292 no newline at end of file
+W293 blank line contains whitespace
+W391 blank line at end of file
+W601 .has_key() is deprecated, use 'in'
+W602 deprecated form of raising exception
+W603 '<>' is deprecated, use '!='
+W604 backticks are deprecated, use 'repr()'

--- a/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/rules.xml
+++ b/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/rules.xml
@@ -560,4 +560,180 @@
           <![CDATA[backticks are deprecated, use 'repr()']]>
       </description>
   </rule>
+  <rule>
+      <key>F401</key>
+      <name><![CDATA[module imported but unused]]></name>
+      <configKey>F401</configKey>
+      <description>
+          <![CDATA[module imported but unused]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F402</key>
+      <name><![CDATA[import module from line N shadowed by loop variable]]></name>
+      <configKey>F402</configKey>
+      <description>
+          <![CDATA[import module from line N shadowed by loop variable]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F403</key>
+      <name><![CDATA['from module import *' used; unable to detect undefined names]]></name>
+      <configKey>F403</configKey>
+      <description>
+          <![CDATA['from module import *' used; unable to detect undefined names]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F404</key>
+      <name><![CDATA[future import(s) name after other statements]]></name>
+      <configKey>F404</configKey>
+      <description>
+          <![CDATA[future import(s) name after other statements]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F811</key>
+      <name><![CDATA[redefinition of unused name from line N]]></name>
+      <configKey>F811</configKey>
+      <description>
+          <![CDATA[redefinition of unused name from line N]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F812</key>
+      <name><![CDATA[list comprehension redefines name from line N]]></name>
+      <configKey>F812</configKey>
+      <description>
+          <![CDATA[list comprehension redefines name from line N]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F821</key>
+      <name><![CDATA[undefined name name]]></name>
+      <configKey>F821</configKey>
+      <description>
+          <![CDATA[undefined name name]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F822</key>
+      <name><![CDATA[undefined name name in __all__]]></name>
+      <configKey>F822</configKey>
+      <description>
+          <![CDATA[undefined name name in __all__]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F823</key>
+      <name><![CDATA[local variable name ... referenced before assignment]]></name>
+      <configKey>F823</configKey>
+      <description>
+          <![CDATA[local variable name ... referenced before assignment]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F831</key>
+      <name><![CDATA[duplicate argument name in function definition]]></name>
+      <configKey>F831</configKey>
+      <description>
+          <![CDATA[duplicate argument name in function definition]]>
+      </description>
+  </rule>
+  <rule>
+      <key>F841</key>
+      <name><![CDATA[local variable name is assigned to but never used]]></name>
+      <configKey>F841</configKey>
+      <description>
+          <![CDATA[local variable name is assigned to but never used]]>
+      </description>
+  </rule>
+  <rule>
+      <key>C901</key>
+      <name><![CDATA[%r is too complex (%d)]]></name>
+      <configKey>C901</configKey>
+      <description>
+          <![CDATA[%r is too complex (%d)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N801</key>
+      <name><![CDATA[class names should use CapWords convention]]></name>
+      <configKey>N801</configKey>
+      <description>
+          <![CDATA[class names should use CapWords convention]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N802</key>
+      <name><![CDATA[function name should be lowercase]]></name>
+      <configKey>N802</configKey>
+      <description>
+          <![CDATA[function name should be lowercase]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N803</key>
+      <name><![CDATA[argument name should be lowercase]]></name>
+      <configKey>N803</configKey>
+      <description>
+          <![CDATA[argument name should be lowercase]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N804</key>
+      <name><![CDATA[first argument of a classmethod should be named 'cls']]></name>
+      <configKey>N804</configKey>
+      <description>
+          <![CDATA[first argument of a classmethod should be named 'cls']]>
+      </description>
+  </rule>
+  <rule>
+      <key>N805</key>
+      <name><![CDATA[first argument of a method should be named 'self']]></name>
+      <configKey>N805</configKey>
+      <description>
+          <![CDATA[first argument of a method should be named 'self']]>
+      </description>
+  </rule>
+  <rule>
+      <key>N806</key>
+      <name><![CDATA[variable in function should be lowercase]]></name>
+      <configKey>N806</configKey>
+      <description>
+          <![CDATA[variable in function should be lowercase]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N811</key>
+      <name><![CDATA[constant imported as non constant]]></name>
+      <configKey>N811</configKey>
+      <description>
+          <![CDATA[constant imported as non constant]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N812</key>
+      <name><![CDATA[lowercase imported as non lowercase]]></name>
+      <configKey>N812</configKey>
+      <description>
+          <![CDATA[lowercase imported as non lowercase]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N813</key>
+      <name><![CDATA[camelcase imported as lowercase]]></name>
+      <configKey>N813</configKey>
+      <description>
+          <![CDATA[camelcase imported as lowercase]]>
+      </description>
+  </rule>
+  <rule>
+      <key>N814</key>
+      <name><![CDATA[camelcase imported as constant]]></name>
+      <configKey>N814</configKey>
+      <description>
+          <![CDATA[camelcase imported as constant]]>
+      </description>
+  </rule>
 </rules>

--- a/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/rules.xml
+++ b/sonar-python-plugin/src/main/resources/org/sonar/plugins/python/flake8/rules.xml
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="ASCII"?>
+<rules>
+  <rule>
+      <key>E101</key>
+      <name><![CDATA[indentation contains mixed spaces and tabs]]></name>
+      <configKey>E101</configKey>
+      <description>
+          <![CDATA[indentation contains mixed spaces and tabs]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E111</key>
+      <name><![CDATA[indentation is not a multiple of four]]></name>
+      <configKey>E111</configKey>
+      <description>
+          <![CDATA[indentation is not a multiple of four]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E112</key>
+      <name><![CDATA[expected an indented block]]></name>
+      <configKey>E112</configKey>
+      <description>
+          <![CDATA[expected an indented block]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E113</key>
+      <name><![CDATA[unexpected indentation]]></name>
+      <configKey>E113</configKey>
+      <description>
+          <![CDATA[unexpected indentation]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E114</key>
+      <name><![CDATA[indentation is not a multiple of four (comment)]]></name>
+      <configKey>E114</configKey>
+      <description>
+          <![CDATA[indentation is not a multiple of four (comment)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E115</key>
+      <name><![CDATA[expected an indented block (comment)]]></name>
+      <configKey>E115</configKey>
+      <description>
+          <![CDATA[expected an indented block (comment)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E116</key>
+      <name><![CDATA[unexpected indentation (comment)]]></name>
+      <configKey>E116</configKey>
+      <description>
+          <![CDATA[unexpected indentation (comment)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E121</key>
+      <name><![CDATA[continuation line under-indented for hanging indent]]></name>
+      <configKey>E121</configKey>
+      <description>
+          <![CDATA[continuation line under-indented for hanging indent]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E122</key>
+      <name><![CDATA[continuation line missing indentation or outdented]]></name>
+      <configKey>E122</configKey>
+      <description>
+          <![CDATA[continuation line missing indentation or outdented]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E123</key>
+      <name><![CDATA[closing bracket does not match indentation of opening bracket's line]]></name>
+      <configKey>E123</configKey>
+      <description>
+          <![CDATA[closing bracket does not match indentation of opening bracket's line]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E124</key>
+      <name><![CDATA[closing bracket does not match visual indentation]]></name>
+      <configKey>E124</configKey>
+      <description>
+          <![CDATA[closing bracket does not match visual indentation]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E125</key>
+      <name><![CDATA[continuation line with same indent as next logical line]]></name>
+      <configKey>E125</configKey>
+      <description>
+          <![CDATA[continuation line with same indent as next logical line]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E126</key>
+      <name><![CDATA[continuation line over-indented for hanging indent]]></name>
+      <configKey>E126</configKey>
+      <description>
+          <![CDATA[continuation line over-indented for hanging indent]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E127</key>
+      <name><![CDATA[continuation line over-indented for visual indent]]></name>
+      <configKey>E127</configKey>
+      <description>
+          <![CDATA[continuation line over-indented for visual indent]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E128</key>
+      <name><![CDATA[continuation line under-indented for visual indent]]></name>
+      <configKey>E128</configKey>
+      <description>
+          <![CDATA[continuation line under-indented for visual indent]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E129</key>
+      <name><![CDATA[visually indented line with same indent as next logical line]]></name>
+      <configKey>E129</configKey>
+      <description>
+          <![CDATA[visually indented line with same indent as next logical line]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E131</key>
+      <name><![CDATA[continuation line unaligned for hanging indent]]></name>
+      <configKey>E131</configKey>
+      <description>
+          <![CDATA[continuation line unaligned for hanging indent]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E133</key>
+      <name><![CDATA[closing bracket is missing indentation]]></name>
+      <configKey>E133</configKey>
+      <description>
+          <![CDATA[closing bracket is missing indentation]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E201</key>
+      <name><![CDATA[whitespace after '(']]></name>
+      <configKey>E201</configKey>
+      <description>
+          <![CDATA[whitespace after '(']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E202</key>
+      <name><![CDATA[whitespace before ')']]></name>
+      <configKey>E202</configKey>
+      <description>
+          <![CDATA[whitespace before ')']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E203</key>
+      <name><![CDATA[whitespace before ':']]></name>
+      <configKey>E203</configKey>
+      <description>
+          <![CDATA[whitespace before ':']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E211</key>
+      <name><![CDATA[whitespace before '(']]></name>
+      <configKey>E211</configKey>
+      <description>
+          <![CDATA[whitespace before '(']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E221</key>
+      <name><![CDATA[multiple spaces before operator]]></name>
+      <configKey>E221</configKey>
+      <description>
+          <![CDATA[multiple spaces before operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E222</key>
+      <name><![CDATA[multiple spaces after operator]]></name>
+      <configKey>E222</configKey>
+      <description>
+          <![CDATA[multiple spaces after operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E223</key>
+      <name><![CDATA[tab before operator]]></name>
+      <configKey>E223</configKey>
+      <description>
+          <![CDATA[tab before operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E224</key>
+      <name><![CDATA[tab after operator]]></name>
+      <configKey>E224</configKey>
+      <description>
+          <![CDATA[tab after operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E225</key>
+      <name><![CDATA[missing whitespace around operator]]></name>
+      <configKey>E225</configKey>
+      <description>
+          <![CDATA[missing whitespace around operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E226</key>
+      <name><![CDATA[missing whitespace around arithmetic operator]]></name>
+      <configKey>E226</configKey>
+      <description>
+          <![CDATA[missing whitespace around arithmetic operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E227</key>
+      <name><![CDATA[missing whitespace around bitwise or shift operator]]></name>
+      <configKey>E227</configKey>
+      <description>
+          <![CDATA[missing whitespace around bitwise or shift operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E228</key>
+      <name><![CDATA[missing whitespace around modulo operator]]></name>
+      <configKey>E228</configKey>
+      <description>
+          <![CDATA[missing whitespace around modulo operator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E231</key>
+      <name><![CDATA[missing whitespace after ',']]></name>
+      <configKey>E231</configKey>
+      <description>
+          <![CDATA[missing whitespace after ',']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E241</key>
+      <name><![CDATA[multiple spaces after ',']]></name>
+      <configKey>E241</configKey>
+      <description>
+          <![CDATA[multiple spaces after ',']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E242</key>
+      <name><![CDATA[tab after ',']]></name>
+      <configKey>E242</configKey>
+      <description>
+          <![CDATA[tab after ',']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E251</key>
+      <name><![CDATA[unexpected spaces around keyword / parameter equals]]></name>
+      <configKey>E251</configKey>
+      <description>
+          <![CDATA[unexpected spaces around keyword / parameter equals]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E261</key>
+      <name><![CDATA[at least two spaces before inline comment]]></name>
+      <configKey>E261</configKey>
+      <description>
+          <![CDATA[at least two spaces before inline comment]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E262</key>
+      <name><![CDATA[inline comment should start with '# ']]></name>
+      <configKey>E262</configKey>
+      <description>
+          <![CDATA[inline comment should start with '# ']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E265</key>
+      <name><![CDATA[block comment should start with '# ']]></name>
+      <configKey>E265</configKey>
+      <description>
+          <![CDATA[block comment should start with '# ']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E266</key>
+      <name><![CDATA[too many leading '#' for block comment]]></name>
+      <configKey>E266</configKey>
+      <description>
+          <![CDATA[too many leading '#' for block comment]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E271</key>
+      <name><![CDATA[multiple spaces after keyword]]></name>
+      <configKey>E271</configKey>
+      <description>
+          <![CDATA[multiple spaces after keyword]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E272</key>
+      <name><![CDATA[multiple spaces before keyword]]></name>
+      <configKey>E272</configKey>
+      <description>
+          <![CDATA[multiple spaces before keyword]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E273</key>
+      <name><![CDATA[tab after keyword]]></name>
+      <configKey>E273</configKey>
+      <description>
+          <![CDATA[tab after keyword]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E274</key>
+      <name><![CDATA[tab before keyword]]></name>
+      <configKey>E274</configKey>
+      <description>
+          <![CDATA[tab before keyword]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E301</key>
+      <name><![CDATA[expected 1 blank line, found 0]]></name>
+      <configKey>E301</configKey>
+      <description>
+          <![CDATA[expected 1 blank line, found 0]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E302</key>
+      <name><![CDATA[expected 2 blank lines, found 0]]></name>
+      <configKey>E302</configKey>
+      <description>
+          <![CDATA[expected 2 blank lines, found 0]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E303</key>
+      <name><![CDATA[too many blank lines (3)]]></name>
+      <configKey>E303</configKey>
+      <description>
+          <![CDATA[too many blank lines (3)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E304</key>
+      <name><![CDATA[blank lines found after function decorator]]></name>
+      <configKey>E304</configKey>
+      <description>
+          <![CDATA[blank lines found after function decorator]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E401</key>
+      <name><![CDATA[multiple imports on one line]]></name>
+      <configKey>E401</configKey>
+      <description>
+          <![CDATA[multiple imports on one line]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E501</key>
+      <name><![CDATA[line too long (82 > 79 characters)]]></name>
+      <configKey>E501</configKey>
+      <description>
+          <![CDATA[line too long (82 > 79 characters)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E502</key>
+      <name><![CDATA[the backslash is redundant between brackets]]></name>
+      <configKey>E502</configKey>
+      <description>
+          <![CDATA[the backslash is redundant between brackets]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E701</key>
+      <name><![CDATA[multiple statements on one line (colon)]]></name>
+      <configKey>E701</configKey>
+      <description>
+          <![CDATA[multiple statements on one line (colon)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E702</key>
+      <name><![CDATA[multiple statements on one line (semicolon)]]></name>
+      <configKey>E702</configKey>
+      <description>
+          <![CDATA[multiple statements on one line (semicolon)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E703</key>
+      <name><![CDATA[statement ends with a semicolon]]></name>
+      <configKey>E703</configKey>
+      <description>
+          <![CDATA[statement ends with a semicolon]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E704</key>
+      <name><![CDATA[multiple statements on one line (def)]]></name>
+      <configKey>E704</configKey>
+      <description>
+          <![CDATA[multiple statements on one line (def)]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E711</key>
+      <name><![CDATA[comparison to None should be 'if cond is None:']]></name>
+      <configKey>E711</configKey>
+      <description>
+          <![CDATA[comparison to None should be 'if cond is None:']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E712</key>
+      <name><![CDATA[comparison to True should be 'if cond is True:' or 'if cond:']]></name>
+      <configKey>E712</configKey>
+      <description>
+          <![CDATA[comparison to True should be 'if cond is True:' or 'if cond:']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E713</key>
+      <name><![CDATA[test for membership should be 'not in']]></name>
+      <configKey>E713</configKey>
+      <description>
+          <![CDATA[test for membership should be 'not in']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E714</key>
+      <name><![CDATA[test for object identity should be 'is not']]></name>
+      <configKey>E714</configKey>
+      <description>
+          <![CDATA[test for object identity should be 'is not']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E721</key>
+      <name><![CDATA[do not compare types, use 'isinstance()']]></name>
+      <configKey>E721</configKey>
+      <description>
+          <![CDATA[do not compare types, use 'isinstance()']]>
+      </description>
+  </rule>
+  <rule>
+      <key>E731</key>
+      <name><![CDATA[do not assign a lambda expression, use a def]]></name>
+      <configKey>E731</configKey>
+      <description>
+          <![CDATA[do not assign a lambda expression, use a def]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E901</key>
+      <name><![CDATA[SyntaxError or IndentationError]]></name>
+      <configKey>E901</configKey>
+      <description>
+          <![CDATA[SyntaxError or IndentationError]]>
+      </description>
+  </rule>
+  <rule>
+      <key>E902</key>
+      <name><![CDATA[IOError]]></name>
+      <configKey>E902</configKey>
+      <description>
+          <![CDATA[IOError]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W191</key>
+      <name><![CDATA[indentation contains tabs]]></name>
+      <configKey>W191</configKey>
+      <description>
+          <![CDATA[indentation contains tabs]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W291</key>
+      <name><![CDATA[trailing whitespace]]></name>
+      <configKey>W291</configKey>
+      <description>
+          <![CDATA[trailing whitespace]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W292</key>
+      <name><![CDATA[no newline at end of file]]></name>
+      <configKey>W292</configKey>
+      <description>
+          <![CDATA[no newline at end of file]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W293</key>
+      <name><![CDATA[blank line contains whitespace]]></name>
+      <configKey>W293</configKey>
+      <description>
+          <![CDATA[blank line contains whitespace]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W391</key>
+      <name><![CDATA[blank line at end of file]]></name>
+      <configKey>W391</configKey>
+      <description>
+          <![CDATA[blank line at end of file]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W601</key>
+      <name><![CDATA[.has_key() is deprecated, use 'in']]></name>
+      <configKey>W601</configKey>
+      <description>
+          <![CDATA[.has_key() is deprecated, use 'in']]>
+      </description>
+  </rule>
+  <rule>
+      <key>W602</key>
+      <name><![CDATA[deprecated form of raising exception]]></name>
+      <configKey>W602</configKey>
+      <description>
+          <![CDATA[deprecated form of raising exception]]>
+      </description>
+  </rule>
+  <rule>
+      <key>W603</key>
+      <name><![CDATA['<>' is deprecated, use '!=']]></name>
+      <configKey>W603</configKey>
+      <description>
+          <![CDATA['<>' is deprecated, use '!=']]>
+      </description>
+  </rule>
+  <rule>
+      <key>W604</key>
+      <name><![CDATA[backticks are deprecated, use 'repr()']]></name>
+      <configKey>W604</configKey>
+      <description>
+          <![CDATA[backticks are deprecated, use 'repr()']]>
+      </description>
+  </rule>
+</rules>

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonPluginTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonPluginTest.java
@@ -27,7 +27,7 @@ public class PythonPluginTest {
 
   @Test
   public void testGetExtensions() {
-    assertThat(new PythonPlugin().getExtensions()).hasSize(14);
+    assertThat(new PythonPlugin().getExtensions()).hasSize(17);
   }
 
 }


### PR DESCRIPTION
Hi 

**This is not a pull request, but just a proof of concept**

In our company we prefer to use `flake8` over `pylint` and as a workaround I have created a 'copy-pasted' solution to add the `flake8` support to the `sonar-python`. So now it support both - flake8 and pylint.

It work's for us. The _jar_ with changes can be downloaded [here](http://tempfiles.org.droxbob.com).

Btw. It would be nice to have 'Issues' for the `sonar-python` project on github. 

Regards,
Max