### PR TITLE
run pylint with one job

### DIFF
--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/pylint/PylintIssuesAnalyzer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/pylint/PylintIssuesAnalyzer.java
@@ -71,7 +71,8 @@ public class PylintIssuesAnalyzer {
   }
 
   public List<Issue> analyze(String path, Charset charset, File out) throws IOException {
-    Command command = Command.create(pylint).addArguments(pylintArguments.arguments()).addArgument(path);
+    String[] one_job = {"-j", "1"};
+    Command command = Command.create(pylint).addArguments(one_job).addArguments(pylintArguments.arguments()).addArgument(path);
 
     if (pylintConfigParam != null) {
       command.addArgument(pylintConfigParam);


### PR DESCRIPTION
sonar-python always starts one pylint process per one python file.
Need to force pylint process not to start more than 1 job.

By default, pylint starts 10 jobs. This parameter can be set in pylintrc file. This is very useful when you run pylint alone. But this is a waste of resources when pylint is run by sonar-scanner from the same directory.