### PR TITLE
Un-deprecate rule S1721 (Parentheses should not be used after certain…

### DIFF
--- a/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S1721.html
+++ b/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S1721.html
@@ -15,6 +15,4 @@ while x &lt; 10:
     print "x is now %d" % (x)
     x += 1
 </pre>
-<h2>Deprecated</h2>
-<p>This rule is deprecated; use {rule:python:S1110} instead.</p>
 

--- a/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S1721.json
+++ b/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S1721.json
@@ -1,7 +1,7 @@
 {
   "title": "Parentheses should not be used after certain keywords",
   "type": "CODE_SMELL",
-  "status": "deprecated",
+  "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
     "constantCost": "1 min"


### PR DESCRIPTION
… keywords)