### PR TITLE
Update jarjar package names - fixes SONARPY-283

### DIFF
--- a/sslr-python-toolkit/pom.xml
+++ b/sslr-python-toolkit/pom.xml
@@ -64,10 +64,10 @@
             <configuration>
               <includes>
                 <include>${project.groupId}:python-squid</include>
-                <include>org.codehaus.sonar.sslr:sslr-core</include>
-                <include>org.codehaus.sonar.sslr:sslr-xpath</include>
+                <include>org.sonarsource.sslr:sslr-core</include>
+                <include>org.sonarsource.sslr:sslr-xpath</include>
                 <include>jaxen:jaxen</include>
-                <include>org.codehaus.sonar.sslr:sslr-toolkit</include>
+                <include>org.sonarsource.sslr:sslr-toolkit</include>
                 <include>org.codehaus.sonar:sonar-colorizer</include>
                 <include>org.codehaus.sonar:sonar-channel</include>
                 <include>ch.qos.logback:logback-classic</include>
@@ -98,8 +98,8 @@
             <configuration>
               <rules>
                 <requireFilesSize>
-                  <maxsize>3900000</maxsize>
-                  <minsize>3800000</minsize>
+                  <maxsize>4200000</maxsize>
+                  <minsize>4000000</minsize>
                   <files>
                     <file>${project.build.directory}/${project.build.finalName}.jar</file>
                   </files>


### PR DESCRIPTION
After running into https://stackoverflow.com/questions/50730049/error-running-sonar-sslr-toolkit and seeing https://jira.sonarsource.com/browse/SONARPY-283 I dug a little deeper and found the cause: the package names in the jarjar includes list are outdated. This commit corrects that and I can confirm the SSLR standalone application for Python is working again correctly.

P.S. The same issue is present in the sonar-flex project - sslr module. Will you fix it or shall I create a PR for that one as well? 