### PR TITLE
TrailingWhitespaceCheck: improve

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/TrailingWhitespaceCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/TrailingWhitespaceCheck.java
@@ -19,21 +19,24 @@
  */
 package org.sonar.python.checks;
 
-import com.google.common.io.Files;
 import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Grammar;
 import org.sonar.api.server.rule.RulesDefinition;
 import org.sonar.check.Priority;
 import org.sonar.check.Rule;
 import org.sonar.python.CharsetAwareVisitor;
+import org.sonar.squidbridge.SquidAstVisitorContext;
 import org.sonar.squidbridge.annotations.SqaleConstantRemediation;
 import org.sonar.squidbridge.annotations.SqaleSubCharacteristic;
 import org.sonar.squidbridge.checks.SquidCheck;
 
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.List;
+import java.nio.file.Files;
+import java.util.regex.Pattern;
 
 @Rule(
     key = TrailingWhitespaceCheck.CHECK_KEY,
@@ -46,6 +49,9 @@ import java.util.List;
 public class TrailingWhitespaceCheck extends SquidCheck<Grammar> implements CharsetAwareVisitor {
   public static final String CHECK_KEY = "S1131";
   public static final String MESSAGE = "Remove the useless trailing whitespaces at the end of this line.";
+
+  private static final Pattern TRAILING_WS = Pattern.compile("\\s$");
+
   private Charset charset;
 
   @Override
@@ -55,16 +61,20 @@ public class TrailingWhitespaceCheck extends SquidCheck<Grammar> implements Char
 
   @Override
   public void visitFile(@Nullable AstNode astNode) {
-    List<String> lines;
-    try {
-      lines = Files.readLines(getContext().getFile(), charset);
-    } catch (IOException e) {
-      throw new IllegalStateException("Could not read " + getContext().getFile(), e);
-    }
-    for (int i = 0; i < lines.size(); i++) {
-      if (lines.get(i).matches(".*\\s$")) {
-        getContext().createLineViolation(this, MESSAGE, i + 1);
+    final SquidAstVisitorContext<Grammar> context = getContext();
+    final File file = context.getFile();
+    try (
+      final BufferedReader reader = Files.newBufferedReader(file.toPath(), charset);
+    ) {
+      int lineNr = 0;
+      String line;
+      while ((line = reader.readLine()) != null) {
+        ++lineNr;
+        if (TRAILING_WS.matcher(line).find())
+          context.createLineViolation(this, MESSAGE, lineNr);
       }
+    } catch (IOException e) {
+      throw new IllegalStateException("Could not read " + file, e);
     }
   }
 


### PR DESCRIPTION
- Since we are using Java 7, use try-with-resources.
- Only read line by line instead of swallowing all lines at once.
- Use JSR 203.
- Use a Matcher and .find() instead of trying to .matches() the whole line.
