### PR TITLE
Migrate Token to PyToken in the Strongly typed AST

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/BreakContinueOutsideLoopCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/BreakContinueOutsideLoopCheck.java
@@ -39,12 +39,12 @@ public class BreakContinueOutsideLoopCheck extends PythonSubscriptionCheck {
       if (currentParent.is(Tree.Kind.WHILE_STMT) || currentParent.is(Tree.Kind.FOR_STMT)) {
         return;
       } else if (currentParent.is(Tree.Kind.CLASSDEF) || currentParent.is(Tree.Kind.FUNCDEF)) {
-        ctx.addIssue(statement, String.format(MESSAGE, statement.firstToken().getValue()));
+        ctx.addIssue(statement, String.format(MESSAGE, statement.firstToken().value()));
         return;
       }
       currentParent = currentParent.parent();
     }
-    ctx.addIssue(statement, String.format(MESSAGE, statement.firstToken().getValue()));
+    ctx.addIssue(statement, String.format(MESSAGE, statement.firstToken().value()));
   };
 
   @Override

--- a/python-checks/src/main/java/org/sonar/python/checks/CheckUtils.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/CheckUtils.java
@@ -108,8 +108,8 @@ public class CheckUtils {
     if (leftLeaf.firstToken() == null && rightLeaf.firstToken() == null) {
       return true;
     }
-    return leftLeaf.firstToken().getType().equals(PythonTokenType.INDENT) || leftLeaf.firstToken().getType().equals(PythonTokenType.DEDENT) ||
-      leftLeaf.firstToken().getValue().equals(rightLeaf.firstToken().getValue());
+    return leftLeaf.firstToken().type().equals(PythonTokenType.INDENT) || leftLeaf.firstToken().type().equals(PythonTokenType.DEDENT) ||
+      leftLeaf.firstToken().value().equals(rightLeaf.firstToken().value());
   }
 
   public static boolean insideFunction(AstNode astNode, AstNode funcDef) {
@@ -185,7 +185,7 @@ public class CheckUtils {
     if (arguments.isEmpty()) {
       return false;
     }
-    return arguments.size() != 1 || !"object".equals(arguments.get(0).firstToken().getValue());
+    return arguments.size() != 1 || !"object".equals(arguments.get(0).firstToken().value());
   }
 
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/EmptyNestedBlockCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/EmptyNestedBlockCheck.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.checks;
 
-import com.sonar.sslr.api.Token;
 import com.sonar.sslr.api.Trivia;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -27,6 +26,7 @@ import org.sonar.check.Rule;
 import org.sonar.python.PythonSubscriptionCheck;
 import org.sonar.python.api.tree.PyStatementListTree;
 import org.sonar.python.api.tree.PyStatementTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 import org.sonar.python.api.tree.Tree.Kind;
 
@@ -59,9 +59,9 @@ public class EmptyNestedBlockCheck extends PythonSubscriptionCheck {
     });
   }
 
-  private static boolean containsComment(List<Token> tokens) {
-    for (Token token : tokens) {
-      for (Trivia trivia : token.getTrivia()) {
+  private static boolean containsComment(List<PyToken> tokens) {
+    for (PyToken token : tokens) {
+      for (Trivia trivia : token.trivia()) {
         if (trivia.isComment()) {
           return true;
         }

--- a/python-checks/src/main/java/org/sonar/python/checks/ExitHasBadArgumentsCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/ExitHasBadArgumentsCheck.java
@@ -19,13 +19,13 @@
  */
 package org.sonar.python.checks;
 
-import com.sonar.sslr.api.Token;
 import org.sonar.check.Rule;
 import org.sonar.python.PythonSubscriptionCheck;
 import org.sonar.python.SubscriptionContext;
 import org.sonar.python.api.tree.PyFunctionDefTree;
 import org.sonar.python.api.tree.PyParameterListTree;
 import org.sonar.python.api.tree.PyParameterTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 
 @Rule(key = "S2733")
@@ -45,8 +45,8 @@ public class ExitHasBadArgumentsCheck extends PythonSubscriptionCheck {
       }
       PyParameterListTree parameters = funcDef.parameters();
       int arity = 0;
-      if(parameters != null) {
-        if(parameters.nonTuple().stream().anyMatch(ExitHasBadArgumentsCheck::isStarredParam)) {
+      if (parameters != null) {
+        if (parameters.nonTuple().stream().anyMatch(ExitHasBadArgumentsCheck::isStarredParam)) {
           return;
         }
         arity = parameters.all().size();
@@ -60,13 +60,13 @@ public class ExitHasBadArgumentsCheck extends PythonSubscriptionCheck {
   }
 
   private static void raiseIssue(SubscriptionContext ctx, PyFunctionDefTree tree, int argumentsNumber) {
-    if (argumentsNumber != EXIT_ARGUMENTS_NUMBER){
+    if (argumentsNumber != EXIT_ARGUMENTS_NUMBER) {
       String message = MESSAGE_ADD;
-      if (argumentsNumber > EXIT_ARGUMENTS_NUMBER){
+      if (argumentsNumber > EXIT_ARGUMENTS_NUMBER) {
         message = MESSAGE_REMOVE;
       }
       Tree funcName = tree.name();
-      Token rightParenthesis = tree.rightPar();
+      PyToken rightParenthesis = tree.rightPar();
       ctx.addIssue(funcName.firstToken(), rightParenthesis, message);
     }
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/MissingDocstringCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/MissingDocstringCheck.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.checks;
 
-import com.sonar.sslr.api.Token;
 import java.util.regex.Pattern;
 import javax.annotation.CheckForNull;
 import org.sonar.check.Rule;
@@ -29,6 +28,7 @@ import org.sonar.python.api.tree.PyClassDefTree;
 import org.sonar.python.api.tree.PyFileInputTree;
 import org.sonar.python.api.tree.PyFunctionDefTree;
 import org.sonar.python.api.tree.PyNameTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 import org.sonar.python.api.tree.Tree.Kind;
 
@@ -61,12 +61,12 @@ public class MissingDocstringCheck extends PythonSubscriptionCheck {
     context.registerSyntaxNodeConsumer(Kind.CLASSDEF, ctx -> checkDocString(ctx, ((PyClassDefTree) ctx.syntaxNode()).docstring()));
   }
 
-  private static void checkDocString(SubscriptionContext ctx, @CheckForNull Token docstring) {
+  private static void checkDocString(SubscriptionContext ctx, @CheckForNull PyToken docstring) {
     Tree tree = ctx.syntaxNode();
     DeclarationType type = getType(tree);
     if (docstring == null) {
       raiseIssueNoDocstring(tree, type, ctx);
-    } else if (EMPTY_STRING_REGEXP.matcher(docstring.getValue()).matches()) {
+    } else if (EMPTY_STRING_REGEXP.matcher(docstring.value()).matches()) {
       raiseIssue(tree, MESSAGE_EMPTY_DOCSTRING, type, ctx);
     }
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/OneStatementPerLineCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/OneStatementPerLineCheck.java
@@ -53,7 +53,7 @@ public class OneStatementPerLineCheck extends PythonSubscriptionCheck {
   }
 
   private void checkStatement(SubscriptionContext ctx) {
-    int line = ctx.syntaxNode().firstToken().getLine();
+    int line = ctx.syntaxNode().firstToken().line();
     if (!statementsPerLine.containsKey(line)) {
       statementsPerLine.put(line, 0);
     }

--- a/python-checks/src/main/java/org/sonar/python/checks/PrintStatementUsageCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/PrintStatementUsageCheck.java
@@ -19,10 +19,10 @@
  */
 package org.sonar.python.checks;
 
-import com.sonar.sslr.api.Token;
 import org.sonar.check.Rule;
 import org.sonar.python.PythonSubscriptionCheck;
 import org.sonar.python.api.tree.PyPrintStatementTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 
 @Rule(key = PrintStatementUsageCheck.CHECK_KEY)
@@ -32,7 +32,7 @@ public class PrintStatementUsageCheck extends PythonSubscriptionCheck {
   @Override
   public void initialize(Context context) {
     context.registerSyntaxNodeConsumer(Tree.Kind.PRINT_STMT, ctx -> {
-      Token token = ((PyPrintStatementTree) ctx.syntaxNode()).printKeyword();
+      PyToken token = ((PyPrintStatementTree) ctx.syntaxNode()).printKeyword();
       ctx.addIssue(token, "Replace print statement by built-in function.");
     });
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/ReturnYieldOutsideFunctionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/ReturnYieldOutsideFunctionCheck.java
@@ -38,12 +38,12 @@ public class ReturnYieldOutsideFunctionCheck extends PythonSubscriptionCheck {
       if (currentParent.is(Tree.Kind.FUNCDEF)) {
         return;
       } else if (currentParent.is(Tree.Kind.CLASSDEF)) {
-        ctx.addIssue(returnStatement, String.format(MESSAGE, returnStatement.firstToken().getValue()));
+        ctx.addIssue(returnStatement, String.format(MESSAGE, returnStatement.firstToken().value()));
         return;
       }
       currentParent = currentParent.parent();
     }
-    ctx.addIssue(returnStatement, String.format(MESSAGE, returnStatement.firstToken().getValue()));
+    ctx.addIssue(returnStatement, String.format(MESSAGE, returnStatement.firstToken().value()));
   };
 
   @Override

--- a/python-checks/src/main/java/org/sonar/python/checks/TooManyLinesInFileCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/TooManyLinesInFileCheck.java
@@ -57,7 +57,7 @@ public class TooManyLinesInFileCheck extends PythonSubscriptionCheck {
     @Override
     public void visitFileInput(PyFileInputTree fileInput) {
       if (fileInput.statements() != null) {
-        numberOfLines = fileInput.statements().tokens().get(fileInput.statements().tokens().size() - 1).getLine();
+        numberOfLines = fileInput.statements().tokens().get(fileInput.statements().tokens().size() - 1).line();
       }
     }
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/UselessParenthesisAfterKeywordCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/UselessParenthesisAfterKeywordCheck.java
@@ -49,11 +49,11 @@ public class UselessParenthesisAfterKeywordCheck extends PythonSubscriptionCheck
     context.registerSyntaxNodeConsumer(Tree.Kind.DEL_STMT, ctx -> checkExpr(((PyDelStatementTree) ctx.syntaxNode()).expressions().get(0), ctx, "del"));
     context.registerSyntaxNodeConsumer(Tree.Kind.IF_STMT, ctx -> {
       PyIfStatementTree ifStmt = (PyIfStatementTree) ctx.syntaxNode();
-      checkExpr(ifStmt.condition(), ctx, ifStmt.keyword().getValue());
+      checkExpr(ifStmt.condition(), ctx, ifStmt.keyword().value());
     });
     context.registerSyntaxNodeConsumer(Tree.Kind.WHILE_STMT, ctx -> {
       PyWhileStatementTree whileStmt = (PyWhileStatementTree) ctx.syntaxNode();
-      checkExpr(whileStmt.condition(), ctx, whileStmt.whileKeyword().getValue());
+      checkExpr(whileStmt.condition(), ctx, whileStmt.whileKeyword().value());
     });
     context.registerSyntaxNodeConsumer(Tree.Kind.FOR_STMT, ctx -> handleForStatement(ctx, (PyForStatementTree) ctx.syntaxNode()));
     context.registerSyntaxNodeConsumer(Tree.Kind.RAISE_STMT, ctx -> handleRaiseStatement(ctx, (PyRaiseStatementTree) ctx.syntaxNode()));
@@ -78,7 +78,7 @@ public class UselessParenthesisAfterKeywordCheck extends PythonSubscriptionCheck
     if (retStmt.expressions().size() == 1) {
       PyExpressionTree expr = retStmt.expressions().get(0);
       if ((expr.is(Tree.Kind.PARENTHESIZED) || (expr.is(Tree.Kind.TUPLE) && !((PyTupleTree) expr).elements().isEmpty()))
-        && expr.firstToken().getLine() == expr.lastToken().getLine()) {
+        && expr.firstToken().line() == expr.lastToken().line()) {
         ctx.addIssue(expr, String.format(MESSAGE, "return"));
       }
     }
@@ -119,7 +119,7 @@ public class UselessParenthesisAfterKeywordCheck extends PythonSubscriptionCheck
 
   private static void checkExpr(PyExpressionTree expr, SubscriptionContext ctx, String keyword, boolean raiseForTuple) {
     if ((expr.is(Tree.Kind.PARENTHESIZED) || (raiseForTuple && expr.is(Tree.Kind.TUPLE)))
-      && expr.firstToken().getLine() == expr.lastToken().getLine()) {
+      && expr.firstToken().line() == expr.lastToken().line()) {
       ctx.addIssue(expr, String.format(MESSAGE, keyword));
     }
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/hotspots/HashingDataCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/hotspots/HashingDataCheck.java
@@ -123,7 +123,7 @@ public class HashingDataCheck extends AbstractCallExpressionCheck {
     if (ctx.pythonFile().fileName().equals("global_settings.py") &&
       assignmentStatementTree.lhsExpressions().stream()
         .flatMap(pelt -> pelt.expressions().stream())
-        .anyMatch(expression -> expression.firstToken().getValue().equals("PASSWORD_HASHERS"))) {
+        .anyMatch(expression -> expression.firstToken().value().equals("PASSWORD_HASHERS"))) {
       ctx.addIssue(assignmentStatementTree, MESSAGE);
     }
   }
@@ -135,7 +135,7 @@ public class HashingDataCheck extends AbstractCallExpressionCheck {
     for (PyExpressionListTree expr : lhsExpressions) {
       for (PyExpressionTree expression : expr.expressions()) {
         PyExpressionTree baseExpr = removeParenthesis(expression);
-        if (baseExpr.lastToken().getValue().equals("PASSWORD_HASHERS")) {
+        if (baseExpr.lastToken().value().equals("PASSWORD_HASHERS")) {
           return baseExpr.is(Tree.Kind.QUALIFIED_EXPR) && getQualifiedName(((PyQualifiedExpressionTree) baseExpr).qualifier(), ctx).equals("django.conf.settings");
         }
       }

--- a/python-checks/src/main/java/org/sonar/python/checks/hotspots/RegexCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/hotspots/RegexCheck.java
@@ -61,7 +61,7 @@ public class RegexCheck extends PythonSubscriptionCheck {
 
   private void checkRegexArgument(PyArgumentTree arg, SubscriptionContext ctx) {
     Symbol argSymbol = ctx.symbolTable().getSymbol(getExpression(arg.expression()));
-    String literal = arg.firstToken().getValue();
+    String literal = arg.firstToken().value();
     IssueLocation secondaryLocation = null;
     // TODO : this cannot be migrated to strongly typed AST as long as semantic is not migrated to strongly typed AST
     if (argSymbol != null && argSymbol.writeUsages().size() == 1) {

--- a/python-squid/src/main/java/org/sonar/python/IssueLocation.java
+++ b/python-squid/src/main/java/org/sonar/python/IssueLocation.java
@@ -23,6 +23,7 @@ import com.sonar.sslr.api.AstNode;
 import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 
 public abstract class IssueLocation {
@@ -57,11 +58,11 @@ public abstract class IssueLocation {
     return new PreciseIssueLocation(tree.firstToken(), tree.lastToken(), message);
   }
 
-  public static IssueLocation preciseLocation(Token token, @Nullable String message) {
+  public static IssueLocation preciseLocation(PyToken token, @Nullable String message) {
     return new PreciseIssueLocation(token, message);
   }
 
-  public static IssueLocation preciseLocation(Token from, Token to, @Nullable String message) {
+  public static IssueLocation preciseLocation(PyToken from, PyToken to, @Nullable String message) {
     return new PreciseIssueLocation(from, to, message);
   }
 
@@ -95,16 +96,16 @@ public abstract class IssueLocation {
       this.lastTokenLocation = new TokenLocation(endNode.getLastToken());
     }
 
-    public PreciseIssueLocation(Token firstToken, Token lastToken, @Nullable String message) {
+    public PreciseIssueLocation(PyToken firstToken, PyToken lastToken, @Nullable String message) {
       super(message);
-      this.firstToken = firstToken;
-      this.lastTokenLocation = new TokenLocation(lastToken);
+      this.firstToken = firstToken.token();
+      this.lastTokenLocation = new TokenLocation(lastToken.token());
     }
 
-    public PreciseIssueLocation(Token token, @Nullable String message) {
+    public PreciseIssueLocation(PyToken token, @Nullable String message) {
       super(message);
-      this.firstToken = token;
-      this.lastTokenLocation = new TokenLocation(token);
+      this.firstToken = token.token();
+      this.lastTokenLocation = new TokenLocation(token.token());
     }
 
     @Override

--- a/python-squid/src/main/java/org/sonar/python/PythonCheck.java
+++ b/python-squid/src/main/java/org/sonar/python/PythonCheck.java
@@ -20,10 +20,10 @@
 package org.sonar.python;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 
 public interface PythonCheck {
@@ -63,7 +63,7 @@ public interface PythonCheck {
       return this;
     }
 
-    public PreciseIssue secondary(Token token, @Nullable String message) {
+    public PreciseIssue secondary(PyToken token, @Nullable String message) {
       secondaryLocations.add(IssueLocation.preciseLocation(token, message));
       return this;
     }

--- a/python-squid/src/main/java/org/sonar/python/PythonCheckTree.java
+++ b/python-squid/src/main/java/org/sonar/python/PythonCheckTree.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.python;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.Nullable;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 import org.sonar.python.tree.BaseTreeVisitor;
 
@@ -32,7 +32,7 @@ public abstract class PythonCheckTree extends BaseTreeVisitor implements PythonC
     return context;
   }
 
-  protected final PreciseIssue addIssue(Token token, @Nullable String message) {
+  protected final PreciseIssue addIssue(PyToken token, @Nullable String message) {
     PreciseIssue newIssue = new PreciseIssue(this, IssueLocation.preciseLocation(token, message));
     getContext().addIssue(newIssue);
     return newIssue;

--- a/python-squid/src/main/java/org/sonar/python/SubscriptionContext.java
+++ b/python-squid/src/main/java/org/sonar/python/SubscriptionContext.java
@@ -19,8 +19,8 @@
  */
 package org.sonar.python;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.Nullable;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 import org.sonar.python.semantic.SymbolTable;
 
@@ -29,9 +29,9 @@ public interface SubscriptionContext {
 
   PythonCheck.PreciseIssue addIssue(Tree element, @Nullable String message);
 
-  PythonCheck.PreciseIssue addIssue(Token token, @Nullable String message);
+  PythonCheck.PreciseIssue addIssue(PyToken token, @Nullable String message);
 
-  PythonCheck.PreciseIssue addIssue(Token from, Token to, @Nullable String message);
+  PythonCheck.PreciseIssue addIssue(PyToken from, PyToken to, @Nullable String message);
 
   PythonCheck.PreciseIssue addFileIssue(String finalMessage);
 

--- a/python-squid/src/main/java/org/sonar/python/SubscriptionVisitor.java
+++ b/python-squid/src/main/java/org/sonar/python/SubscriptionVisitor.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python;
 
-import com.sonar.sslr.api.Token;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -28,6 +27,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyFileInputTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 import org.sonar.python.api.tree.Tree.Kind;
 import org.sonar.python.semantic.SymbolTable;
@@ -91,12 +91,12 @@ public class SubscriptionVisitor extends BaseTreeVisitor {
     }
 
     @Override
-    public PythonCheck.PreciseIssue addIssue(Token token, @Nullable String message) {
+    public PythonCheck.PreciseIssue addIssue(PyToken token, @Nullable String message) {
       return addIssue(IssueLocation.preciseLocation(token, message));
     }
 
     @Override
-    public PythonCheck.PreciseIssue addIssue(Token from, Token to, @Nullable String message) {
+    public PythonCheck.PreciseIssue addIssue(PyToken from, PyToken to, @Nullable String message) {
       return addIssue(IssueLocation.preciseLocation(from, to, message));
     }
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyAliasedNameTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyAliasedNameTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 /**
@@ -31,7 +30,7 @@ import javax.annotation.CheckForNull;
  */
 public interface PyAliasedNameTree extends Tree {
   @CheckForNull
-  Token asKeyword();
+  PyToken asKeyword();
 
   @CheckForNull
   PyNameTree alias();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyAnnotatedAssignmentTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyAnnotatedAssignmentTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyAnnotatedAssignmentTree extends PyStatementTree {
@@ -27,13 +26,13 @@ public interface PyAnnotatedAssignmentTree extends PyStatementTree {
   PyExpressionTree variable();
 
   // TODO: move to a dedicated tree for typed expression
-  Token colonToken();
+  PyToken colonToken();
 
   // TODO: move to a dedicated tree for typed expression
   PyExpressionTree annotation();
 
   @CheckForNull
-  Token equalToken();
+  PyToken equalToken();
 
   @CheckForNull
   PyExpressionTree assignedValue();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyArgumentTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyArgumentTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyArgumentTree extends Tree {
@@ -27,13 +26,13 @@ public interface PyArgumentTree extends Tree {
   PyNameTree keywordArgument();
 
   @CheckForNull
-  Token equalToken();
+  PyToken equalToken();
 
   PyExpressionTree expression();
 
   @CheckForNull
-  Token starToken();
+  PyToken starToken();
 
   @CheckForNull
-  Token starStarToken();
+  PyToken starStarToken();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyAssertStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyAssertStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.Nullable;
 
 public interface PyAssertStatementTree extends PyStatementTree {
-  Token assertKeyword();
+  PyToken assertKeyword();
 
   PyExpressionTree condition();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyAssignmentStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyAssignmentStatementTree.java
@@ -19,13 +19,12 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyAssignmentStatementTree extends PyStatementTree {
   PyExpressionTree assignedValue();
 
-  List<Token> equalTokens();
+  List<PyToken> equalTokens();
 
   List<PyExpressionListTree> lhsExpressions();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyAwaitExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyAwaitExpressionTree.java
@@ -19,11 +19,9 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyAwaitExpressionTree extends PyExpressionTree {
 
-  Token awaitToken();
+  PyToken awaitToken();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyBinaryExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyBinaryExpressionTree.java
@@ -19,13 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyBinaryExpressionTree extends PyExpressionTree {
 
   PyExpressionTree leftOperand();
 
-  Token operator();
+  PyToken operator();
 
   PyExpressionTree rightOperand();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyBreakStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyBreakStatementTree.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyBreakStatementTree extends PyStatementTree {
-  Token breakKeyword();
+  PyToken breakKeyword();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyCallExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyCallExpressionTree.java
@@ -19,14 +19,13 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyCallExpressionTree extends PyExpressionTree {
   PyExpressionTree callee();
 
-  Token leftPar();
+  PyToken leftPar();
 
   @CheckForNull
   PyArgListTree argumentList();
@@ -36,5 +35,5 @@ public interface PyCallExpressionTree extends PyExpressionTree {
    */
   List<PyArgumentTree> arguments();
 
-  Token rightPar();
+  PyToken rightPar();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyClassDefTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyClassDefTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -27,12 +26,12 @@ public interface PyClassDefTree extends PyStatementTree {
 
   List<PyDecoratorTree> decorators();
 
-  Token classKeyword();
+  PyToken classKeyword();
 
   PyNameTree name();
 
   @CheckForNull
-  Token leftPar();
+  PyToken leftPar();
 
   /**
    * null if class is defined without args {@code class Foo:...} or {@code class Foo():...}
@@ -41,12 +40,12 @@ public interface PyClassDefTree extends PyStatementTree {
   PyArgListTree args();
 
   @CheckForNull
-  Token rightPar();
+  PyToken rightPar();
 
-  Token colon();
+  PyToken colon();
 
   PyStatementListTree body();
 
   @CheckForNull
-  Token docstring();
+  PyToken docstring();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyCompoundAssignmentStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyCompoundAssignmentStatementTree.java
@@ -19,12 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyCompoundAssignmentStatementTree extends PyStatementTree {
   PyExpressionTree rhsExpression();
 
-  Token compoundAssignmentToken();
+  PyToken compoundAssignmentToken();
 
   PyExpressionTree lhsExpression();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyComprehensionForTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyComprehensionForTree.java
@@ -19,15 +19,13 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyComprehensionForTree extends PyComprehensionClauseTree {
 
-  Token forToken();
+  PyToken forToken();
 
   PyExpressionTree loopExpression();
 
-  Token inToken();
+  PyToken inToken();
 
   PyExpressionTree iterable();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyComprehensionIfTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyComprehensionIfTree.java
@@ -19,11 +19,9 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyComprehensionIfTree extends PyComprehensionClauseTree {
 
-  Token ifToken();
+  PyToken ifToken();
 
   PyExpressionTree condition();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyConditionalExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyConditionalExpressionTree.java
@@ -19,12 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyConditionalExpressionTree extends PyExpressionTree {
-  Token ifKeyword();
+  PyToken ifKeyword();
 
-  Token elseKeyword();
+  PyToken elseKeyword();
 
   PyExpressionTree trueExpression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyContinueStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyContinueStatementTree.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyContinueStatementTree extends PyStatementTree {
-  Token continueKeyword();
+  PyToken continueKeyword();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyDecoratorTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyDecoratorTree.java
@@ -19,20 +19,19 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyDecoratorTree extends Tree {
-  Token atToken();
+  PyToken atToken();
 
   PyDottedNameTree name();
 
   @CheckForNull
-  Token leftPar();
+  PyToken leftPar();
 
   @CheckForNull
   PyArgListTree arguments();
 
   @CheckForNull
-  Token rightPar();
+  PyToken rightPar();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyDelStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyDelStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyDelStatementTree extends PyStatementTree {
-  Token delKeyword();
+  PyToken delKeyword();
 
   List<PyExpressionTree> expressions();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyDictCompExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyDictCompExpressionTree.java
@@ -19,13 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyDictCompExpressionTree extends PyExpressionTree {
 
   PyExpressionTree keyExpression();
 
-  Token colonToken();
+  PyToken colonToken();
 
   PyExpressionTree valueExpression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyDictionaryLiteralTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyDictionaryLiteralTree.java
@@ -19,17 +19,16 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyDictionaryLiteralTree extends PyExpressionTree {
 
-  Token lCurlyBrace();
+  PyToken lCurlyBrace();
 
   List<PyKeyValuePairTree> elements();
 
-  List<Token> commas();
+  List<PyToken> commas();
 
-  Token rCurlyBrace();
+  PyToken rCurlyBrace();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyEllipsisExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyEllipsisExpressionTree.java
@@ -19,9 +19,8 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyEllipsisExpressionTree extends PyExpressionTree {
-  List<Token> ellipsis();
+  List<PyToken> ellipsis();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyElseStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyElseStatementTree.java
@@ -19,10 +19,8 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyElseStatementTree extends PyStatementTree {
-  Token elseKeyword();
+  PyToken elseKeyword();
 
   PyStatementListTree body();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyExceptClauseTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyExceptClauseTree.java
@@ -19,19 +19,18 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyExceptClauseTree extends Tree {
-  Token exceptKeyword();
+  PyToken exceptKeyword();
 
   PyStatementListTree body();
 
   @CheckForNull
-  Token asKeyword();
+  PyToken asKeyword();
 
   @CheckForNull
-  Token commaToken();
+  PyToken commaToken();
 
   @CheckForNull
   PyExpressionTree exception();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyExecStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyExecStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyExecStatementTree extends PyStatementTree {
-  Token execKeyword();
+  PyToken execKeyword();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyFileInputTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyFileInputTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyFileInputTree extends Tree {
@@ -27,5 +26,5 @@ public interface PyFileInputTree extends Tree {
   PyStatementListTree statements();
 
   @CheckForNull
-  Token docstring();
+  PyToken docstring();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyFinallyClauseTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyFinallyClauseTree.java
@@ -19,10 +19,8 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyFinallyClauseTree extends Tree {
-  Token finallyKeyword();
+  PyToken finallyKeyword();
 
   PyStatementListTree body();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyForStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyForStatementTree.java
@@ -19,28 +19,27 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyForStatementTree extends PyStatementTree {
-  Token forKeyword();
+  PyToken forKeyword();
 
   List<PyExpressionTree> expressions();
 
-  Token inKeyword();
+  PyToken inKeyword();
 
   List<PyExpressionTree> testExpressions();
 
-  Token colon();
+  PyToken colon();
 
   PyStatementListTree body();
 
   @CheckForNull
-  Token elseKeyword();
+  PyToken elseKeyword();
 
   @CheckForNull
-  Token elseColon();
+  PyToken elseColon();
 
   @CheckForNull
   PyStatementListTree elseBody();
@@ -48,5 +47,5 @@ public interface PyForStatementTree extends PyStatementTree {
   boolean isAsync();
 
   @CheckForNull
-  Token asyncKeyword();
+  PyToken asyncKeyword();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyFunctionDefTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyFunctionDefTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -27,19 +26,19 @@ public interface PyFunctionDefTree extends PyStatementTree {
 
   List<PyDecoratorTree> decorators();
 
-  Token defKeyword();
+  PyToken defKeyword();
 
   @CheckForNull
-  Token asyncKeyword();
+  PyToken asyncKeyword();
 
   PyNameTree name();
 
-  Token leftPar();
+  PyToken leftPar();
 
   @CheckForNull
   PyParameterListTree parameters();
 
-  Token rightPar();
+  PyToken rightPar();
 
   /**
    * {@code -> returnType}
@@ -47,13 +46,13 @@ public interface PyFunctionDefTree extends PyStatementTree {
   @CheckForNull
   PyTypeAnnotationTree returnTypeAnnotation();
 
-  Token colon();
+  PyToken colon();
 
   PyStatementListTree body();
 
   boolean isMethodDefinition();
 
   @CheckForNull
-  Token docstring();
+  PyToken docstring();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyGlobalStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyGlobalStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyGlobalStatementTree extends PyStatementTree {
-  Token globalKeyword();
+  PyToken globalKeyword();
 
   List<PyNameTree> variables();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyIfStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyIfStatementTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -27,7 +26,7 @@ import javax.annotation.CheckForNull;
  * if-elif-else statement
  */
 public interface PyIfStatementTree extends PyStatementTree {
-  Token keyword();
+  PyToken keyword();
 
   PyExpressionTree condition();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyImportFromTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyImportFromTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -31,20 +30,20 @@ import javax.annotation.CheckForNull;
  * </pre>
  */
 public interface PyImportFromTree extends PyImportStatementTree {
-  Token fromKeyword();
+  PyToken fromKeyword();
 
   @CheckForNull
   PyDottedNameTree module();
 
-  Token importKeyword();
+  PyToken importKeyword();
 
   @CheckForNull
-  List<Token> dottedPrefixForModule();
+  List<PyToken> dottedPrefixForModule();
 
   List<PyAliasedNameTree> importedNames();
 
   boolean isWildcardImport();
 
   @CheckForNull
-  Token wildcard();
+  PyToken wildcard();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyImportNameTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyImportNameTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ import java.util.List;
  * </pre>
  */
 public interface PyImportNameTree extends PyImportStatementTree {
-  Token importKeyword();
+  PyToken importKeyword();
 
   List<PyAliasedNameTree> modules();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyImportStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyImportStatementTree.java
@@ -21,7 +21,6 @@ package org.sonar.python.api.tree;
 
 /**
  * Import statement
- *
  */
 public interface PyImportStatementTree extends PyStatementTree {
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyInExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyInExpressionTree.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyInExpressionTree extends PyBinaryExpressionTree {
 
   @CheckForNull
-  Token notToken();
+  PyToken notToken();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyIsExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyIsExpressionTree.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyIsExpressionTree extends PyBinaryExpressionTree {
 
   @CheckForNull
-  Token notToken();
+  PyToken notToken();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyKeyValuePairTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyKeyValuePairTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 /**
@@ -32,13 +31,13 @@ public interface PyKeyValuePairTree extends Tree {
   PyExpressionTree key();
 
   @CheckForNull
-  Token colon();
+  PyToken colon();
 
   @CheckForNull
   PyExpressionTree value();
 
   @CheckForNull
-  Token starStarToken();
+  PyToken starStarToken();
 
   @CheckForNull
   PyExpressionTree expression();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyLambdaExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyLambdaExpressionTree.java
@@ -19,13 +19,12 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyLambdaExpressionTree extends PyExpressionTree {
-  Token lambdaKeyword();
+  PyToken lambdaKeyword();
 
-  Token colonToken();
+  PyToken colonToken();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyListLiteralTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyListLiteralTree.java
@@ -19,13 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyListLiteralTree extends PyExpressionTree {
 
-  Token leftBracket();
+  PyToken leftBracket();
 
   PyExpressionListTree elements();
 
-  Token rightBracket();
+  PyToken rightBracket();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyNoneExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyNoneExpressionTree.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyNoneExpressionTree extends PyExpressionTree {
-  Token none();
+  PyToken none();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyNonlocalStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyNonlocalStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyNonlocalStatementTree extends PyStatementTree {
-  Token nonlocalKeyword();
+  PyToken nonlocalKeyword();
 
   List<PyNameTree> variables();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyParameterTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyParameterTree.java
@@ -19,13 +19,12 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyParameterTree extends PyAnyParameterTree {
 
   @CheckForNull
-  Token starToken();
+  PyToken starToken();
 
   PyNameTree name();
 
@@ -33,7 +32,7 @@ public interface PyParameterTree extends PyAnyParameterTree {
   PyTypeAnnotationTree typeAnnotation();
 
   @CheckForNull
-  Token equalToken();
+  PyToken equalToken();
 
   @CheckForNull
   PyExpressionTree defaultValue();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyParenthesizedExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyParenthesizedExpressionTree.java
@@ -19,14 +19,12 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyParenthesizedExpressionTree extends PyExpressionTree {
 
-  Token leftParenthesis();
+  PyToken leftParenthesis();
 
   PyExpressionTree expression();
 
-  Token rightParenthesis();
+  PyToken rightParenthesis();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyPassStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyPassStatementTree.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyPassStatementTree extends PyStatementTree {
-  Token passKeyword();
+  PyToken passKeyword();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyPrintStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyPrintStatementTree.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyPrintStatementTree extends PyStatementTree {
 
-  Token printKeyword();
+  PyToken printKeyword();
 
   List<PyExpressionTree> expressions();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyQualifiedExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyQualifiedExpressionTree.java
@@ -19,15 +19,13 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 /**
  * Qualified expression like "foo.bar"
  */
 public interface PyQualifiedExpressionTree extends PyExpressionTree {
   PyExpressionTree qualifier();
 
-  Token dotToken();
+  PyToken dotToken();
 
   PyNameTree name();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyRaiseStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyRaiseStatementTree.java
@@ -19,15 +19,14 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyRaiseStatementTree extends PyStatementTree {
-  Token raiseKeyword();
+  PyToken raiseKeyword();
 
   @CheckForNull
-  Token fromKeyword();
+  PyToken fromKeyword();
 
   @CheckForNull
   PyExpressionTree fromExpression();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyReprExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyReprExpressionTree.java
@@ -19,15 +19,13 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 /**
  * Python 2 only.
  */
 public interface PyReprExpressionTree extends PyExpressionTree {
-  Token openingBacktick();
+  PyToken openingBacktick();
 
   PyExpressionListTree expressionList();
 
-  Token closingBacktick();
+  PyToken closingBacktick();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyReturnStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyReturnStatementTree.java
@@ -19,11 +19,10 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyReturnStatementTree extends PyStatementTree {
-  Token returnKeyword();
+  PyToken returnKeyword();
 
   List<PyExpressionTree> expressions();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PySetLiteralTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PySetLiteralTree.java
@@ -19,15 +19,14 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PySetLiteralTree extends PyExpressionTree {
-  Token lCurlyBrace();
+  PyToken lCurlyBrace();
 
   List<PyExpressionTree> elements();
 
-  List<Token> commas();
+  List<PyToken> commas();
 
-  Token rCurlyBrace();
+  PyToken rCurlyBrace();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PySliceExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PySliceExpressionTree.java
@@ -19,16 +19,14 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PySliceExpressionTree extends PyExpressionTree {
 
   PyExpressionTree object();
 
-  Token leftBracket();
+  PyToken leftBracket();
 
   PySliceListTree sliceList();
 
-  Token rightBracket();
+  PyToken rightBracket();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PySliceItemTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PySliceItemTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PySliceItemTree extends Tree {
@@ -27,13 +26,13 @@ public interface PySliceItemTree extends Tree {
   @CheckForNull
   PyExpressionTree lowerBound();
 
-  Token boundSeparator();
+  PyToken boundSeparator();
 
   @CheckForNull
   PyExpressionTree upperBound();
 
   @CheckForNull
-  Token strideSeparator();
+  PyToken strideSeparator();
 
   @CheckForNull
   PyExpressionTree stride();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PySliceListTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PySliceListTree.java
@@ -19,13 +19,12 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PySliceListTree extends Tree {
 
   List<Tree> slices();
 
-  List<Token> separators();
+  List<PyToken> separators();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyStarredExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyStarredExpressionTree.java
@@ -19,11 +19,9 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyStarredExpressionTree extends PyExpressionTree {
 
-  Token starToken();
+  PyToken starToken();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyStatementListTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyStatementListTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyStatementListTree extends Tree {
@@ -27,6 +26,6 @@ public interface PyStatementListTree extends Tree {
   List<PyStatementTree> statements();
 
   // Temporary API, to be moved to Tree interface
-  List<Token> tokens();
+  List<PyToken> tokens();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PySubscriptionExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PySubscriptionExpressionTree.java
@@ -19,16 +19,14 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PySubscriptionExpressionTree extends PyExpressionTree {
 
   PyExpressionTree object();
 
-  Token leftBracket();
+  PyToken leftBracket();
 
   PyExpressionListTree subscripts();
 
-  Token rightBracket();
+  PyToken rightBracket();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyToken.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyToken.java
@@ -17,26 +17,25 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.python.checks;
+package org.sonar.python.api.tree;
 
-import org.sonar.check.Rule;
-import org.sonar.python.PythonSubscriptionCheck;
-import org.sonar.python.api.PythonPunctuator;
-import org.sonar.python.api.tree.PyBinaryExpressionTree;
-import org.sonar.python.api.tree.PyToken;
-import org.sonar.python.api.tree.Tree;
+import com.sonar.sslr.api.Token;
+import com.sonar.sslr.api.TokenType;
+import com.sonar.sslr.api.Trivia;
+import java.util.List;
 
-@Rule(key = "InequalityUsage")
-public class InequalityUsageCheck extends PythonSubscriptionCheck {
+public interface PyToken extends Tree {
 
-  @Override
-  public void initialize(Context context) {
-    context.registerSyntaxNodeConsumer(Tree.Kind.COMPARISON, ctx -> {
-      PyBinaryExpressionTree expr = (PyBinaryExpressionTree) ctx.syntaxNode();
-      PyToken operator = expr.operator();
-      if (operator.value().equals(PythonPunctuator.NOT_EQU2.getValue())) {
-        ctx.addIssue(operator, "Replace \"<>\" by \"!=\".");
-      }
-    });
-  }
+  Token token();
+
+  String value();
+
+  int line();
+
+  int column();
+
+  List<Trivia> trivia();
+
+  TokenType type();
+
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyTreeVisitor.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyTreeVisitor.java
@@ -164,4 +164,6 @@ public interface PyTreeVisitor {
   void visitEllipsis(PyEllipsisExpressionTree pyEllipsisExpressionTree);
 
   void visitDecorator(PyDecoratorTree pyDecoratorTree);
+
+  void visitToken(PyToken token);
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyTryStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyTryStatementTree.java
@@ -19,12 +19,11 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyTryStatementTree extends PyStatementTree {
-  Token tryKeyword();
+  PyToken tryKeyword();
 
   List<PyExceptClauseTree> exceptClauses();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyTupleParameterTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyTupleParameterTree.java
@@ -19,17 +19,16 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 
 public interface PyTupleParameterTree extends PyAnyParameterTree {
 
-  Token openingParenthesis();
+  PyToken openingParenthesis();
 
   List<PyAnyParameterTree> parameters();
 
-  List<Token> commas();
+  List<PyToken> commas();
 
-  Token closingParenthesis();
+  PyToken closingParenthesis();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyTupleTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyTupleTree.java
@@ -19,20 +19,19 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyTupleTree extends PyExpressionTree {
 
   @CheckForNull
-  Token leftParenthesis();
+  PyToken leftParenthesis();
 
   List<PyExpressionTree> elements();
 
-  List<Token> commas();
+  List<PyToken> commas();
 
   @CheckForNull
-  Token rightParenthesis();
+  PyToken rightParenthesis();
 
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyTypeAnnotationTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyTypeAnnotationTree.java
@@ -19,18 +19,17 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyTypeAnnotationTree extends Tree {
   @CheckForNull
-  Token colonToken();
+  PyToken colonToken();
 
   @CheckForNull
-  Token dash();
+  PyToken dash();
 
   @CheckForNull
-  Token gt();
+  PyToken gt();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyUnaryExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyUnaryExpressionTree.java
@@ -19,11 +19,9 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
-
 public interface PyUnaryExpressionTree extends PyExpressionTree {
 
-  Token operator();
+  PyToken operator();
 
   PyExpressionTree expression();
 

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyWhileStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyWhileStatementTree.java
@@ -19,23 +19,22 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyWhileStatementTree extends PyStatementTree {
-  Token whileKeyword();
+  PyToken whileKeyword();
 
   PyExpressionTree condition();
 
-  Token colon();
+  PyToken colon();
 
   PyStatementListTree body();
 
   @CheckForNull
-  Token elseKeyword();
+  PyToken elseKeyword();
 
   @CheckForNull
-  Token elseColon();
+  PyToken elseColon();
 
   @CheckForNull
   PyStatementListTree elseBody();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyWithItemTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyWithItemTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
 
 public interface PyWithItemTree extends Tree {
@@ -27,7 +26,7 @@ public interface PyWithItemTree extends Tree {
   PyExpressionTree test();
 
   @CheckForNull
-  Token as();
+  PyToken as();
 
   @CheckForNull
   PyExpressionTree expression();

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyWithStatementTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyWithStatementTree.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -27,12 +26,12 @@ public interface PyWithStatementTree extends PyStatementTree {
 
   List<PyWithItemTree> withItems();
 
-  Token colon();
+  PyToken colon();
 
   PyStatementListTree statements();
 
   boolean isAsync();
 
   @CheckForNull
-  Token asyncKeyword();
+  PyToken asyncKeyword();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/PyYieldExpressionTree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/PyYieldExpressionTree.java
@@ -19,15 +19,14 @@
  */
 package org.sonar.python.api.tree;
 
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
 public interface PyYieldExpressionTree extends PyExpressionTree {
-  Token yieldKeyword();
+  PyToken yieldKeyword();
 
   @CheckForNull
-  Token fromKeyword();
+  PyToken fromKeyword();
 
   List<PyExpressionTree> expressions();
 }

--- a/python-squid/src/main/java/org/sonar/python/api/tree/Tree.java
+++ b/python-squid/src/main/java/org/sonar/python/api/tree/Tree.java
@@ -20,7 +20,6 @@
 package org.sonar.python.api.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
 import java.util.List;
 import javax.annotation.CheckForNull;
 
@@ -34,9 +33,9 @@ public interface Tree {
   @Deprecated
   AstNode astNode();
 
-  Token firstToken();
+  PyToken firstToken();
 
-  Token lastToken();
+  PyToken lastToken();
 
   Tree parent();
 
@@ -202,8 +201,8 @@ public interface Tree {
     BITWISE_COMPLEMENT(PyUnaryExpressionTree.class),
     NOT(PyUnaryExpressionTree.class),
 
-    KEY_VALUE_PAIR(PyKeyValuePairTree.class);
-
+    KEY_VALUE_PAIR(PyKeyValuePairTree.class),
+    TOKEN(PyToken.class);
     final Class<? extends Tree> associatedInterface;
 
     Kind(Class<? extends Tree> associatedInterface) {

--- a/python-squid/src/main/java/org/sonar/python/tree/BaseTreeVisitor.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/BaseTreeVisitor.java
@@ -22,8 +22,8 @@ package org.sonar.python.tree;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyAliasedNameTree;
-import org.sonar.python.api.tree.PyArgListTree;
 import org.sonar.python.api.tree.PyAnnotatedAssignmentTree;
+import org.sonar.python.api.tree.PyArgListTree;
 import org.sonar.python.api.tree.PyArgumentTree;
 import org.sonar.python.api.tree.PyAssertStatementTree;
 import org.sonar.python.api.tree.PyAssignmentStatementTree;
@@ -33,6 +33,7 @@ import org.sonar.python.api.tree.PyBreakStatementTree;
 import org.sonar.python.api.tree.PyCallExpressionTree;
 import org.sonar.python.api.tree.PyClassDefTree;
 import org.sonar.python.api.tree.PyCompoundAssignmentStatementTree;
+import org.sonar.python.api.tree.PyComprehensionExpressionTree;
 import org.sonar.python.api.tree.PyComprehensionForTree;
 import org.sonar.python.api.tree.PyComprehensionIfTree;
 import org.sonar.python.api.tree.PyConditionalExpressionTree;
@@ -58,11 +59,11 @@ import org.sonar.python.api.tree.PyImportNameTree;
 import org.sonar.python.api.tree.PyKeyValuePairTree;
 import org.sonar.python.api.tree.PyLambdaExpressionTree;
 import org.sonar.python.api.tree.PyListLiteralTree;
-import org.sonar.python.api.tree.PyComprehensionExpressionTree;
 import org.sonar.python.api.tree.PyNameTree;
 import org.sonar.python.api.tree.PyNoneExpressionTree;
 import org.sonar.python.api.tree.PyNonlocalStatementTree;
 import org.sonar.python.api.tree.PyNumericLiteralTree;
+import org.sonar.python.api.tree.PyParameterListTree;
 import org.sonar.python.api.tree.PyParameterTree;
 import org.sonar.python.api.tree.PyParenthesizedExpressionTree;
 import org.sonar.python.api.tree.PyPassStatementTree;
@@ -80,12 +81,12 @@ import org.sonar.python.api.tree.PyStatementListTree;
 import org.sonar.python.api.tree.PyStringElementTree;
 import org.sonar.python.api.tree.PyStringLiteralTree;
 import org.sonar.python.api.tree.PySubscriptionExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyTryStatementTree;
 import org.sonar.python.api.tree.PyTupleParameterTree;
 import org.sonar.python.api.tree.PyTupleTree;
 import org.sonar.python.api.tree.PyTypeAnnotationTree;
-import org.sonar.python.api.tree.PyParameterListTree;
 import org.sonar.python.api.tree.PyUnaryExpressionTree;
 import org.sonar.python.api.tree.PyWhileStatementTree;
 import org.sonar.python.api.tree.PyWithItemTree;
@@ -519,5 +520,9 @@ public class BaseTreeVisitor implements PyTreeVisitor {
   public void visitDecorator(PyDecoratorTree pyDecoratorTree) {
     scan(pyDecoratorTree.name());
     scan(pyDecoratorTree.arguments());
+  }
+
+  public void visitToken(PyToken token) {
+    // noop
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAliasedNameTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAliasedNameTreeImpl.java
@@ -20,14 +20,16 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyAliasedNameTree;
 import org.sonar.python.api.tree.PyDottedNameTree;
 import org.sonar.python.api.tree.PyNameTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -73,6 +75,6 @@ public class PyAliasedNameTreeImpl extends PyTree implements PyAliasedNameTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(dottedName, alias);
+    return Stream.of(asKeyword, dottedName, alias).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAliasedNameTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAliasedNameTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,11 +33,11 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyAliasedNameTreeImpl extends PyTree implements PyAliasedNameTree {
 
-  private final Token asKeyword;
+  private final PyToken asKeyword;
   private final PyDottedNameTree dottedName;
   private final PyNameTree alias;
 
-  public PyAliasedNameTreeImpl(AstNode astNode, @Nullable Token asKeyword, PyDottedNameTree dottedName, @Nullable PyNameTree alias) {
+  public PyAliasedNameTreeImpl(AstNode astNode, @Nullable PyToken asKeyword, PyDottedNameTree dottedName, @Nullable PyNameTree alias) {
     super(astNode);
     this.asKeyword = asKeyword;
     this.dottedName = dottedName;
@@ -46,7 +46,7 @@ public class PyAliasedNameTreeImpl extends PyTree implements PyAliasedNameTree {
 
   @CheckForNull
   @Override
-  public Token asKeyword() {
+  public PyToken asKeyword() {
     return asKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAnnotatedAssignmentTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAnnotatedAssignmentTreeImpl.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyAnnotatedAssignmentTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -80,7 +81,7 @@ public class PyAnnotatedAssignmentTreeImpl extends PyTree implements PyAnnotated
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(variable, annotation, assignedValue);
+    return Stream.of(variable, colonToken, annotation, equalToken, assignedValue).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAnnotatedAssignmentTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAnnotatedAssignmentTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -31,13 +31,13 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyAnnotatedAssignmentTreeImpl extends PyTree implements PyAnnotatedAssignmentTree {
   private final PyExpressionTree variable;
-  private final Token colonToken;
+  private final PyToken colonToken;
   private final PyExpressionTree annotation;
-  private final Token equalToken;
+  private final PyToken equalToken;
   private final PyExpressionTree assignedValue;
 
-  public PyAnnotatedAssignmentTreeImpl(PyExpressionTree variable, Token colonToken, PyExpressionTree annotation,
-                                       @Nullable Token equalToken, @Nullable PyExpressionTree assignedValue) {
+  public PyAnnotatedAssignmentTreeImpl(PyExpressionTree variable, PyToken colonToken, PyExpressionTree annotation,
+                                       @Nullable PyToken equalToken, @Nullable PyExpressionTree assignedValue) {
     super(variable.firstToken(), assignedValue != null ? assignedValue.lastToken() : annotation.lastToken());
     this.variable = variable;
     this.colonToken = colonToken;
@@ -52,7 +52,7 @@ public class PyAnnotatedAssignmentTreeImpl extends PyTree implements PyAnnotated
   }
 
   @Override
-  public Token colonToken() {
+  public PyToken colonToken() {
     return colonToken;
   }
 
@@ -63,7 +63,7 @@ public class PyAnnotatedAssignmentTreeImpl extends PyTree implements PyAnnotated
 
   @CheckForNull
   @Override
-  public Token equalToken() {
+  public PyToken equalToken() {
     return equalToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyArgumentTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyArgumentTreeImpl.java
@@ -20,14 +20,16 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.List;
-import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyArgumentTree;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyNameTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -97,6 +99,6 @@ public class PyArgumentTreeImpl extends PyTree implements PyArgumentTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(keywordArgument, expression);
+    return Stream.of(keywordArgument, expression, equalToken, star, starStar).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyArgumentTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyArgumentTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.List;
 import java.util.Arrays;
 import javax.annotation.CheckForNull;
@@ -34,26 +34,26 @@ import org.sonar.python.api.tree.Tree;
 public class PyArgumentTreeImpl extends PyTree implements PyArgumentTree {
   private final PyNameTree keywordArgument;
   private final PyExpressionTree expression;
-  private final Token equalToken;
-  private final Token star;
-  private final Token starStar;
+  private final PyToken equalToken;
+  private final PyToken star;
+  private final PyToken starStar;
 
-  public PyArgumentTreeImpl(AstNode node, PyNameTree keywordArgument, PyExpressionTree expression, Token equalToken, @Nullable AstNode star, @Nullable AstNode starStar) {
+  public PyArgumentTreeImpl(AstNode node, PyNameTree keywordArgument, PyExpressionTree expression, PyToken equalToken, @Nullable PyToken star, @Nullable PyToken starStar) {
     super(node);
     this.keywordArgument = keywordArgument;
     this.expression = expression;
     this.equalToken = equalToken;
-    this.star = star != null ? star.getToken() : null;
-    this.starStar = starStar != null ? starStar.getToken() : null;
+    this.star = star;
+    this.starStar = starStar;
   }
 
-  public PyArgumentTreeImpl(AstNode astNode, PyExpressionTree expression, @Nullable AstNode star, @Nullable AstNode starStar) {
+  public PyArgumentTreeImpl(AstNode astNode, PyExpressionTree expression, @Nullable PyToken star, @Nullable PyToken starStar) {
     super(astNode);
     this.keywordArgument = null;
     this.expression = expression;
     this.equalToken = null;
-    this.star = star != null ? star.getToken() : null;
-    this.starStar = starStar != null ? starStar.getToken() : null;
+    this.star = star;
+    this.starStar = starStar;
   }
 
   @CheckForNull
@@ -64,7 +64,7 @@ public class PyArgumentTreeImpl extends PyTree implements PyArgumentTree {
 
   @CheckForNull
   @Override
-  public Token equalToken() {
+  public PyToken equalToken() {
     return equalToken;
   }
 
@@ -75,13 +75,13 @@ public class PyArgumentTreeImpl extends PyTree implements PyArgumentTree {
 
   @CheckForNull
   @Override
-  public Token starToken() {
+  public PyToken starToken() {
     return star;
   }
 
   @CheckForNull
   @Override
-  public Token starStarToken() {
+  public PyToken starStarToken() {
     return starStar;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAssertStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAssertStatementTreeImpl.java
@@ -20,12 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyAssertStatementTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -70,6 +72,6 @@ public class PyAssertStatementTreeImpl extends PyTree implements PyAssertStateme
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(condition, message);
+    return Stream.of(assertKeyword, condition, message).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAssertStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAssertStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -30,12 +30,12 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyAssertStatementTreeImpl extends PyTree implements PyAssertStatementTree {
-  private final Token assertKeyword;
+  private final PyToken assertKeyword;
   private final PyExpressionTree condition;
   @Nullable
   private final PyExpressionTree message;
 
-  public PyAssertStatementTreeImpl(AstNode astNode, Token assertKeyword, PyExpressionTree condition, @Nullable PyExpressionTree message) {
+  public PyAssertStatementTreeImpl(AstNode astNode, PyToken assertKeyword, PyExpressionTree condition, @Nullable PyExpressionTree message) {
     super(astNode);
     this.assertKeyword = assertKeyword;
     this.condition = condition;
@@ -43,7 +43,7 @@ public class PyAssertStatementTreeImpl extends PyTree implements PyAssertStateme
   }
 
   @Override
-  public Token assertKeyword() {
+  public PyToken assertKeyword() {
     return assertKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAssignmentStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAssignmentStatementTreeImpl.java
@@ -20,6 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -70,6 +71,7 @@ public class PyAssignmentStatementTreeImpl extends PyTree implements PyAssignmen
 
   @Override
   public List<Tree> children() {
-    return Stream.of(lhsExpressions, Collections.singletonList(assignedValue)).flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(assignTokens, lhsExpressions, Collections.singletonList(assignedValue))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAssignmentStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAssignmentStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -32,11 +32,11 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyAssignmentStatementTreeImpl extends PyTree implements PyAssignmentStatementTree {
-  private final List<Token> assignTokens;
+  private final List<PyToken> assignTokens;
   private final List<PyExpressionListTree> lhsExpressions;
   private final PyExpressionTree assignedValue;
 
-  public PyAssignmentStatementTreeImpl(AstNode astNode, List<Token> assignTokens, List<PyExpressionListTree> lhsExpressions,PyExpressionTree assignedValue) {
+  public PyAssignmentStatementTreeImpl(AstNode astNode, List<PyToken> assignTokens, List<PyExpressionListTree> lhsExpressions,PyExpressionTree assignedValue) {
     super(astNode);
     this.assignTokens = assignTokens;
     this.lhsExpressions = lhsExpressions;
@@ -49,7 +49,7 @@ public class PyAssignmentStatementTreeImpl extends PyTree implements PyAssignmen
   }
 
   @Override
-  public List<Token> equalTokens() {
+  public List<PyToken> equalTokens() {
     return assignTokens;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAwaitExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAwaitExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyAwaitExpressionTree;
@@ -30,17 +30,17 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyAwaitExpressionTreeImpl extends PyTree implements PyAwaitExpressionTree {
 
-  private final Token awaitToken;
+  private final PyToken awaitToken;
   private final PyExpressionTree expression;
 
-  public PyAwaitExpressionTreeImpl(AstNode node, Token await, PyExpressionTree expression) {
+  public PyAwaitExpressionTreeImpl(AstNode node, PyToken await, PyExpressionTree expression) {
     super(node);
     this.awaitToken = await;
     this.expression = expression;
   }
 
   @Override
-  public Token awaitToken() {
+  public PyToken awaitToken() {
     return awaitToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyAwaitExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyAwaitExpressionTreeImpl.java
@@ -20,11 +20,13 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyAwaitExpressionTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -56,7 +58,7 @@ public class PyAwaitExpressionTreeImpl extends PyTree implements PyAwaitExpressi
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expression);
+    return Stream.of(awaitToken, expression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyBinaryExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyBinaryExpressionTreeImpl.java
@@ -19,13 +19,15 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyBinaryExpressionTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -100,6 +102,6 @@ public class PyBinaryExpressionTreeImpl extends PyTree implements PyBinaryExpres
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(leftOperand, rightOperand);
+    return Stream.of(leftOperand, operator, rightOperand).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyBinaryExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyBinaryExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +35,7 @@ public class PyBinaryExpressionTreeImpl extends PyTree implements PyBinaryExpres
 
   private final Kind kind;
   private final PyExpressionTree leftOperand;
-  private final Token operator;
+  private final PyToken operator;
   private final PyExpressionTree rightOperand;
 
   private static Map<String, Kind> kindsByOperator() {
@@ -65,9 +65,9 @@ public class PyBinaryExpressionTreeImpl extends PyTree implements PyBinaryExpres
     return map;
   }
 
-  public PyBinaryExpressionTreeImpl(PyExpressionTree leftOperand, Token operator, PyExpressionTree rightOperand) {
+  public PyBinaryExpressionTreeImpl(PyExpressionTree leftOperand, PyToken operator, PyExpressionTree rightOperand) {
     super(leftOperand.firstToken(), rightOperand.lastToken());
-    this.kind = KINDS_BY_OPERATOR.get(operator.getValue());
+    this.kind = KINDS_BY_OPERATOR.get(operator.value());
     this.leftOperand = leftOperand;
     this.operator = operator;
     this.rightOperand = rightOperand;
@@ -79,7 +79,7 @@ public class PyBinaryExpressionTreeImpl extends PyTree implements PyBinaryExpres
   }
 
   @Override
-  public Token operator() {
+  public PyToken operator() {
     return operator;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyBreakStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyBreakStatementTreeImpl.java
@@ -52,6 +52,6 @@ public class PyBreakStatementTreeImpl extends PyTree implements PyBreakStatement
 
   @Override
   public List<Tree> children() {
-    return Collections.emptyList();
+    return Collections.singletonList(breakKeyword);
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyBreakStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyBreakStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyBreakStatementTree;
@@ -28,15 +28,15 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyBreakStatementTreeImpl extends PyTree implements PyBreakStatementTree {
-  private final Token breakKeyword;
+  private final PyToken breakKeyword;
 
-  public PyBreakStatementTreeImpl(AstNode astNode, Token breakKeyword) {
+  public PyBreakStatementTreeImpl(AstNode astNode, PyToken breakKeyword) {
     super(astNode);
     this.breakKeyword = breakKeyword;
   }
 
   @Override
-  public Token breakKeyword() {
+  public PyToken breakKeyword() {
     return breakKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyCallExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyCallExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,23 +35,23 @@ import org.sonar.python.api.tree.Tree;
 public class PyCallExpressionTreeImpl extends PyTree implements PyCallExpressionTree {
   private final PyExpressionTree callee;
   private final PyArgListTree argumentList;
-  private final Token leftPar;
-  private final Token rightPar;
+  private final PyToken leftPar;
+  private final PyToken rightPar;
 
-  public PyCallExpressionTreeImpl(AstNode astNode, PyExpressionTree callee, @Nullable PyArgListTree argumentList, AstNode leftPar, AstNode rightPar) {
+  public PyCallExpressionTreeImpl(AstNode astNode, PyExpressionTree callee, @Nullable PyArgListTree argumentList, PyToken leftPar, PyToken rightPar) {
     super(astNode);
     this.callee = callee;
     this.argumentList = argumentList;
-    this.leftPar = leftPar.getToken();
-    this.rightPar = rightPar.getToken();
+    this.leftPar = leftPar;
+    this.rightPar = rightPar;
   }
 
-  public PyCallExpressionTreeImpl(PyExpressionTree callee, @Nullable PyArgListTree argumentList, AstNode leftPar, AstNode rightPar) {
-    super(callee.firstToken(), rightPar.getToken());
+  public PyCallExpressionTreeImpl(PyExpressionTree callee, @Nullable PyArgListTree argumentList, PyToken leftPar, PyToken rightPar) {
+    super(callee.firstToken(), rightPar);
     this.callee = callee;
     this.argumentList = argumentList;
-    this.leftPar = leftPar.getToken();
-    this.rightPar = rightPar.getToken();
+    this.leftPar = leftPar;
+    this.rightPar = rightPar;
   }
 
   @Override
@@ -70,12 +70,12 @@ public class PyCallExpressionTreeImpl extends PyTree implements PyCallExpression
   }
 
   @Override
-  public Token leftPar() {
+  public PyToken leftPar() {
     return leftPar;
   }
 
   @Override
-  public Token rightPar() {
+  public PyToken rightPar() {
     return rightPar;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyCallExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyCallExpressionTreeImpl.java
@@ -20,15 +20,17 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyArgListTree;
 import org.sonar.python.api.tree.PyArgumentTree;
 import org.sonar.python.api.tree.PyCallExpressionTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -91,6 +93,6 @@ public class PyCallExpressionTreeImpl extends PyTree implements PyCallExpression
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(callee, argumentList);
+    return Stream.of(callee, leftPar, argumentList, rightPar).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyClassDefTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyClassDefTreeImpl.java
@@ -20,9 +20,11 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyArgListTree;
@@ -30,6 +32,7 @@ import org.sonar.python.api.tree.PyClassDefTree;
 import org.sonar.python.api.tree.PyDecoratorTree;
 import org.sonar.python.api.tree.PyNameTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -121,6 +124,7 @@ public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(name, args, body);
+    return Stream.of(decorators, Arrays.asList(classKeyword, name, leftPar, args, rightPar, colon, body, docstring))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyClassDefTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyClassDefTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -36,18 +36,18 @@ import org.sonar.python.api.tree.Tree;
 public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
 
   private final List<PyDecoratorTree> decorators;
-  private final Token classKeyword;
+  private final PyToken classKeyword;
   private final PyNameTree name;
-  private final Token leftPar;
+  private final PyToken leftPar;
   private final PyArgListTree args;
-  private final Token rightPar;
-  private final Token colon;
+  private final PyToken rightPar;
+  private final PyToken colon;
   private final PyStatementListTree body;
-  private final Token docstring;
+  private final PyToken docstring;
 
-  public PyClassDefTreeImpl(AstNode astNode, List<PyDecoratorTree> decorators, Token classKeyword, PyNameTree name,
-                            @Nullable Token leftPar, @Nullable PyArgListTree args, @Nullable Token rightPar,
-                            Token colon, PyStatementListTree body, Token docstring) {
+  public PyClassDefTreeImpl(AstNode astNode, List<PyDecoratorTree> decorators, PyToken classKeyword, PyNameTree name,
+                            @Nullable PyToken leftPar, @Nullable PyArgListTree args, @Nullable PyToken rightPar,
+                            PyToken colon, PyStatementListTree body, PyToken docstring) {
     super(astNode);
     this.decorators = decorators;
     this.classKeyword = classKeyword;
@@ -76,7 +76,7 @@ public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
   }
 
   @Override
-  public Token classKeyword() {
+  public PyToken classKeyword() {
     return classKeyword;
   }
 
@@ -87,7 +87,7 @@ public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
 
   @CheckForNull
   @Override
-  public Token leftPar() {
+  public PyToken leftPar() {
     return leftPar;
   }
 
@@ -99,12 +99,12 @@ public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
 
   @CheckForNull
   @Override
-  public Token rightPar() {
+  public PyToken rightPar() {
     return rightPar;
   }
 
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -115,7 +115,7 @@ public class PyClassDefTreeImpl extends PyTree implements PyClassDefTree {
 
   @CheckForNull
   @Override
-  public Token docstring() {
+  public PyToken docstring() {
     return docstring;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyCompoundAssignmentStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyCompoundAssignmentStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyCompoundAssignmentStatementTree;
@@ -30,10 +30,10 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyCompoundAssignmentStatementTreeImpl extends PyTree implements PyCompoundAssignmentStatementTree {
   private final PyExpressionTree lhsExpression;
-  private final Token augAssignToken;
+  private final PyToken augAssignToken;
   private final PyExpressionTree rhsExpression;
 
-  public PyCompoundAssignmentStatementTreeImpl(AstNode astNode, PyExpressionTree lhsExpression, Token augAssignToken, PyExpressionTree rhsExpression) {
+  public PyCompoundAssignmentStatementTreeImpl(AstNode astNode, PyExpressionTree lhsExpression, PyToken augAssignToken, PyExpressionTree rhsExpression) {
     super(astNode);
     this.lhsExpression = lhsExpression;
     this.augAssignToken = augAssignToken;
@@ -46,7 +46,7 @@ public class PyCompoundAssignmentStatementTreeImpl extends PyTree implements PyC
   }
 
   @Override
-  public Token compoundAssignmentToken() {
+  public PyToken compoundAssignmentToken() {
     return augAssignToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyCompoundAssignmentStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyCompoundAssignmentStatementTreeImpl.java
@@ -20,11 +20,13 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyCompoundAssignmentStatementTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -62,7 +64,7 @@ public class PyCompoundAssignmentStatementTreeImpl extends PyTree implements PyC
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(lhsExpression, rhsExpression);
+    return Stream.of(lhsExpression, augAssignToken, rhsExpression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyComprehensionForTree;
@@ -34,8 +34,8 @@ public class PyComprehensionExpressionTreeImpl extends PyTree implements PyCompr
   private final PyExpressionTree resultExpression;
   private final PyComprehensionForTree comprehensionFor;
 
-  public PyComprehensionExpressionTreeImpl(Kind kind, Token openingToken, PyExpressionTree resultExpression,
-                                           PyComprehensionForTree compFor, Token closingToken) {
+  public PyComprehensionExpressionTreeImpl(Kind kind, PyToken openingToken, PyExpressionTree resultExpression,
+                                           PyComprehensionForTree compFor, PyToken closingToken) {
     super(openingToken, closingToken);
     this.kind = kind;
     this.resultExpression = resultExpression;

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionExpressionTreeImpl.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.sonar.python.api.tree.PyComprehensionExpressionTree;
 import org.sonar.python.api.tree.PyComprehensionForTree;
 import org.sonar.python.api.tree.PyExpressionTree;
-import org.sonar.python.api.tree.PyComprehensionExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -59,7 +61,7 @@ public class PyComprehensionExpressionTreeImpl extends PyTree implements PyCompr
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(resultExpression, comprehensionFor);
+    return Stream.of(resultExpression, comprehensionFor).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionForTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionForTreeImpl.java
@@ -20,14 +20,16 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyComprehensionClauseTree;
 import org.sonar.python.api.tree.PyComprehensionForTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -82,7 +84,7 @@ public class PyComprehensionForTreeImpl extends PyTree implements PyComprehensio
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(loopExpression, iterable, nested);
+    return Stream.of(forToken, loopExpression, inToken, iterable, nested).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionForTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionForTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,13 +33,13 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyComprehensionForTreeImpl extends PyTree implements PyComprehensionForTree {
 
-  private final Token forToken;
+  private final PyToken forToken;
   private final PyExpressionTree loopExpression;
-  private final Token inToken;
+  private final PyToken inToken;
   private final PyExpressionTree iterable;
   private final PyComprehensionClauseTree nested;
 
-  public PyComprehensionForTreeImpl(AstNode node, Token forToken, PyExpressionTree loopExpression, Token inToken,
+  public PyComprehensionForTreeImpl(AstNode node, PyToken forToken, PyExpressionTree loopExpression, PyToken inToken,
                                     PyExpressionTree iterable, @Nullable PyComprehensionClauseTree nested) {
     super(node);
     this.forToken = forToken;
@@ -50,7 +50,7 @@ public class PyComprehensionForTreeImpl extends PyTree implements PyComprehensio
   }
 
   @Override
-  public Token forToken() {
+  public PyToken forToken() {
     return forToken;
   }
 
@@ -60,7 +60,7 @@ public class PyComprehensionForTreeImpl extends PyTree implements PyComprehensio
   }
 
   @Override
-  public Token inToken() {
+  public PyToken inToken() {
     return inToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionIfTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionIfTreeImpl.java
@@ -20,14 +20,16 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyComprehensionClauseTree;
 import org.sonar.python.api.tree.PyComprehensionIfTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -67,7 +69,7 @@ public class PyComprehensionIfTreeImpl extends PyTree implements PyComprehension
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(condition, nestedClause);
+    return Stream.of(ifToken, condition, nestedClause).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionIfTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyComprehensionIfTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,11 +33,11 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyComprehensionIfTreeImpl extends PyTree implements PyComprehensionIfTree {
 
-  private final Token ifToken;
+  private final PyToken ifToken;
   private final PyExpressionTree condition;
   private final PyComprehensionClauseTree nestedClause;
 
-  public PyComprehensionIfTreeImpl(AstNode node, Token ifToken, PyExpressionTree condition, @Nullable PyComprehensionClauseTree nestedClause) {
+  public PyComprehensionIfTreeImpl(AstNode node, PyToken ifToken, PyExpressionTree condition, @Nullable PyComprehensionClauseTree nestedClause) {
     super(node);
     this.ifToken = ifToken;
     this.condition = condition;
@@ -45,7 +45,7 @@ public class PyComprehensionIfTreeImpl extends PyTree implements PyComprehension
   }
 
   @Override
-  public Token ifToken() {
+  public PyToken ifToken() {
     return ifToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyConditionalExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyConditionalExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyConditionalExpressionTree;
@@ -30,13 +30,13 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyConditionalExpressionTreeImpl extends PyTree implements PyConditionalExpressionTree {
   private final PyExpressionTree trueExpression;
-  private final Token ifToken;
+  private final PyToken ifToken;
   private final PyExpressionTree condition;
-  private final Token elseToken;
+  private final PyToken elseToken;
   private final PyExpressionTree falseExpression;
 
   public PyConditionalExpressionTreeImpl(AstNode node, PyExpressionTree trueExpression,
-                                         Token ifToken, PyExpressionTree condition, Token elseToken, PyExpressionTree falseExpression) {
+                                         PyToken ifToken, PyExpressionTree condition, PyToken elseToken, PyExpressionTree falseExpression) {
     super(node);
     this.trueExpression = trueExpression;
     this.ifToken = ifToken;
@@ -46,12 +46,12 @@ public class PyConditionalExpressionTreeImpl extends PyTree implements PyConditi
   }
 
   @Override
-  public Token ifKeyword() {
+  public PyToken ifKeyword() {
     return ifToken;
   }
 
   @Override
-  public Token elseKeyword() {
+  public PyToken elseKeyword() {
     return elseToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyConditionalExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyConditionalExpressionTreeImpl.java
@@ -20,11 +20,13 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyConditionalExpressionTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -77,7 +79,7 @@ public class PyConditionalExpressionTreeImpl extends PyTree implements PyConditi
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(condition, trueExpression, falseExpression);
+    return Stream.of(ifToken, condition, trueExpression, elseToken, falseExpression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyContinueStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyContinueStatementTreeImpl.java
@@ -52,6 +52,6 @@ public class PyContinueStatementTreeImpl extends PyTree implements PyContinueSta
 
   @Override
   public List<Tree> children() {
-    return Collections.emptyList();
+    return Collections.singletonList(continueKeyword);
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyContinueStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyContinueStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyContinueStatementTree;
@@ -28,15 +28,15 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyContinueStatementTreeImpl extends PyTree implements PyContinueStatementTree {
-  private final Token continueKeyword;
+  private final PyToken continueKeyword;
 
-  public PyContinueStatementTreeImpl(AstNode astNode, Token continueKeyword) {
+  public PyContinueStatementTreeImpl(AstNode astNode, PyToken continueKeyword) {
     super(astNode);
     this.continueKeyword = continueKeyword;
   }
 
   @Override
-  public Token continueKeyword() {
+  public PyToken continueKeyword() {
     return continueKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDecoratorTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDecoratorTreeImpl.java
@@ -20,14 +20,16 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyArgListTree;
 import org.sonar.python.api.tree.PyDecoratorTree;
 import org.sonar.python.api.tree.PyDottedNameTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -82,7 +84,7 @@ public class PyDecoratorTreeImpl extends PyTree implements PyDecoratorTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(dottedName, argListTree);
+    return Stream.of(atToken, dottedName, lPar, argListTree, rPar).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDecoratorTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDecoratorTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -32,23 +32,23 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyDecoratorTreeImpl extends PyTree implements PyDecoratorTree {
-  private final Token atToken;
+  private final PyToken atToken;
   private final PyDottedNameTree dottedName;
-  private final Token lPar;
+  private final PyToken lPar;
   private final PyArgListTree argListTree;
-  private final Token rPar;
+  private final PyToken rPar;
 
-  public PyDecoratorTreeImpl(AstNode astNode, Token atToken, PyDottedNameTree dottedName, @Nullable AstNode lPar, @Nullable PyArgListTree argListTree, @Nullable AstNode rPar) {
+  public PyDecoratorTreeImpl(AstNode astNode, PyToken atToken, PyDottedNameTree dottedName, @Nullable PyToken lPar, @Nullable PyArgListTree argListTree, @Nullable PyToken rPar) {
     super(astNode);
     this.atToken = atToken;
     this.dottedName = dottedName;
-    this.lPar = lPar != null ? lPar.getToken() : null;
+    this.lPar = lPar != null ? lPar : null;
     this.argListTree = argListTree;
-    this.rPar = rPar != null ? rPar.getToken() : null;
+    this.rPar = rPar != null ? rPar : null;
   }
 
   @Override
-  public Token atToken() {
+  public PyToken atToken() {
     return atToken;
   }
 
@@ -59,7 +59,7 @@ public class PyDecoratorTreeImpl extends PyTree implements PyDecoratorTree {
 
   @CheckForNull
   @Override
-  public Token leftPar() {
+  public PyToken leftPar() {
     return lPar;
   }
 
@@ -71,7 +71,7 @@ public class PyDecoratorTreeImpl extends PyTree implements PyDecoratorTree {
 
   @CheckForNull
   @Override
-  public Token rightPar() {
+  public PyToken rightPar() {
     return rPar;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDelStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDelStatementTreeImpl.java
@@ -20,11 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyDelStatementTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -60,6 +63,6 @@ public class PyDelStatementTreeImpl extends PyTree implements PyDelStatementTree
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(expressionTrees);
+    return Stream.of(Collections.singletonList(delKeyword), expressionTrees).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDictCompExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDictCompExpressionTreeImpl.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyComprehensionForTree;
 import org.sonar.python.api.tree.PyDictCompExpressionTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -71,7 +73,7 @@ public class PyDictCompExpressionTreeImpl extends PyTree implements PyDictCompEx
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(keyExpression, valueExpression, comprehensionFor);
+    return Stream.of(keyExpression, colon, valueExpression, comprehensionFor).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDictCompExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDictCompExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyComprehensionForTree;
@@ -31,12 +31,12 @@ import org.sonar.python.api.tree.Tree;
 public class PyDictCompExpressionTreeImpl extends PyTree implements PyDictCompExpressionTree {
 
   private final PyExpressionTree keyExpression;
-  private final Token colon;
+  private final PyToken colon;
   private final PyExpressionTree valueExpression;
   private final PyComprehensionForTree comprehensionFor;
 
-  public PyDictCompExpressionTreeImpl(Token openingBrace, PyExpressionTree keyExpression, Token colon, PyExpressionTree valueExpression,
-                                      PyComprehensionForTree compFor, Token closingBrace) {
+  public PyDictCompExpressionTreeImpl(PyToken openingBrace, PyExpressionTree keyExpression, PyToken colon, PyExpressionTree valueExpression,
+                                      PyComprehensionForTree compFor, PyToken closingBrace) {
     super(openingBrace, closingBrace);
     this.keyExpression = keyExpression;
     this.colon = colon;
@@ -50,7 +50,7 @@ public class PyDictCompExpressionTreeImpl extends PyTree implements PyDictCompEx
   }
 
   @Override
-  public Token colonToken() {
+  public PyToken colonToken() {
     return colon;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDictOrSetLiteralTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDictOrSetLiteralTreeImpl.java
@@ -20,30 +20,30 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.List;
 
 public abstract class PyDictOrSetLiteralTreeImpl extends PyTree {
-  private final Token lCurlyBrace;
-  private final List<Token> commas;
-  private final Token rCurlyBrace;
+  private final PyToken lCurlyBrace;
+  private final List<PyToken> commas;
+  private final PyToken rCurlyBrace;
 
-  public PyDictOrSetLiteralTreeImpl(AstNode node, Token lCurlyBrace, List<Token> commas, Token rCurlyBrace) {
+  public PyDictOrSetLiteralTreeImpl(AstNode node, PyToken lCurlyBrace, List<PyToken> commas, PyToken rCurlyBrace) {
     super(node);
     this.lCurlyBrace = lCurlyBrace;
     this.commas = commas;
     this.rCurlyBrace = rCurlyBrace;
   }
 
-  public Token lCurlyBrace() {
+  public PyToken lCurlyBrace() {
     return lCurlyBrace;
   }
 
-  public Token rCurlyBrace() {
+  public PyToken rCurlyBrace() {
     return rCurlyBrace;
   }
 
-  public List<Token> commas() {
+  public List<PyToken> commas() {
     return commas;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyDictionaryLiteralTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyDictionaryLiteralTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyDictionaryLiteralTree;
@@ -32,7 +32,7 @@ public class PyDictionaryLiteralTreeImpl extends PyDictOrSetLiteralTreeImpl impl
 
   private final List<PyKeyValuePairTree> elements;
 
-  public PyDictionaryLiteralTreeImpl(AstNode node, Token lCurlyBrace, List<Token> commas, List<PyKeyValuePairTree> elements, Token rCurlyBrace) {
+  public PyDictionaryLiteralTreeImpl(AstNode node, PyToken lCurlyBrace, List<PyToken> commas, List<PyKeyValuePairTree> elements, PyToken rCurlyBrace) {
     super(node, lCurlyBrace, commas, rCurlyBrace);
     this.elements = elements;
   }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyEllipsisExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyEllipsisExpressionTreeImpl.java
@@ -20,7 +20,8 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import java.util.stream.Collectors;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyEllipsisExpressionTree;
@@ -29,15 +30,15 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyEllipsisExpressionTreeImpl extends PyTree implements PyEllipsisExpressionTree {
 
-  private final List<Token> ellipsis;
+  private final List<PyToken> ellipsis;
 
   public PyEllipsisExpressionTreeImpl(AstNode node) {
     super(node);
-    this.ellipsis = node.getTokens();
+    this.ellipsis = node.getTokens().stream().map(PyTokenImpl::new).collect(Collectors.toList());
   }
 
   @Override
-  public List<Token> ellipsis() {
+  public List<PyToken> ellipsis() {
     return ellipsis;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyEllipsisExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyEllipsisExpressionTreeImpl.java
@@ -49,7 +49,7 @@ public class PyEllipsisExpressionTreeImpl extends PyTree implements PyEllipsisEx
 
   @Override
   public List<Tree> children() {
-    return Collections.emptyList();
+    return Collections.unmodifiableList(ellipsis);
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyElseStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyElseStatementTreeImpl.java
@@ -19,11 +19,13 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyElseStatementTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -59,6 +61,6 @@ public class PyElseStatementTreeImpl extends PyTree implements PyElseStatementTr
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(body);
+    return Stream.of(elseKeyword, body).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyElseStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyElseStatementTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyElseStatementTree;
@@ -28,10 +28,10 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyElseStatementTreeImpl extends PyTree implements PyElseStatementTree {
-  private final Token elseKeyword;
+  private final PyToken elseKeyword;
   private final PyStatementListTree body;
 
-  public PyElseStatementTreeImpl(Token elseKeyword, PyStatementListTree body) {
+  public PyElseStatementTreeImpl(PyToken elseKeyword, PyStatementListTree body) {
     super(elseKeyword, body.lastToken());
     this.elseKeyword = elseKeyword;
     this.body = body;
@@ -43,7 +43,7 @@ public class PyElseStatementTreeImpl extends PyTree implements PyElseStatementTr
   }
 
   @Override
-  public Token elseKeyword() {
+  public PyToken elseKeyword() {
     return elseKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyExceptClauseTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyExceptClauseTreeImpl.java
@@ -19,8 +19,10 @@
  */
 package org.sonar.python.tree;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExceptClauseTree;
@@ -115,6 +117,6 @@ public class PyExceptClauseTreeImpl extends PyTree implements PyExceptClauseTree
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(body, exception, exceptionInstance);
+    return Stream.of(exceptKeyword, exception, asKeyword, exceptionInstance, commaToken, body).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyExceptClauseTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyExceptClauseTreeImpl.java
@@ -19,8 +19,6 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -28,18 +26,19 @@ import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExceptClauseTree;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyExceptClauseTreeImpl extends PyTree implements PyExceptClauseTree {
-  private final Token exceptKeyword;
+  private final PyToken exceptKeyword;
   private final PyStatementListTree body;
   private final PyExpressionTree exception;
-  private final Token asKeyword;
-  private final Token commaToken;
+  private final PyToken asKeyword;
+  private final PyToken commaToken;
   private final PyExpressionTree exceptionInstance;
 
-  public PyExceptClauseTreeImpl(Token exceptKeyword, PyStatementListTree body) {
+  public PyExceptClauseTreeImpl(PyToken exceptKeyword, PyStatementListTree body) {
     super(exceptKeyword, body.lastToken());
     this.exceptKeyword = exceptKeyword;
     this.body = body;
@@ -49,18 +48,18 @@ public class PyExceptClauseTreeImpl extends PyTree implements PyExceptClauseTree
     this.exceptionInstance = null;
   }
 
-  public PyExceptClauseTreeImpl(Token exceptKeyword, PyStatementListTree body,
-                                PyExpressionTree exception, @Nullable AstNode asNode, @Nullable AstNode commaNode, PyExpressionTree exceptionInstance) {
+  public PyExceptClauseTreeImpl(PyToken exceptKeyword, PyStatementListTree body,
+                                PyExpressionTree exception, @Nullable PyToken asNode, @Nullable PyToken commaNode, PyExpressionTree exceptionInstance) {
     super(exceptKeyword, body.lastToken());
     this.exceptKeyword = exceptKeyword;
     this.body = body;
     this.exception = exception;
-    this.asKeyword = asNode != null ? asNode.getToken() : null;
-    this.commaToken = commaNode != null ? commaNode.getToken() : null;
+    this.asKeyword = asNode;
+    this.commaToken = commaNode;
     this.exceptionInstance = exceptionInstance;
   }
 
-  public PyExceptClauseTreeImpl(Token exceptKeyword, PyStatementListTree body, PyExpressionTree exception) {
+  public PyExceptClauseTreeImpl(PyToken exceptKeyword, PyStatementListTree body, PyExpressionTree exception) {
     super(exceptKeyword, body.lastToken());
     this.exceptKeyword = exceptKeyword;
     this.body = body;
@@ -71,7 +70,7 @@ public class PyExceptClauseTreeImpl extends PyTree implements PyExceptClauseTree
   }
 
   @Override
-  public Token exceptKeyword() {
+  public PyToken exceptKeyword() {
     return exceptKeyword;
   }
 
@@ -82,13 +81,13 @@ public class PyExceptClauseTreeImpl extends PyTree implements PyExceptClauseTree
 
   @CheckForNull
   @Override
-  public Token asKeyword() {
+  public PyToken asKeyword() {
     return asKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token commaToken() {
+  public PyToken commaToken() {
     return commaToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyExecStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyExecStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -30,12 +30,12 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyExecStatementTreeImpl extends PyTree implements PyExecStatementTree {
-  private final Token execKeyword;
+  private final PyToken execKeyword;
   private final PyExpressionTree expression;
   private final PyExpressionTree globalsExpression;
   private final PyExpressionTree localsExpression;
 
-  public PyExecStatementTreeImpl(AstNode astNode, Token execKeyword, PyExpressionTree expression,
+  public PyExecStatementTreeImpl(AstNode astNode, PyToken execKeyword, PyExpressionTree expression,
                                  @Nullable PyExpressionTree globalsExpression, @Nullable PyExpressionTree localsExpression) {
     super(astNode);
     this.execKeyword = execKeyword;
@@ -44,7 +44,7 @@ public class PyExecStatementTreeImpl extends PyTree implements PyExecStatementTr
     this.localsExpression = localsExpression;
   }
 
-  public PyExecStatementTreeImpl(AstNode astNode, Token execKeyword, PyExpressionTree expression) {
+  public PyExecStatementTreeImpl(AstNode astNode, PyToken execKeyword, PyExpressionTree expression) {
     super(astNode);
     this.execKeyword = execKeyword;
     this.expression = expression;
@@ -53,7 +53,7 @@ public class PyExecStatementTreeImpl extends PyTree implements PyExecStatementTr
   }
 
   @Override
-  public Token execKeyword() {
+  public PyToken execKeyword() {
     return execKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyExecStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyExecStatementTreeImpl.java
@@ -20,12 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExecStatementTree;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -84,6 +86,6 @@ public class PyExecStatementTreeImpl extends PyTree implements PyExecStatementTr
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(expression, globalsExpression, localsExpression);
+    return Stream.of(execKeyword, expression, globalsExpression, localsExpression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFileInputTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFileInputTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,9 +33,9 @@ import org.sonar.python.api.tree.Tree;
 public class PyFileInputTreeImpl extends PyTree implements PyFileInputTree {
 
   private final PyStatementListTree statements;
-  private final Token docstring;
+  private final PyToken docstring;
 
-  public PyFileInputTreeImpl(AstNode astNode, @Nullable PyStatementListTree statements, Token docstring) {
+  public PyFileInputTreeImpl(AstNode astNode, @Nullable PyStatementListTree statements, PyToken docstring) {
     super(astNode);
     this.statements = statements;
     this.docstring = docstring;
@@ -54,7 +54,7 @@ public class PyFileInputTreeImpl extends PyTree implements PyFileInputTree {
 
   @CheckForNull
   @Override
-  public Token docstring() {
+  public PyToken docstring() {
     return docstring;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFileInputTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFileInputTreeImpl.java
@@ -20,13 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyFileInputTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -65,6 +67,6 @@ public class PyFileInputTreeImpl extends PyTree implements PyFileInputTree {
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(statements);
+    return Stream.of(statements, docstring).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFinallyClauseTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFinallyClauseTreeImpl.java
@@ -19,11 +19,13 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyFinallyClauseTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -59,6 +61,6 @@ public class PyFinallyClauseTreeImpl extends PyTree implements PyFinallyClauseTr
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(body);
+    return Stream.of(finallyKeyword, body).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFinallyClauseTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFinallyClauseTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyFinallyClauseTree;
@@ -28,17 +28,17 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyFinallyClauseTreeImpl extends PyTree implements PyFinallyClauseTree {
-  private final Token finallyKeyword;
+  private final PyToken finallyKeyword;
   private final PyStatementListTree body;
 
-  public PyFinallyClauseTreeImpl(Token finallyKeyword, PyStatementListTree body) {
+  public PyFinallyClauseTreeImpl(PyToken finallyKeyword, PyStatementListTree body) {
     super(finallyKeyword, body.lastToken());
     this.finallyKeyword = finallyKeyword;
     this.body = body;
   }
 
   @Override
-  public Token finallyKeyword() {
+  public PyToken finallyKeyword() {
     return finallyKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyForStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyForStatementTreeImpl.java
@@ -20,6 +20,8 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Collections;
+import java.util.Objects;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
@@ -137,7 +139,7 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
 
   @Override
   public List<Tree> children() {
-    return Stream.of(expressions, testExpressions, Arrays.asList(body, elseBody))
-      .flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(Arrays.asList(asyncKeyword, forKeyword), expressions, Collections.singletonList(inKeyword), testExpressions,
+      Arrays.asList(colon, body, elseKeyword, colon, elseBody)).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyForStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyForStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,23 +35,23 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree {
 
-  private final Token forKeyword;
+  private final PyToken forKeyword;
   private final List<PyExpressionTree> expressions;
-  private final Token inKeyword;
+  private final PyToken inKeyword;
   private final List<PyExpressionTree> testExpressions;
-  private final Token colon;
+  private final PyToken colon;
   private final PyStatementListTree body;
   @Nullable
-  private final Token elseKeyword;
+  private final PyToken elseKeyword;
   @Nullable
-  private final Token elseColon;
+  private final PyToken elseColon;
   private final PyStatementListTree elseBody;
-  private final Token asyncKeyword;
+  private final PyToken asyncKeyword;
   private final boolean isAsync;
 
-  public PyForStatementTreeImpl(AstNode astNode, Token forKeyword, List<PyExpressionTree> expressions, Token inKeyword,
-                                List<PyExpressionTree> testExpressions, Token colon, PyStatementListTree body,
-                                @Nullable Token elseKeyword, @Nullable Token elseColon, @Nullable PyStatementListTree elseBody, @Nullable Token asyncKeyword) {
+  public PyForStatementTreeImpl(AstNode astNode, PyToken forKeyword, List<PyExpressionTree> expressions, PyToken inKeyword,
+                                List<PyExpressionTree> testExpressions, PyToken colon, PyStatementListTree body,
+                                @Nullable PyToken elseKeyword, @Nullable PyToken elseColon, @Nullable PyStatementListTree elseBody, @Nullable PyToken asyncKeyword) {
     super(astNode);
     this.forKeyword = forKeyword;
     this.expressions = expressions;
@@ -77,7 +77,7 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
   }
 
   @Override
-  public Token forKeyword() {
+  public PyToken forKeyword() {
     return forKeyword;
   }
 
@@ -87,7 +87,7 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
   }
 
   @Override
-  public Token inKeyword() {
+  public PyToken inKeyword() {
     return inKeyword;
   }
 
@@ -97,7 +97,7 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
   }
 
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -108,13 +108,13 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
 
   @CheckForNull
   @Override
-  public Token elseKeyword() {
+  public PyToken elseKeyword() {
     return elseKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token elseColon() {
+  public PyToken elseColon() {
     return elseColon;
   }
 
@@ -131,7 +131,7 @@ public class PyForStatementTreeImpl extends PyTree implements PyForStatementTree
 
   @CheckForNull
   @Override
-  public Token asyncKeyword() {
+  public PyToken asyncKeyword() {
     return asyncKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFunctionDefTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFunctionDefTreeImpl.java
@@ -20,9 +20,11 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyDecoratorTree;
@@ -30,6 +32,7 @@ import org.sonar.python.api.tree.PyFunctionDefTree;
 import org.sonar.python.api.tree.PyNameTree;
 import org.sonar.python.api.tree.PyParameterListTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyTypeAnnotationTree;
 import org.sonar.python.api.tree.Tree;
@@ -143,6 +146,7 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(name, parameters, body);
+    return Stream.of(decorators, Arrays.asList(asyncKeyword, defKeyword, name, leftPar, parameters, rightPar, returnType, colon, docstring, body))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyFunctionDefTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyFunctionDefTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -37,21 +37,21 @@ import org.sonar.python.api.tree.Tree;
 public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
 
   private final List<PyDecoratorTree> decorators;
-  private final Token asyncKeyword;
-  private final Token defKeyword;
+  private final PyToken asyncKeyword;
+  private final PyToken defKeyword;
   private final PyNameTree name;
-  private final Token leftPar;
+  private final PyToken leftPar;
   private final PyParameterListTree parameters;
-  private final Token rightPar;
+  private final PyToken rightPar;
   private final PyTypeAnnotationTree returnType;
-  private final Token colon;
+  private final PyToken colon;
   private final PyStatementListTree body;
   private final boolean isMethodDefinition;
-  private final Token docstring;
+  private final PyToken docstring;
 
-  public PyFunctionDefTreeImpl(AstNode astNode, List<PyDecoratorTree> decorators, @Nullable Token asyncKeyword, Token defKeyword, PyNameTree name,
-                               Token leftPar, @Nullable PyParameterListTree parameters, Token rightPar, @Nullable PyTypeAnnotationTree returnType,
-                               Token colon, PyStatementListTree body, boolean isMethodDefinition, @Nullable Token docstring) {
+  public PyFunctionDefTreeImpl(AstNode astNode, List<PyDecoratorTree> decorators, @Nullable PyToken asyncKeyword, PyToken defKeyword, PyNameTree name,
+                               PyToken leftPar, @Nullable PyParameterListTree parameters, PyToken rightPar, @Nullable PyTypeAnnotationTree returnType,
+                               PyToken colon, PyStatementListTree body, boolean isMethodDefinition, @Nullable PyToken docstring) {
     super(astNode);
     this.decorators = decorators;
     this.asyncKeyword = asyncKeyword;
@@ -73,13 +73,13 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
   }
 
   @Override
-  public Token defKeyword() {
+  public PyToken defKeyword() {
     return defKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token asyncKeyword() {
+  public PyToken asyncKeyword() {
     return asyncKeyword;
   }
 
@@ -89,7 +89,7 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
   }
 
   @Override
-  public Token leftPar() {
+  public PyToken leftPar() {
     return leftPar;
   }
 
@@ -100,7 +100,7 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
   }
 
   @Override
-  public Token rightPar() {
+  public PyToken rightPar() {
     return rightPar;
   }
 
@@ -111,7 +111,7 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
   }
 
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -127,7 +127,7 @@ public class PyFunctionDefTreeImpl extends PyTree implements PyFunctionDefTree {
 
   @CheckForNull
   @Override
-  public Token docstring() {
+  public PyToken docstring() {
     return docstring;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyGlobalStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyGlobalStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyGlobalStatementTree;
@@ -29,17 +29,17 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyGlobalStatementTreeImpl extends PyTree implements PyGlobalStatementTree {
-  private final Token globalKeyword;
+  private final PyToken globalKeyword;
   private final List<PyNameTree> variables;
 
-  public PyGlobalStatementTreeImpl(AstNode astNode, Token globalKeyword, List<PyNameTree> variables) {
+  public PyGlobalStatementTreeImpl(AstNode astNode, PyToken globalKeyword, List<PyNameTree> variables) {
     super(astNode);
     this.globalKeyword = globalKeyword;
     this.variables = variables;
   }
 
   @Override
-  public Token globalKeyword() {
+  public PyToken globalKeyword() {
     return globalKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyGlobalStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyGlobalStatementTreeImpl.java
@@ -20,11 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyGlobalStatementTree;
 import org.sonar.python.api.tree.PyNameTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -60,6 +63,6 @@ public class PyGlobalStatementTreeImpl extends PyTree implements PyGlobalStateme
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(variables);
+    return Stream.of(Collections.singletonList(globalKeyword), variables).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyIfStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyIfStatementTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +35,7 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyIfStatementTreeImpl extends PyTree implements PyIfStatementTree {
 
-  private final Token keyword;
+  private final PyToken keyword;
   private final PyExpressionTree condition;
   private final PyStatementListTree statements;
   private final List<PyIfStatementTree> elifBranches;
@@ -47,7 +47,7 @@ public class PyIfStatementTreeImpl extends PyTree implements PyIfStatementTree {
    *
    * If statement constructor
    */
-  public PyIfStatementTreeImpl(Token ifKeyword, PyExpressionTree condition,
+  public PyIfStatementTreeImpl(PyToken ifKeyword, PyExpressionTree condition,
                                PyStatementListTree statements, List<PyIfStatementTree> elifBranches, @CheckForNull PyElseStatementTree elseStatement) {
     super(ifKeyword, statements.lastToken());
     this.keyword = ifKeyword;
@@ -61,7 +61,7 @@ public class PyIfStatementTreeImpl extends PyTree implements PyIfStatementTree {
   /**
    * Elif statement constructor
    */
-  public PyIfStatementTreeImpl(Token elifKeyword, PyExpressionTree condition, PyStatementListTree statements) {
+  public PyIfStatementTreeImpl(PyToken elifKeyword, PyExpressionTree condition, PyStatementListTree statements) {
     super(elifKeyword, statements.lastToken());
     this.keyword = elifKeyword;
     this.condition = condition;
@@ -72,7 +72,7 @@ public class PyIfStatementTreeImpl extends PyTree implements PyIfStatementTree {
   }
 
   @Override
-  public Token keyword() {
+  public PyToken keyword() {
     return keyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyIfStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyIfStatementTreeImpl.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.tree;
 
+import java.util.Objects;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.Collections;
@@ -114,7 +115,7 @@ public class PyIfStatementTreeImpl extends PyTree implements PyIfStatementTree {
 
   @Override
   public List<Tree> children() {
-    return Stream.of(elifBranches, Arrays.asList(condition, statements, elseStatement))
-      .flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(Arrays.asList(keyword, condition, statements), elifBranches, Collections.singletonList(elseStatement))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyImportFromTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyImportFromTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -35,16 +35,16 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyImportFromTreeImpl extends PyTree implements PyImportFromTree {
-  private final Token fromKeyword;
-  private final List<Token> dottedPrefixForModule;
+  private final PyToken fromKeyword;
+  private final List<PyToken> dottedPrefixForModule;
   private final PyDottedNameTree moduleName;
-  private final Token importKeyword;
+  private final PyToken importKeyword;
   private final List<PyAliasedNameTree> aliasedImportNames;
   private final boolean isWildcardImport;
-  private final Token wildcard;
+  private final PyToken wildcard;
 
-  public PyImportFromTreeImpl(AstNode astNode, Token fromKeyword, @Nullable List<Token> dottedPrefixForModule,
-                              @Nullable PyDottedNameTree moduleName, Token importKeyword,
+  public PyImportFromTreeImpl(AstNode astNode, PyToken fromKeyword, @Nullable List<PyToken> dottedPrefixForModule,
+                              @Nullable PyDottedNameTree moduleName, PyToken importKeyword,
                               @Nullable List<PyAliasedNameTree> aliasedImportNames, boolean isWildcardImport) {
     super(astNode);
     this.fromKeyword = fromKeyword;
@@ -53,11 +53,11 @@ public class PyImportFromTreeImpl extends PyTree implements PyImportFromTree {
     this.importKeyword = importKeyword;
     this.aliasedImportNames = aliasedImportNames == null ? Collections.emptyList() : aliasedImportNames;
     this.isWildcardImport = isWildcardImport;
-    this.wildcard = isWildcardImport ? astNode.getFirstChild(PythonPunctuator.MUL).getToken() : null;
+    this.wildcard = isWildcardImport ? new PyTokenImpl(astNode.getFirstChild(PythonPunctuator.MUL).getToken()) : null;
   }
 
   @Override
-  public Token fromKeyword() {
+  public PyToken fromKeyword() {
     return fromKeyword;
   }
 
@@ -68,13 +68,13 @@ public class PyImportFromTreeImpl extends PyTree implements PyImportFromTree {
   }
 
   @Override
-  public Token importKeyword() {
+  public PyToken importKeyword() {
     return importKeyword;
   }
 
   @CheckForNull
   @Override
-  public List<Token> dottedPrefixForModule() {
+  public List<PyToken> dottedPrefixForModule() {
     return dottedPrefixForModule;
   }
 
@@ -90,7 +90,7 @@ public class PyImportFromTreeImpl extends PyTree implements PyImportFromTree {
 
   @CheckForNull
   @Override
-  public Token wildcard() {
+  public PyToken wildcard() {
     return wildcard;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyImportFromTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyImportFromTreeImpl.java
@@ -20,9 +20,10 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
@@ -31,6 +32,7 @@ import org.sonar.python.api.PythonPunctuator;
 import org.sonar.python.api.tree.PyAliasedNameTree;
 import org.sonar.python.api.tree.PyDottedNameTree;
 import org.sonar.python.api.tree.PyImportFromTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -106,7 +108,7 @@ public class PyImportFromTreeImpl extends PyTree implements PyImportFromTree {
 
   @Override
   public List<Tree> children() {
-    return Stream.of(aliasedImportNames, Collections.singletonList(moduleName))
-      .flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(Collections.singletonList(importKeyword), aliasedImportNames, Collections.singletonList(fromKeyword),
+      dottedPrefixForModule, Arrays.asList(moduleName, wildcard)).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyImportNameTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyImportNameTreeImpl.java
@@ -20,6 +20,9 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -61,6 +64,6 @@ public class PyImportNameTreeImpl extends PyTree implements PyImportNameTree {
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(aliasedNames);
+    return Stream.of(Collections.singletonList(importKeyword), aliasedNames).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyImportNameTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyImportNameTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyAliasedNameTree;
@@ -30,17 +30,17 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyImportNameTreeImpl extends PyTree implements PyImportNameTree {
 
-  private final Token importKeyword;
+  private final PyToken importKeyword;
   private final List<PyAliasedNameTree> aliasedNames;
 
-  public PyImportNameTreeImpl(AstNode astNode, Token importKeyword, List<PyAliasedNameTree> aliasedNames) {
+  public PyImportNameTreeImpl(AstNode astNode, PyToken importKeyword, List<PyAliasedNameTree> aliasedNames) {
     super(astNode);
     this.importKeyword = importKeyword;
     this.aliasedNames = aliasedNames;
   }
 
   @Override
-  public Token importKeyword() {
+  public PyToken importKeyword() {
     return importKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyInExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyInExpressionTreeImpl.java
@@ -19,11 +19,17 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyInExpressionTree;
+import org.sonar.python.api.tree.PyToken;
+import org.sonar.python.api.tree.Tree;
 
 public class PyInExpressionTreeImpl extends PyBinaryExpressionTreeImpl implements PyInExpressionTree {
 
@@ -43,5 +49,10 @@ public class PyInExpressionTreeImpl extends PyBinaryExpressionTreeImpl implement
   @Override
   public PyToken notToken() {
     return notToken;
+  }
+
+  @Override
+  public List<Tree> children() {
+    return Stream.of(Collections.singletonList(notToken), super.children()).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyInExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyInExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -27,9 +27,9 @@ import org.sonar.python.api.tree.PyInExpressionTree;
 
 public class PyInExpressionTreeImpl extends PyBinaryExpressionTreeImpl implements PyInExpressionTree {
 
-  private final Token notToken;
+  private final PyToken notToken;
 
-  public PyInExpressionTreeImpl(PyExpressionTree leftOperand, @Nullable Token not, Token operator, PyExpressionTree rightOperand) {
+  public PyInExpressionTreeImpl(PyExpressionTree leftOperand, @Nullable PyToken not, PyToken operator, PyExpressionTree rightOperand) {
     super(leftOperand, operator, rightOperand);
     this.notToken = not;
   }
@@ -41,7 +41,7 @@ public class PyInExpressionTreeImpl extends PyBinaryExpressionTreeImpl implement
 
   @CheckForNull
   @Override
-  public Token notToken() {
+  public PyToken notToken() {
     return notToken;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyIsExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyIsExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -27,9 +27,9 @@ import org.sonar.python.api.tree.PyIsExpressionTree;
 
 public class PyIsExpressionTreeImpl extends PyBinaryExpressionTreeImpl implements PyIsExpressionTree {
 
-  private final Token notToken;
+  private final PyToken notToken;
 
-  public PyIsExpressionTreeImpl(PyExpressionTree leftOperand, Token operator, @Nullable Token not, PyExpressionTree rightOperand) {
+  public PyIsExpressionTreeImpl(PyExpressionTree leftOperand, PyToken operator, @Nullable PyToken not, PyExpressionTree rightOperand) {
     super(leftOperand, operator, rightOperand);
     this.notToken = not;
   }
@@ -41,7 +41,7 @@ public class PyIsExpressionTreeImpl extends PyBinaryExpressionTreeImpl implement
 
   @CheckForNull
   @Override
-  public Token notToken() {
+  public PyToken notToken() {
     return notToken;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyIsExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyIsExpressionTreeImpl.java
@@ -19,11 +19,17 @@
  */
 package org.sonar.python.tree;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyIsExpressionTree;
+import org.sonar.python.api.tree.Tree;
 
 public class PyIsExpressionTreeImpl extends PyBinaryExpressionTreeImpl implements PyIsExpressionTree {
 
@@ -43,5 +49,10 @@ public class PyIsExpressionTreeImpl extends PyBinaryExpressionTreeImpl implement
   @Override
   public PyToken notToken() {
     return notToken;
+  }
+
+  @Override
+  public List<Tree> children() {
+    return Stream.of(Collections.singletonList(notToken), super.children()).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyKeyValuePairTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyKeyValuePairTreeImpl.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyKeyValuePairTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -91,7 +93,7 @@ public class PyKeyValuePairTreeImpl extends PyTree implements PyKeyValuePairTree
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(expression, key, value);
+    return Stream.of(expression, key, colon, value, starStarToken).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyKeyValuePairTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyKeyValuePairTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -30,13 +30,13 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyKeyValuePairTreeImpl extends PyTree implements PyKeyValuePairTree {
 
-  private final Token starStarToken;
+  private final PyToken starStarToken;
   private final PyExpressionTree expression;
   private final PyExpressionTree key;
-  private final Token colon;
+  private final PyToken colon;
   private final PyExpressionTree value;
 
-  public PyKeyValuePairTreeImpl(Token starStarToken, PyExpressionTree expression) {
+  public PyKeyValuePairTreeImpl(PyToken starStarToken, PyExpressionTree expression) {
     super(starStarToken, expression.lastToken());
     this.starStarToken = starStarToken;
     this.expression = expression;
@@ -45,7 +45,7 @@ public class PyKeyValuePairTreeImpl extends PyTree implements PyKeyValuePairTree
     this.value = null;
   }
 
-  public PyKeyValuePairTreeImpl(PyExpressionTree key, Token colon, PyExpressionTree value) {
+  public PyKeyValuePairTreeImpl(PyExpressionTree key, PyToken colon, PyExpressionTree value) {
     super(key.firstToken(), value.lastToken());
     this.key = key;
     this.colon = colon;
@@ -62,7 +62,7 @@ public class PyKeyValuePairTreeImpl extends PyTree implements PyKeyValuePairTree
 
   @CheckForNull
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -74,7 +74,7 @@ public class PyKeyValuePairTreeImpl extends PyTree implements PyKeyValuePairTree
 
   @CheckForNull
   @Override
-  public Token starStarToken() {
+  public PyToken starStarToken() {
     return starStarToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyLambdaExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyLambdaExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -32,12 +32,12 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyLambdaExpressionTreeImpl extends PyTree implements PyLambdaExpressionTree {
-  private final Token lambdaKeyword;
-  private final Token colonToken;
+  private final PyToken lambdaKeyword;
+  private final PyToken colonToken;
   private final PyExpressionTree body;
   private final PyParameterListTree parameterList;
 
-  public PyLambdaExpressionTreeImpl(AstNode astNode, Token lambdaKeyword, Token colonToken, PyExpressionTree body, @Nullable PyParameterListTree parameterList) {
+  public PyLambdaExpressionTreeImpl(AstNode astNode, PyToken lambdaKeyword, PyToken colonToken, PyExpressionTree body, @Nullable PyParameterListTree parameterList) {
     super(astNode);
     this.lambdaKeyword = lambdaKeyword;
     this.colonToken = colonToken;
@@ -46,12 +46,12 @@ public class PyLambdaExpressionTreeImpl extends PyTree implements PyLambdaExpres
   }
 
   @Override
-  public Token lambdaKeyword() {
+  public PyToken lambdaKeyword() {
     return lambdaKeyword;
   }
 
   @Override
-  public Token colonToken() {
+  public PyToken colonToken() {
     return colonToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyLambdaExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyLambdaExpressionTreeImpl.java
@@ -20,14 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyLambdaExpressionTree;
 import org.sonar.python.api.tree.PyParameterListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -78,6 +79,6 @@ public class PyLambdaExpressionTreeImpl extends PyTree implements PyLambdaExpres
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(parameterList, body);
+    return Stream.of(lambdaKeyword, parameterList, colonToken, body).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyListLiteralTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyListLiteralTreeImpl.java
@@ -20,11 +20,12 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionListTree;
 import org.sonar.python.api.tree.PyListLiteralTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -68,6 +69,6 @@ public class PyListLiteralTreeImpl extends PyTree implements PyListLiteralTree {
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(elements);
+    return Stream.of(leftBracket, elements, rightBracket).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyListLiteralTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyListLiteralTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionListTree;
@@ -30,11 +30,11 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyListLiteralTreeImpl extends PyTree implements PyListLiteralTree {
 
-  private final Token leftBracket;
+  private final PyToken leftBracket;
   private final PyExpressionListTree elements;
-  private final Token rightBracket;
+  private final PyToken rightBracket;
 
-  public PyListLiteralTreeImpl(AstNode astNode, Token leftBracket, PyExpressionListTree elements, Token rightBracket) {
+  public PyListLiteralTreeImpl(AstNode astNode, PyToken leftBracket, PyExpressionListTree elements, PyToken rightBracket) {
     super(astNode);
     this.leftBracket = leftBracket;
     this.elements = elements;
@@ -52,7 +52,7 @@ public class PyListLiteralTreeImpl extends PyTree implements PyListLiteralTree {
   }
 
   @Override
-  public Token leftBracket() {
+  public PyToken leftBracket() {
     return leftBracket;
   }
 
@@ -62,7 +62,7 @@ public class PyListLiteralTreeImpl extends PyTree implements PyListLiteralTree {
   }
 
   @Override
-  public Token rightBracket() {
+  public PyToken rightBracket() {
     return rightBracket;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyNoneExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyNoneExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyNoneExpressionTree;
@@ -28,15 +28,15 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyNoneExpressionTreeImpl extends PyTree implements PyNoneExpressionTree {
-  private final Token none;
+  private final PyToken none;
 
-  public PyNoneExpressionTreeImpl(AstNode astNode, Token none) {
+  public PyNoneExpressionTreeImpl(AstNode astNode, PyToken none) {
     super(astNode);
     this.none = none;
   }
 
   @Override
-  public Token none() {
+  public PyToken none() {
     return none;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyNoneExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyNoneExpressionTreeImpl.java
@@ -47,7 +47,7 @@ public class PyNoneExpressionTreeImpl extends PyTree implements PyNoneExpression
 
   @Override
   public List<Tree> children() {
-    return Collections.emptyList();
+    return Collections.singletonList(none);
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyNonlocalStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyNonlocalStatementTreeImpl.java
@@ -20,6 +20,9 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +63,6 @@ public class PyNonlocalStatementTreeImpl extends PyTree implements PyNonlocalSta
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(variables);
+    return Stream.of(Collections.singletonList(nonlocalKeyword), variables).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyNonlocalStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyNonlocalStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyNameTree;
@@ -29,17 +29,17 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyNonlocalStatementTreeImpl extends PyTree implements PyNonlocalStatementTree {
-  private final Token nonlocalKeyword;
+  private final PyToken nonlocalKeyword;
   private final List<PyNameTree> variables;
 
-  public PyNonlocalStatementTreeImpl(AstNode astNode, Token nonlocalKeyword, List<PyNameTree> variables) {
+  public PyNonlocalStatementTreeImpl(AstNode astNode, PyToken nonlocalKeyword, List<PyNameTree> variables) {
     super(astNode);
     this.nonlocalKeyword = nonlocalKeyword;
     this.variables = variables;
   }
 
   @Override
-  public Token nonlocalKeyword() {
+  public PyToken nonlocalKeyword() {
     return nonlocalKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyParameterTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyParameterTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -36,12 +36,12 @@ public class PyParameterTreeImpl extends PyTree implements PyParameterTree {
 
   private final PyNameTree name;
   private final PyTypeAnnotationTree annotation;
-  private final Token equalToken;
+  private final PyToken equalToken;
   private final PyExpressionTree defaultValue;
-  private final Token starToken;
+  private final PyToken starToken;
 
-  public PyParameterTreeImpl(AstNode node, @Nullable Token starToken, PyNameTree name, @Nullable PyTypeAnnotationTree annotation,
-                             @Nullable Token equalToken, @Nullable PyExpressionTree defaultValue) {
+  public PyParameterTreeImpl(AstNode node, @Nullable PyToken starToken, PyNameTree name, @Nullable PyTypeAnnotationTree annotation,
+                             @Nullable PyToken equalToken, @Nullable PyExpressionTree defaultValue) {
     super(node);
     this.starToken = starToken;
     this.name = name;
@@ -52,7 +52,7 @@ public class PyParameterTreeImpl extends PyTree implements PyParameterTree {
 
   @CheckForNull
   @Override
-  public Token starToken() {
+  public PyToken starToken() {
     return starToken;
   }
 
@@ -69,7 +69,7 @@ public class PyParameterTreeImpl extends PyTree implements PyParameterTree {
 
   @CheckForNull
   @Override
-  public Token equalToken() {
+  public PyToken equalToken() {
     return equalToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyParameterTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyParameterTreeImpl.java
@@ -20,14 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyNameTree;
 import org.sonar.python.api.tree.PyParameterTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyTypeAnnotationTree;
 import org.sonar.python.api.tree.Tree;
@@ -91,6 +92,6 @@ public class PyParameterTreeImpl extends PyTree implements PyParameterTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(name, annotation, defaultValue);
+    return Stream.of(name, annotation, equalToken, defaultValue, starToken).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyParenthesizedExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyParenthesizedExpressionTreeImpl.java
@@ -19,11 +19,12 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyParenthesizedExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -62,7 +63,7 @@ public class PyParenthesizedExpressionTreeImpl extends PyTree implements PyParen
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expression);
+    return Stream.of(leftParenthesis, expression, rightParenthesis).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyParenthesizedExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyParenthesizedExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -29,11 +29,11 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyParenthesizedExpressionTreeImpl extends PyTree implements PyParenthesizedExpressionTree {
 
-  private final Token leftParenthesis;
+  private final PyToken leftParenthesis;
   private final PyExpressionTree expression;
-  private final Token rightParenthesis;
+  private final PyToken rightParenthesis;
 
-  public PyParenthesizedExpressionTreeImpl(Token leftParenthesis, PyExpressionTree expression, Token rightParenthesis) {
+  public PyParenthesizedExpressionTreeImpl(PyToken leftParenthesis, PyExpressionTree expression, PyToken rightParenthesis) {
     super(leftParenthesis, rightParenthesis);
     this.leftParenthesis = leftParenthesis;
     this.expression = expression;
@@ -41,7 +41,7 @@ public class PyParenthesizedExpressionTreeImpl extends PyTree implements PyParen
   }
 
   @Override
-  public Token leftParenthesis() {
+  public PyToken leftParenthesis() {
     return leftParenthesis;
   }
 
@@ -51,7 +51,7 @@ public class PyParenthesizedExpressionTreeImpl extends PyTree implements PyParen
   }
 
   @Override
-  public Token rightParenthesis() {
+  public PyToken rightParenthesis() {
     return rightParenthesis;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyPassStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyPassStatementTreeImpl.java
@@ -52,6 +52,6 @@ public class PyPassStatementTreeImpl extends PyTree implements PyPassStatementTr
 
   @Override
   public List<Tree> children() {
-    return Collections.emptyList();
+    return Collections.singletonList(passKeyword);
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyPassStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyPassStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyPassStatementTree;
@@ -28,15 +28,15 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyPassStatementTreeImpl extends PyTree implements PyPassStatementTree {
-  private final Token passKeyword;
+  private final PyToken passKeyword;
 
-  public PyPassStatementTreeImpl(AstNode astNode, Token passKeyword) {
+  public PyPassStatementTreeImpl(AstNode astNode, PyToken passKeyword) {
     super(astNode);
     this.passKeyword = passKeyword;
   }
 
   @Override
-  public Token passKeyword() {
+  public PyToken passKeyword() {
     return passKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyPrintStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyPrintStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -29,17 +29,17 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyPrintStatementTreeImpl extends PyTree implements PyPrintStatementTree {
-  private final Token printKeyword;
+  private final PyToken printKeyword;
   private final List<PyExpressionTree> expressions;
 
-  public PyPrintStatementTreeImpl(AstNode astNode, Token printKeyword, List<PyExpressionTree> expressions) {
+  public PyPrintStatementTreeImpl(AstNode astNode, PyToken printKeyword, List<PyExpressionTree> expressions) {
     super(astNode);
     this.printKeyword = printKeyword;
     this.expressions = expressions;
   }
 
   @Override
-  public Token printKeyword() {
+  public PyToken printKeyword() {
     return printKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyPrintStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyPrintStatementTreeImpl.java
@@ -20,11 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyPrintStatementTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -60,6 +63,6 @@ public class PyPrintStatementTreeImpl extends PyTree implements PyPrintStatement
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(expressions);
+    return Stream.of(Collections.singletonList(printKeyword), expressions).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyQualifiedExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyQualifiedExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,10 +33,10 @@ import org.sonar.python.api.tree.Tree;
 public class PyQualifiedExpressionTreeImpl extends PyTree implements PyQualifiedExpressionTree {
   private final PyNameTree name;
   private final PyExpressionTree qualifier;
-  private final Token dotToken;
+  private final PyToken dotToken;
   private final AstNode astNode;
 
-  public PyQualifiedExpressionTreeImpl(AstNode astNode, PyNameTree name, PyExpressionTree qualifier, Token dotToken) {
+  public PyQualifiedExpressionTreeImpl(AstNode astNode, PyNameTree name, PyExpressionTree qualifier, PyToken dotToken) {
     super(qualifier.firstToken(), name.lastToken());
     // FIXME : astNode is required to make semantic work at function level, this should disappear once semantic relies on strongly typed AST.
     this.astNode = astNode;
@@ -57,7 +57,7 @@ public class PyQualifiedExpressionTreeImpl extends PyTree implements PyQualified
   }
 
   @Override
-  public Token dotToken() {
+  public PyToken dotToken() {
     return dotToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyQualifiedExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyQualifiedExpressionTreeImpl.java
@@ -20,13 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyNameTree;
 import org.sonar.python.api.tree.PyQualifiedExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -78,6 +79,6 @@ public class PyQualifiedExpressionTreeImpl extends PyTree implements PyQualified
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(name, qualifier);
+    return Stream.of(name, dotToken, qualifier).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyRaiseStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyRaiseStatementTreeImpl.java
@@ -20,6 +20,8 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Arrays;
+import java.util.Objects;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -81,7 +83,7 @@ public class PyRaiseStatementTreeImpl extends PyTree implements PyRaiseStatement
 
   @Override
   public List<Tree> children() {
-    return Stream.of(expressions, Collections.singletonList(fromExpression))
-      .flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(Collections.singletonList(raiseKeyword), expressions, Arrays.asList(fromKeyword, fromExpression))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyRaiseStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyRaiseStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -33,13 +33,13 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyRaiseStatementTreeImpl extends PyTree implements PyRaiseStatementTree {
-  private final Token raiseKeyword;
+  private final PyToken raiseKeyword;
   private final List<PyExpressionTree> expressions;
-  private final Token fromKeyword;
+  private final PyToken fromKeyword;
   private final PyExpressionTree fromExpression;
 
-  public PyRaiseStatementTreeImpl(AstNode astNode, Token raiseKeyword, List<PyExpressionTree> expressions,
-                                  @Nullable Token fromKeyword, @Nullable PyExpressionTree fromExpression) {
+  public PyRaiseStatementTreeImpl(AstNode astNode, PyToken raiseKeyword, List<PyExpressionTree> expressions,
+                                  @Nullable PyToken fromKeyword, @Nullable PyExpressionTree fromExpression) {
     super(astNode);
     this.raiseKeyword = raiseKeyword;
     this.expressions = expressions;
@@ -48,13 +48,13 @@ public class PyRaiseStatementTreeImpl extends PyTree implements PyRaiseStatement
   }
 
   @Override
-  public Token raiseKeyword() {
+  public PyToken raiseKeyword() {
     return raiseKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token fromKeyword() {
+  public PyToken fromKeyword() {
     return fromKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyReprExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyReprExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionListTree;
@@ -29,11 +29,11 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyReprExpressionTreeImpl extends PyTree implements PyReprExpressionTree {
-  private final Token openingBacktick;
+  private final PyToken openingBacktick;
   private final PyExpressionListTree expressionListTree;
-  private final Token closingBacktick;
+  private final PyToken closingBacktick;
 
-  public PyReprExpressionTreeImpl(AstNode astNode, Token openingBacktick, PyExpressionListTree expressionListTree, Token closingBacktick) {
+  public PyReprExpressionTreeImpl(AstNode astNode, PyToken openingBacktick, PyExpressionListTree expressionListTree, PyToken closingBacktick) {
     super(astNode);
     this.openingBacktick = openingBacktick;
     this.expressionListTree = expressionListTree;
@@ -56,7 +56,7 @@ public class PyReprExpressionTreeImpl extends PyTree implements PyReprExpression
   }
 
   @Override
-  public Token openingBacktick() {
+  public PyToken openingBacktick() {
     return openingBacktick;
   }
 
@@ -66,7 +66,7 @@ public class PyReprExpressionTreeImpl extends PyTree implements PyReprExpression
   }
 
   @Override
-  public Token closingBacktick() {
+  public PyToken closingBacktick() {
     return closingBacktick;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyReprExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyReprExpressionTreeImpl.java
@@ -20,11 +20,12 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionListTree;
 import org.sonar.python.api.tree.PyReprExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -47,7 +48,7 @@ public class PyReprExpressionTreeImpl extends PyTree implements PyReprExpression
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expressionListTree);
+    return Stream.of(openingBacktick, expressionListTree, closingBacktick).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyReturnStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyReturnStatementTreeImpl.java
@@ -20,6 +20,9 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -60,6 +63,6 @@ public class PyReturnStatementTreeImpl extends PyTree implements PyReturnStateme
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(expressionTrees);
+    return Stream.of(Collections.singletonList(returnKeyword), expressionTrees).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyReturnStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyReturnStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -29,17 +29,17 @@ import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
 public class PyReturnStatementTreeImpl extends PyTree implements PyReturnStatementTree {
-  private final Token returnKeyword;
+  private final PyToken returnKeyword;
   private final List<PyExpressionTree> expressionTrees;
 
-  public PyReturnStatementTreeImpl(AstNode astNode, Token returnKeyword, List<PyExpressionTree> expressionTrees) {
+  public PyReturnStatementTreeImpl(AstNode astNode, PyToken returnKeyword, List<PyExpressionTree> expressionTrees) {
     super(astNode);
     this.returnKeyword = returnKeyword;
     this.expressionTrees = expressionTrees;
   }
 
   @Override
-  public Token returnKeyword() {
+  public PyToken returnKeyword() {
     return returnKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PySetLiteralTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySetLiteralTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -31,7 +31,7 @@ import org.sonar.python.api.tree.Tree;
 public class PySetLiteralTreeImpl extends PyDictOrSetLiteralTreeImpl implements PySetLiteralTree {
   private final List<PyExpressionTree> elements;
 
-  public PySetLiteralTreeImpl(AstNode node, Token lCurlyBrace, List<PyExpressionTree> elements, List<Token> commas, Token rCurlyBrace) {
+  public PySetLiteralTreeImpl(AstNode node, PyToken lCurlyBrace, List<PyExpressionTree> elements, List<PyToken> commas, PyToken rCurlyBrace) {
     super(node, lCurlyBrace, commas, rCurlyBrace);
     this.elements = elements;
   }

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -31,11 +31,11 @@ import org.sonar.python.api.tree.Tree;
 public class PySliceExpressionTreeImpl extends PyTree implements PySliceExpressionTree {
 
   private final PyExpressionTree object;
-  private final Token leftBracket;
+  private final PyToken leftBracket;
   private final PySliceListTree sliceList;
-  private final Token rightBracket;
+  private final PyToken rightBracket;
 
-  public PySliceExpressionTreeImpl(PyExpressionTree object, Token leftBracket, PySliceListTree sliceList, Token rightBracket) {
+  public PySliceExpressionTreeImpl(PyExpressionTree object, PyToken leftBracket, PySliceListTree sliceList, PyToken rightBracket) {
     super(object.firstToken(), rightBracket);
     this.object = object;
     this.leftBracket = leftBracket;
@@ -49,7 +49,7 @@ public class PySliceExpressionTreeImpl extends PyTree implements PySliceExpressi
   }
 
   @Override
-  public Token leftBracket() {
+  public PyToken leftBracket() {
     return leftBracket;
   }
 
@@ -59,7 +59,7 @@ public class PySliceExpressionTreeImpl extends PyTree implements PySliceExpressi
   }
 
   @Override
-  public Token rightBracket() {
+  public PyToken rightBracket() {
     return rightBracket;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceExpressionTreeImpl.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PySliceExpressionTree;
 import org.sonar.python.api.tree.PySliceListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -70,7 +72,7 @@ public class PySliceExpressionTreeImpl extends PyTree implements PySliceExpressi
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(object, sliceList);
+    return Stream.of(object, leftBracket, sliceList, rightBracket).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceItemTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceItemTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,14 +33,14 @@ import org.sonar.python.api.tree.Tree;
 public class PySliceItemTreeImpl extends PyTree implements PySliceItemTree {
 
   private final PyExpressionTree lowerBound;
-  private final Token boundSeparator;
+  private final PyToken boundSeparator;
   private final PyExpressionTree upperBound;
-  private final Token strideSeparator;
+  private final PyToken strideSeparator;
   private final PyExpressionTree stride;
 
   public PySliceItemTreeImpl(
-    AstNode node, @Nullable PyExpressionTree lowerBound, Token boundSeparator, @Nullable PyExpressionTree upperBound,
-    @Nullable Token strideSeparator, @Nullable PyExpressionTree stride
+    AstNode node, @Nullable PyExpressionTree lowerBound, PyToken boundSeparator, @Nullable PyExpressionTree upperBound,
+    @Nullable PyToken strideSeparator, @Nullable PyExpressionTree stride
   ) {
     super(node);
     this.lowerBound = lowerBound;
@@ -57,7 +57,7 @@ public class PySliceItemTreeImpl extends PyTree implements PySliceItemTree {
   }
 
   @Override
-  public Token boundSeparator() {
+  public PyToken boundSeparator() {
     return boundSeparator;
   }
 
@@ -69,7 +69,7 @@ public class PySliceItemTreeImpl extends PyTree implements PySliceItemTree {
 
   @CheckForNull
   @Override
-  public Token strideSeparator() {
+  public PyToken strideSeparator() {
     return strideSeparator;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceItemTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceItemTreeImpl.java
@@ -20,13 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PySliceItemTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -86,7 +88,7 @@ public class PySliceItemTreeImpl extends PyTree implements PySliceItemTree {
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(lowerBound, upperBound, stride);
+    return Stream.of(lowerBound, boundSeparator, upperBound, strideSeparator, stride).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceListTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceListTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.List;
 import org.sonar.python.api.tree.PySliceListTree;
 import org.sonar.python.api.tree.PyTreeVisitor;
@@ -29,9 +29,9 @@ import org.sonar.python.api.tree.Tree;
 public class PySliceListTreeImpl extends PyTree implements PySliceListTree {
 
   private final List<Tree> slices;
-  private final List<Token> separators;
+  private final List<PyToken> separators;
 
-  public PySliceListTreeImpl(AstNode node, List<Tree> slices, List<Token> separators) {
+  public PySliceListTreeImpl(AstNode node, List<Tree> slices, List<PyToken> separators) {
     super(node);
     this.slices = slices;
     this.separators = separators;
@@ -43,7 +43,7 @@ public class PySliceListTreeImpl extends PyTree implements PySliceListTree {
   }
 
   @Override
-  public List<Token> separators() {
+  public List<PyToken> separators() {
     return separators;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PySliceListTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySliceListTreeImpl.java
@@ -20,6 +20,9 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import java.util.List;
 import org.sonar.python.api.tree.PySliceListTree;
@@ -54,7 +57,7 @@ public class PySliceListTreeImpl extends PyTree implements PySliceListTree {
 
   @Override
   public List<Tree> children() {
-    return slices;
+    return Stream.of(slices, separators).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyStarredExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyStarredExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionTree;
@@ -30,17 +30,17 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyStarredExpressionTreeImpl extends PyTree implements PyStarredExpressionTree {
 
-  private final Token starToken;
+  private final PyToken starToken;
   private final PyExpressionTree expression;
 
-  public PyStarredExpressionTreeImpl(AstNode node, Token starToken, PyExpressionTree expression) {
+  public PyStarredExpressionTreeImpl(AstNode node, PyToken starToken, PyExpressionTree expression) {
     super(node);
     this.starToken = starToken;
     this.expression = expression;
   }
 
   @Override
-  public Token starToken() {
+  public PyToken starToken() {
     return starToken;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyStarredExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyStarredExpressionTreeImpl.java
@@ -20,11 +20,13 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyStarredExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -56,7 +58,7 @@ public class PyStarredExpressionTreeImpl extends PyTree implements PyStarredExpr
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expression);
+    return Stream.of(starToken, expression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyStatementListTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyStatementListTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyStatementListTree;
@@ -31,9 +31,9 @@ import org.sonar.python.api.tree.Tree;
 public class PyStatementListTreeImpl extends PyTree implements PyStatementListTree {
 
   private List<PyStatementTree> statements;
-  private final List<Token> tokens;
+  private final List<PyToken> tokens;
 
-  public PyStatementListTreeImpl(AstNode astNode, List<PyStatementTree> statements, List<Token> tokens) {
+  public PyStatementListTreeImpl(AstNode astNode, List<PyStatementTree> statements, List<PyToken> tokens) {
     super(astNode);
     this.statements = statements;
     this.tokens = tokens;
@@ -60,7 +60,7 @@ public class PyStatementListTreeImpl extends PyTree implements PyStatementListTr
   }
 
   @Override
-  public List<Token> tokens() {
+  public List<PyToken> tokens() {
     return tokens;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyStatementListTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyStatementListTreeImpl.java
@@ -20,11 +20,13 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyStatementListTree;
 import org.sonar.python.api.tree.PyStatementTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -56,7 +58,7 @@ public class PyStatementListTreeImpl extends PyTree implements PyStatementListTr
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(statements);
+    return Stream.of(statements, tokens).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PySubscriptionExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySubscriptionExpressionTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import org.sonar.python.api.tree.PyExpressionListTree;
@@ -31,11 +31,11 @@ import org.sonar.python.api.tree.Tree;
 public class PySubscriptionExpressionTreeImpl extends PyTree implements PySubscriptionExpressionTree {
 
   private final PyExpressionTree object;
-  private final Token lBracket;
+  private final PyToken lBracket;
   private final PyExpressionListTree subscripts;
-  private final Token rBracket;
+  private final PyToken rBracket;
 
-  public PySubscriptionExpressionTreeImpl(PyExpressionTree object, Token lBracket, PyExpressionListTree subscripts, Token rBracket) {
+  public PySubscriptionExpressionTreeImpl(PyExpressionTree object, PyToken lBracket, PyExpressionListTree subscripts, PyToken rBracket) {
     super(object.firstToken(), rBracket);
     this.object = object;
     this.lBracket = lBracket;
@@ -49,7 +49,7 @@ public class PySubscriptionExpressionTreeImpl extends PyTree implements PySubscr
   }
 
   @Override
-  public Token leftBracket() {
+  public PyToken leftBracket() {
     return lBracket;
   }
 
@@ -59,7 +59,7 @@ public class PySubscriptionExpressionTreeImpl extends PyTree implements PySubscr
   }
 
   @Override
-  public Token rightBracket() {
+  public PyToken rightBracket() {
     return rBracket;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PySubscriptionExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PySubscriptionExpressionTreeImpl.java
@@ -19,12 +19,14 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionListTree;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PySubscriptionExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
@@ -70,7 +72,7 @@ public class PySubscriptionExpressionTreeImpl extends PyTree implements PySubscr
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(object, subscripts);
+    return Stream.of(object, lBracket, subscripts, rBracket).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTokenImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTokenImpl.java
@@ -19,47 +19,74 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
+import com.sonar.sslr.api.Token;
+import com.sonar.sslr.api.TokenType;
+import com.sonar.sslr.api.Trivia;
 import java.util.Collections;
 import java.util.List;
-import org.sonar.python.api.tree.PyDelStatementTree;
-import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.Tree;
 
-public class PyDelStatementTreeImpl extends PyTree implements PyDelStatementTree {
-  private final PyToken delKeyword;
-  private final List<PyExpressionTree> expressionTrees;
+public class PyTokenImpl extends PyTree implements PyToken {
 
-  public PyDelStatementTreeImpl(AstNode astNode, PyToken delKeyword, List<PyExpressionTree> expressionTrees) {
-    super(astNode);
-    this.delKeyword = delKeyword;
-    this.expressionTrees = expressionTrees;
+  private Token token;
+
+  public PyTokenImpl(Token token) {
+    super(null);
+    this.token = token;
+  }
+
+  public Token token() {
+    return token;
   }
 
   @Override
-  public PyToken delKeyword() {
-    return delKeyword;
+  public String value() {
+    return token.getValue();
   }
 
   @Override
-  public List<PyExpressionTree> expressions() {
-    return expressionTrees;
+  public int line() {
+    return token.getLine();
   }
 
   @Override
-  public Kind getKind() {
-    return Kind.DEL_STMT;
+  public int column() {
+    return token.getColumn();
+  }
+
+  @Override
+  public List<Trivia> trivia() {
+    return token.getTrivia();
+  }
+
+  public TokenType type() {
+    return token.getType();
   }
 
   @Override
   public void accept(PyTreeVisitor visitor) {
-    visitor.visitDelStatement(this);
+    visitor.visitToken(this);
   }
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(expressionTrees);
+    return Collections.emptyList();
+  }
+
+  @Override
+  public Kind getKind() {
+    return Tree.Kind.TOKEN;
+  }
+
+  @Override
+  public PyToken firstToken() {
+    return this;
+  }
+
+  @Override
+  public PyToken lastToken() {
+    return this;
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTree.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTree.java
@@ -20,23 +20,24 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.Tree;
 
 public abstract class PyTree implements Tree {
   private final AstNode node;
-  private final Token firstToken;
-  private final Token lastToken;
+  private final PyToken firstToken;
+  private final PyToken lastToken;
   private Tree parent = null;
 
-  public PyTree(AstNode node) {
+  public PyTree(@Nullable AstNode node) {
     this.node = node;
-    this.firstToken = null;
-    this.lastToken = null;
+    this.firstToken = node == null ? null : new PyTokenImpl(node.getToken());
+    this.lastToken = node == null ? null : new PyTokenImpl(node.getLastToken());
   }
 
-  public PyTree(Token firstToken, Token lastToken) {
+  public PyTree(PyToken firstToken, PyToken lastToken) {
     this.node = null;
     this.firstToken = firstToken;
     this.lastToken = lastToken;
@@ -54,13 +55,13 @@ public abstract class PyTree implements Tree {
   }
 
   @Override
-  public Token firstToken() {
-    return node == null ? firstToken : node.getToken();
+  public PyToken firstToken() {
+    return firstToken;
   }
 
   @Override
-  public Token lastToken() {
-    return node == null ? lastToken : node.getLastToken();
+  public PyToken lastToken() {
+    return lastToken;
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTryStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTryStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -36,13 +36,13 @@ import org.sonar.python.api.tree.PyTryStatementTree;
 import org.sonar.python.api.tree.Tree;
 
 public class PyTryStatementTreeImpl extends PyTree implements PyTryStatementTree {
-  private final Token tryKeyword;
+  private final PyToken tryKeyword;
   private final PyStatementListTree tryBody;
   private final List<PyExceptClauseTree> exceptClauses;
   private final PyFinallyClauseTree finallyClause;
   private final PyElseStatementTree elseStatement;
 
-  public PyTryStatementTreeImpl(AstNode astNode, Token tryKeyword, PyStatementListTree tryBody, List<PyExceptClauseTree> exceptClauses,
+  public PyTryStatementTreeImpl(AstNode astNode, PyToken tryKeyword, PyStatementListTree tryBody, List<PyExceptClauseTree> exceptClauses,
                                 @Nullable PyFinallyClauseTree finallyClause, @Nullable PyElseStatementTree elseStatement) {
     super(astNode);
     this.tryKeyword = tryKeyword;
@@ -53,7 +53,7 @@ public class PyTryStatementTreeImpl extends PyTree implements PyTryStatementTree
   }
 
   @Override
-  public Token tryKeyword() {
+  public PyToken tryKeyword() {
     return tryKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTryStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTryStatementTreeImpl.java
@@ -20,6 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
@@ -91,7 +92,7 @@ public class PyTryStatementTreeImpl extends PyTree implements PyTryStatementTree
 
   @Override
   public List<Tree> children() {
-    return Stream.of(exceptClauses, Arrays.asList(tryBody, finallyClause, elseStatement))
-      .flatMap(List::stream).collect(Collectors.toList());
+    return Stream.of(Arrays.asList(tryKeyword, tryBody), exceptClauses, Arrays.asList(finallyClause, elseStatement))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTupleParameterTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTupleParameterTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import org.sonar.python.api.tree.PyAnyParameterTree;
@@ -31,16 +31,16 @@ import org.sonar.python.api.tree.Tree;
 public class PyTupleParameterTreeImpl extends PyTree implements PyTupleParameterTree {
 
   private final List<PyAnyParameterTree> parameters;
-  private final List<Token> commas;
+  private final List<PyToken> commas;
 
-  public PyTupleParameterTreeImpl(AstNode node, List<PyAnyParameterTree> parameters, List<Token> commas) {
+  public PyTupleParameterTreeImpl(AstNode node, List<PyAnyParameterTree> parameters, List<PyToken> commas) {
     super(node);
     this.parameters = parameters;
     this.commas = commas;
   }
 
   @Override
-  public Token openingParenthesis() {
+  public PyToken openingParenthesis() {
     return firstToken();
   }
 
@@ -50,12 +50,12 @@ public class PyTupleParameterTreeImpl extends PyTree implements PyTupleParameter
   }
 
   @Override
-  public List<Token> commas() {
+  public List<PyToken> commas() {
     return commas;
   }
 
   @Override
-  public Token closingParenthesis() {
+  public PyToken closingParenthesis() {
     return lastToken();
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTupleParameterTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTupleParameterTreeImpl.java
@@ -20,10 +20,12 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyAnyParameterTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyTupleParameterTree;
 import org.sonar.python.api.tree.Tree;
@@ -66,7 +68,7 @@ public class PyTupleParameterTreeImpl extends PyTree implements PyTupleParameter
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(parameters);
+    return Stream.of(parameters, commas).flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTupleTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTupleTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -32,12 +32,12 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyTupleTreeImpl extends PyTree implements PyTupleTree {
 
-  private final Token leftParenthesis;
+  private final PyToken leftParenthesis;
   private final List<PyExpressionTree> elements;
-  private final List<Token> commas;
-  private final Token rightParenthesis;
+  private final List<PyToken> commas;
+  private final PyToken rightParenthesis;
 
-  public PyTupleTreeImpl(AstNode node, @Nullable Token leftParenthesis, List<PyExpressionTree> elements, List<Token> commas, @Nullable Token rightParenthesis) {
+  public PyTupleTreeImpl(AstNode node, @Nullable PyToken leftParenthesis, List<PyExpressionTree> elements, List<PyToken> commas, @Nullable PyToken rightParenthesis) {
     super(node);
     this.leftParenthesis = leftParenthesis;
     this.elements = elements;
@@ -47,7 +47,7 @@ public class PyTupleTreeImpl extends PyTree implements PyTupleTree {
 
   @CheckForNull
   @Override
-  public Token leftParenthesis() {
+  public PyToken leftParenthesis() {
     return leftParenthesis;
   }
 
@@ -57,13 +57,13 @@ public class PyTupleTreeImpl extends PyTree implements PyTupleTree {
   }
 
   @Override
-  public List<Token> commas() {
+  public List<PyToken> commas() {
     return commas;
   }
 
   @CheckForNull
   @Override
-  public Token rightParenthesis() {
+  public PyToken rightParenthesis() {
     return rightParenthesis;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTupleTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTupleTreeImpl.java
@@ -20,6 +20,9 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
@@ -74,7 +77,8 @@ public class PyTupleTreeImpl extends PyTree implements PyTupleTree {
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(elements);
+    return Stream.of(Collections.singletonList(leftParenthesis), elements, commas, Collections.singletonList(rightParenthesis))
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTypeAnnotationTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTypeAnnotationTreeImpl.java
@@ -19,11 +19,13 @@
  */
 package org.sonar.python.tree;
 
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyTypeAnnotationTree;
 import org.sonar.python.api.tree.Tree;
@@ -84,7 +86,7 @@ public class PyTypeAnnotationTreeImpl extends PyTree implements PyTypeAnnotation
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expression);
+    return Stream.of(dash, gt, colonToken, expression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyTypeAnnotationTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyTypeAnnotationTreeImpl.java
@@ -19,7 +19,7 @@
  */
 package org.sonar.python.tree;
 
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -30,13 +30,13 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyTypeAnnotationTreeImpl extends PyTree implements PyTypeAnnotationTree {
 
-  private final Token dash;
-  private final Token gt;
-  private final Token colonToken;
+  private final PyToken dash;
+  private final PyToken gt;
+  private final PyToken colonToken;
   private final PyExpressionTree expression;
   private final Kind kind;
 
-  public PyTypeAnnotationTreeImpl(Token colonToken, PyExpressionTree expression) {
+  public PyTypeAnnotationTreeImpl(PyToken colonToken, PyExpressionTree expression) {
     super(colonToken, expression.lastToken());
     this.colonToken = colonToken;
     this.dash = null;
@@ -45,7 +45,7 @@ public class PyTypeAnnotationTreeImpl extends PyTree implements PyTypeAnnotation
     this.kind = Kind.TYPE_ANNOTATION;
   }
 
-  public PyTypeAnnotationTreeImpl(Token dash, Token gt, PyExpressionTree expression) {
+  public PyTypeAnnotationTreeImpl(PyToken dash, PyToken gt, PyExpressionTree expression) {
     super(dash, expression.lastToken());
     this.colonToken = null;
     this.dash = dash;
@@ -56,19 +56,19 @@ public class PyTypeAnnotationTreeImpl extends PyTree implements PyTypeAnnotation
 
   @CheckForNull
   @Override
-  public Token colonToken() {
+  public PyToken colonToken() {
     return colonToken;
   }
 
   @CheckForNull
   @Override
-  public Token dash() {
+  public PyToken dash() {
     return dash;
   }
 
   @CheckForNull
   @Override
-  public Token gt() {
+  public PyToken gt() {
     return gt;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyUnaryExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyUnaryExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -35,7 +35,7 @@ public class PyUnaryExpressionTreeImpl extends PyTree implements PyUnaryExpressi
   private static final Map<String, Kind> KINDS_BY_OPERATOR = kindsByOperator();
 
   private final Kind kind;
-  private final Token operator;
+  private final PyToken operator;
   private final PyExpressionTree expression;
 
   private static Map<String, Kind> kindsByOperator() {
@@ -47,15 +47,15 @@ public class PyUnaryExpressionTreeImpl extends PyTree implements PyUnaryExpressi
     return map;
   }
 
-  public PyUnaryExpressionTreeImpl(AstNode node, Token operator, PyExpressionTree expression) {
+  public PyUnaryExpressionTreeImpl(AstNode node, PyToken operator, PyExpressionTree expression) {
     super(node);
-    this.kind = KINDS_BY_OPERATOR.get(operator.getValue());
+    this.kind = KINDS_BY_OPERATOR.get(operator.value());
     this.operator = operator;
     this.expression = expression;
   }
 
   @Override
-  public Token operator() {
+  public PyToken operator() {
     return operator;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyUnaryExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyUnaryExpressionTreeImpl.java
@@ -20,12 +20,14 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyUnaryExpressionTree;
 import org.sonar.python.api.tree.Tree;
@@ -71,7 +73,7 @@ public class PyUnaryExpressionTreeImpl extends PyTree implements PyUnaryExpressi
 
   @Override
   public List<Tree> children() {
-    return Collections.singletonList(expression);
+    return Stream.of(operator, expression).filter(Objects::nonNull).collect(Collectors.toList());
   }
 
   @Override

--- a/python-squid/src/main/java/org/sonar/python/tree/PyWhileStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyWhileStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -33,16 +33,16 @@ import org.sonar.python.api.tree.Tree;
 
 public class PyWhileStatementTreeImpl extends PyTree implements PyWhileStatementTree {
 
-  private final Token whileKeyword;
+  private final PyToken whileKeyword;
   private final PyExpressionTree condition;
-  private final Token colon;
+  private final PyToken colon;
   private final PyStatementListTree body;
-  private final Token elseKeyword;
-  private final Token elseColon;
+  private final PyToken elseKeyword;
+  private final PyToken elseColon;
   private final PyStatementListTree elseBody;
 
-  public PyWhileStatementTreeImpl(AstNode astNode, Token whileKeyword, PyExpressionTree condition, Token colon, PyStatementListTree body,
-                                  @Nullable Token elseKeyword, @Nullable Token elseColon, @Nullable PyStatementListTree elseBody) {
+  public PyWhileStatementTreeImpl(AstNode astNode, PyToken whileKeyword, PyExpressionTree condition, PyToken colon, PyStatementListTree body,
+                                  @Nullable PyToken elseKeyword, @Nullable PyToken elseColon, @Nullable PyStatementListTree elseBody) {
     super(astNode);
     this.whileKeyword = whileKeyword;
     this.condition = condition;
@@ -64,7 +64,7 @@ public class PyWhileStatementTreeImpl extends PyTree implements PyWhileStatement
   }
 
   @Override
-  public Token whileKeyword() {
+  public PyToken whileKeyword() {
     return whileKeyword;
   }
 
@@ -74,7 +74,7 @@ public class PyWhileStatementTreeImpl extends PyTree implements PyWhileStatement
   }
 
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -85,13 +85,13 @@ public class PyWhileStatementTreeImpl extends PyTree implements PyWhileStatement
 
   @CheckForNull
   @Override
-  public Token elseKeyword() {
+  public PyToken elseKeyword() {
     return elseKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token elseColon() {
+  public PyToken elseColon() {
     return elseColon;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyWhileStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyWhileStatementTreeImpl.java
@@ -20,13 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyWhileStatementTree;
 import org.sonar.python.api.tree.Tree;
@@ -103,6 +105,7 @@ public class PyWhileStatementTreeImpl extends PyTree implements PyWhileStatement
 
   @Override
   public List<Tree> children() {
-    return Arrays.asList(condition, body, elseBody);
+    return Stream.of(whileKeyword, condition, colon, body, elseKeyword, elseColon, elseBody).filter(Objects::nonNull)
+      .collect(Collectors.toList());
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyWithStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyWithStatementTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -39,11 +39,11 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
 
   private final List<PyWithItemTree> withItems;
   private final PyStatementListTree statements;
-  private final Token asyncKeyword;
+  private final PyToken asyncKeyword;
   private final boolean isAsync;
-  private final Token colon;
+  private final PyToken colon;
 
-  public PyWithStatementTreeImpl(AstNode node, List<PyWithItemTree> withItems, Token colon, PyStatementListTree statements, @Nullable Token asyncKeyword) {
+  public PyWithStatementTreeImpl(AstNode node, List<PyWithItemTree> withItems, PyToken colon, PyStatementListTree statements, @Nullable PyToken asyncKeyword) {
     super(node);
     this.withItems = withItems;
     this.colon = colon;
@@ -58,7 +58,7 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
   }
 
   @Override
-  public Token colon() {
+  public PyToken colon() {
     return colon;
   }
 
@@ -74,7 +74,7 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
 
   @CheckForNull
   @Override
-  public Token asyncKeyword() {
+  public PyToken asyncKeyword() {
     return asyncKeyword;
   }
 
@@ -97,10 +97,10 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
   public static class PyWithItemTreeImpl extends PyTree implements PyWithItemTree {
 
     private final PyExpressionTree test;
-    private final Token as;
+    private final PyToken as;
     private final PyExpressionTree expr;
 
-    public PyWithItemTreeImpl(AstNode node, PyExpressionTree test, @Nullable Token as, @Nullable PyExpressionTree expr) {
+    public PyWithItemTreeImpl(AstNode node, PyExpressionTree test, @Nullable PyToken as, @Nullable PyExpressionTree expr) {
       super(node);
       this.test = test;
       this.as = as;
@@ -114,7 +114,7 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
 
     @CheckForNull
     @Override
-    public Token as() {
+    public PyToken as() {
       return as;
     }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyWithStatementTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyWithStatementTreeImpl.java
@@ -20,16 +20,17 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
 import org.sonar.python.api.tree.PyStatementListTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyWithItemTree;
 import org.sonar.python.api.tree.PyWithStatementTree;
@@ -90,7 +91,7 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
 
   @Override
   public List<Tree> children() {
-    return Stream.of(withItems, Collections.singletonList(statements))
+    return Stream.of(Collections.singletonList(asyncKeyword), withItems, Arrays.asList(colon, statements))
       .flatMap(List::stream).collect(Collectors.toList());
   }
 
@@ -136,7 +137,7 @@ public class PyWithStatementTreeImpl extends PyTree implements PyWithStatementTr
 
     @Override
     public List<Tree> children() {
-      return Arrays.asList(test, expr);
+      return Stream.of(test, as, expr).filter(Objects::nonNull).collect(Collectors.toList());
     }
   }
 }

--- a/python-squid/src/main/java/org/sonar/python/tree/PyYieldExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyYieldExpressionTreeImpl.java
@@ -20,7 +20,7 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import com.sonar.sslr.api.Token;
+import org.sonar.python.api.tree.PyToken;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.CheckForNull;
@@ -31,11 +31,11 @@ import org.sonar.python.api.tree.PyYieldExpressionTree;
 import org.sonar.python.api.tree.Tree;
 
 public class PyYieldExpressionTreeImpl extends PyTree implements PyYieldExpressionTree {
-  private final Token yieldKeyword;
-  private final Token fromKeyword;
+  private final PyToken yieldKeyword;
+  private final PyToken fromKeyword;
   private final List<PyExpressionTree> expressionTrees;
 
-  public PyYieldExpressionTreeImpl(AstNode astNode, Token yieldKeyword, @Nullable Token fromKeyword, List<PyExpressionTree> expressionTrees) {
+  public PyYieldExpressionTreeImpl(AstNode astNode, PyToken yieldKeyword, @Nullable PyToken fromKeyword, List<PyExpressionTree> expressionTrees) {
     super(astNode);
     this.yieldKeyword = yieldKeyword;
     this.fromKeyword = fromKeyword;
@@ -43,13 +43,13 @@ public class PyYieldExpressionTreeImpl extends PyTree implements PyYieldExpressi
   }
 
   @Override
-  public Token yieldKeyword() {
+  public PyToken yieldKeyword() {
     return yieldKeyword;
   }
 
   @CheckForNull
   @Override
-  public Token fromKeyword() {
+  public PyToken fromKeyword() {
     return fromKeyword;
   }
 

--- a/python-squid/src/main/java/org/sonar/python/tree/PyYieldExpressionTreeImpl.java
+++ b/python-squid/src/main/java/org/sonar/python/tree/PyYieldExpressionTreeImpl.java
@@ -20,12 +20,15 @@
 package org.sonar.python.tree;
 
 import com.sonar.sslr.api.AstNode;
-import org.sonar.python.api.tree.PyToken;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.python.api.tree.PyExpressionTree;
+import org.sonar.python.api.tree.PyToken;
 import org.sonar.python.api.tree.PyTreeVisitor;
 import org.sonar.python.api.tree.PyYieldExpressionTree;
 import org.sonar.python.api.tree.Tree;
@@ -70,6 +73,7 @@ public class PyYieldExpressionTreeImpl extends PyTree implements PyYieldExpressi
 
   @Override
   public List<Tree> children() {
-    return Collections.unmodifiableList(expressionTrees);
+    return Stream.of(Arrays.asList(yieldKeyword, fromKeyword), expressionTrees)
+      .flatMap(List::stream).filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-squid/src/test/java/org/sonar/python/IssueLocationTest.java
+++ b/python-squid/src/test/java/org/sonar/python/IssueLocationTest.java
@@ -28,6 +28,7 @@ import org.sonar.python.api.PythonGrammar;
 import org.sonar.python.api.PythonPunctuator;
 import org.sonar.python.api.PythonTokenType;
 import org.sonar.python.parser.PythonParser;
+import org.sonar.python.tree.PyTokenImpl;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -87,7 +88,7 @@ public class IssueLocationTest {
     AstNode root = parser.parse("\n\nfoo(42 + y) + 2");
     AstNode firstNode = root.getFirstDescendant(PythonTokenType.NUMBER);
     AstNode lastNode = root.getFirstDescendant(PythonPunctuator.RPARENTHESIS);
-    IssueLocation issueLocation = IssueLocation.preciseLocation(firstNode.getToken(), lastNode.getToken(), MESSAGE);
+    IssueLocation issueLocation = IssueLocation.preciseLocation(new PyTokenImpl(firstNode.getToken()), new PyTokenImpl(lastNode.getToken()), MESSAGE);
     assertThat(issueLocation.message()).isEqualTo(MESSAGE);
     assertThat(issueLocation.startLine()).isEqualTo(3);
     assertThat(issueLocation.endLine()).isEqualTo(3);

--- a/python-squid/src/test/java/org/sonar/python/PythonCheckTreeTest.java
+++ b/python-squid/src/test/java/org/sonar/python/PythonCheckTreeTest.java
@@ -46,7 +46,7 @@ public class PythonCheckTreeTest {
       public void visitFunctionDef(PyFunctionDefTree pyFunctionDefTree) {
         super.visitFunctionDef(pyFunctionDefTree);
         PyNameTree name = pyFunctionDefTree.name();
-        addIssue(name, name.firstToken().getValue());
+        addIssue(name, name.firstToken().value());
       }
     };
 

--- a/python-squid/src/test/java/org/sonar/python/PythonSubscriptionCheckTest.java
+++ b/python-squid/src/test/java/org/sonar/python/PythonSubscriptionCheckTest.java
@@ -49,7 +49,7 @@ public class PythonSubscriptionCheckTest {
       public void initialize(Context context) {
         context.registerSyntaxNodeConsumer(Tree.Kind.FUNCDEF, ctx -> {
           PyFunctionDefTree tree = (PyFunctionDefTree) ctx.syntaxNode();
-          ctx.addIssue(tree.name(), tree.name().firstToken().getValue());
+          ctx.addIssue(tree.name(), tree.name().firstToken().value());
         });
       }
     };
@@ -95,7 +95,7 @@ public class PythonSubscriptionCheckTest {
       @Override
       public void initialize(Context context) {
         context.registerSyntaxNodeConsumer(Tree.Kind.PASS_STMT, ctx -> {
-          ctx.addLineIssue(MESSAGE, ctx.syntaxNode().firstToken().getLine());
+          ctx.addLineIssue(MESSAGE, ctx.syntaxNode().firstToken().line());
           ctx.addFileIssue(MESSAGE);
         });
       }

--- a/python-squid/src/test/java/org/sonar/python/metrics/CognitiveComplexityVisitorTest.java
+++ b/python-squid/src/test/java/org/sonar/python/metrics/CognitiveComplexityVisitorTest.java
@@ -45,7 +45,7 @@ public class CognitiveComplexityVisitorTest {
   public void file() {
     Map<Integer, String> complexityByLine = new TreeMap<>();
     CognitiveComplexityVisitor fileComplexityVisitor = new CognitiveComplexityVisitor(
-      (token, message) -> complexityByLine.merge(token.getLine(), message, (a, b) -> a + " " + b));
+      (token, message) -> complexityByLine.merge(token.line(), message, (a, b) -> a + " " + b));
 
     StringBuilder comments = new StringBuilder();
     // TODO: use BaseTreeVisitor when we will have a way to access tokens and comments in strongly typed AST

--- a/python-squid/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
+++ b/python-squid/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
@@ -210,7 +210,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(elseBranch).isNotNull();
     assertThat(elseBranch.elseKeyword().value()).isEqualTo("else");
     assertThat(elseBranch.body().statements()).hasSize(1);
-    assertThat(pyIfStatementTree.children()).hasSize(3);
+    assertThat(pyIfStatementTree.children()).hasSize(4);
 
 
     pyIfStatementTree = parse("if x: pass\nelif y: pass", treeMaker::ifStatement);
@@ -254,14 +254,14 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(printStmt).isNotNull();
     assertThat(printStmt.printKeyword().value()).isEqualTo("print");
     assertThat(printStmt.expressions()).hasSize(1);
-    assertThat(printStmt.children()).hasSize(1);
+    assertThat(printStmt.children()).hasSize(2);
 
     astNode = p.parse("print 'foo', 'bar'");
     printStmt = treeMaker.printStatement(astNode);
     assertThat(printStmt).isNotNull();
     assertThat(printStmt.printKeyword().value()).isEqualTo("print");
     assertThat(printStmt.expressions()).hasSize(2);
-    assertThat(printStmt.children()).hasSize(2);
+    assertThat(printStmt.children()).hasSize(3);
 
     astNode = p.parse("print >> 'foo'");
     printStmt = treeMaker.printStatement(astNode);
@@ -280,7 +280,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(execStatement.expression()).isNotNull();
     assertThat(execStatement.globalsExpression()).isNull();
     assertThat(execStatement.localsExpression()).isNull();
-    assertThat(execStatement.children()).hasSize(3);
+    assertThat(execStatement.children()).hasSize(2);
 
     astNode = p.parse("exec 'foo' in globals");
     execStatement = treeMaker.execStatement(astNode);
@@ -298,7 +298,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(execStatement.expression()).isNotNull();
     assertThat(execStatement.globalsExpression()).isNotNull();
     assertThat(execStatement.localsExpression()).isNotNull();
-    assertThat(execStatement.children()).hasSize(3);
+    assertThat(execStatement.children()).hasSize(4);
 
     // TODO: exec stmt should parse exec ('foo', globals, locals); see https://docs.python.org/2/reference/simple_stmts.html#exec
   }
@@ -320,7 +320,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(assertStatement.assertKeyword().value()).isEqualTo("assert");
     assertThat(assertStatement.condition()).isNotNull();
     assertThat(assertStatement.message()).isNotNull();
-    assertThat(assertStatement.children()).hasSize(2);
+    assertThat(assertStatement.children()).hasSize(3);
   }
 
   @Test
@@ -330,7 +330,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyPassStatementTree passStatement = treeMaker.passStatement(astNode);
     assertThat(passStatement).isNotNull();
     assertThat(passStatement.passKeyword().value()).isEqualTo("pass");
-    assertThat(passStatement.children()).isEmpty();
+    assertThat(passStatement.children()).hasSize(1);
   }
 
   @Test
@@ -341,7 +341,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(passStatement).isNotNull();
     assertThat(passStatement.delKeyword().value()).isEqualTo("del");
     assertThat(passStatement.expressions()).hasSize(1);
-    assertThat(passStatement.children()).hasSize(1);
+    assertThat(passStatement.children()).hasSize(2);
 
 
     astNode = p.parse("del foo, bar");
@@ -349,14 +349,14 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(passStatement).isNotNull();
     assertThat(passStatement.delKeyword().value()).isEqualTo("del");
     assertThat(passStatement.expressions()).hasSize(2);
-    assertThat(passStatement.children()).hasSize(2);
+    assertThat(passStatement.children()).hasSize(3);
 
     astNode = p.parse("del *foo");
     passStatement = treeMaker.delStatement(astNode);
     assertThat(passStatement).isNotNull();
     assertThat(passStatement.delKeyword().value()).isEqualTo("del");
     assertThat(passStatement.expressions()).hasSize(1);
-    assertThat(passStatement.children()).hasSize(1);
+    assertThat(passStatement.children()).hasSize(2);
   }
 
   @Test
@@ -367,21 +367,21 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(returnStatement).isNotNull();
     assertThat(returnStatement.returnKeyword().value()).isEqualTo("return");
     assertThat(returnStatement.expressions()).hasSize(1);
-    assertThat(returnStatement.children()).hasSize(1);
+    assertThat(returnStatement.children()).hasSize(2);
 
     astNode = p.parse("return foo, bar");
     returnStatement = treeMaker.returnStatement(astNode);
     assertThat(returnStatement).isNotNull();
     assertThat(returnStatement.returnKeyword().value()).isEqualTo("return");
     assertThat(returnStatement.expressions()).hasSize(2);
-    assertThat(returnStatement.children()).hasSize(2);
+    assertThat(returnStatement.children()).hasSize(3);
 
     astNode = p.parse("return");
     returnStatement = treeMaker.returnStatement(astNode);
     assertThat(returnStatement).isNotNull();
     assertThat(returnStatement.returnKeyword().value()).isEqualTo("return");
     assertThat(returnStatement.expressions()).hasSize(0);
-    assertThat(returnStatement.children()).isEmpty();
+    assertThat(returnStatement.children()).hasSize(1);
   }
 
   @Test
@@ -394,7 +394,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyYieldExpressionTree yieldExpression = yieldStatement.yieldExpression();
     assertThat(yieldExpression).isInstanceOf(PyYieldExpressionTree.class);
     assertThat(yieldExpression.expressions()).hasSize(1);
-    assertThat(yieldExpression.children()).hasSize(1);
+    assertThat(yieldExpression.children()).hasSize(2);
 
     astNode = p.parse("yield foo, bar");
     yieldStatement = treeMaker.yieldStatement(astNode);
@@ -405,7 +405,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(yieldExpression.yieldKeyword().value()).isEqualTo("yield");
     assertThat(yieldExpression.fromKeyword()).isNull();
     assertThat(yieldExpression.expressions()).hasSize(2);
-    assertThat(yieldExpression.children()).hasSize(2);
+    assertThat(yieldExpression.children()).hasSize(3);
 
     astNode = p.parse("yield from foo");
     yieldStatement = treeMaker.yieldStatement(astNode);
@@ -416,7 +416,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(yieldExpression.yieldKeyword().value()).isEqualTo("yield");
     assertThat(yieldExpression.fromKeyword().value()).isEqualTo("from");
     assertThat(yieldExpression.expressions()).hasSize(1);
-    assertThat(yieldExpression.children()).hasSize(1);
+    assertThat(yieldExpression.children()).hasSize(3);
 
     astNode = p.parse("yield");
     yieldStatement = treeMaker.yieldStatement(astNode);
@@ -452,7 +452,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(raiseStatement.fromKeyword().value()).isEqualTo("from");
     assertThat(raiseStatement.fromExpression()).isNotNull();
     assertThat(raiseStatement.expressions()).hasSize(1);
-    assertThat(raiseStatement.children()).hasSize(2);
+    assertThat(raiseStatement.children()).hasSize(4);
 
     astNode = p.parse("raise");
     raiseStatement = treeMaker.raiseStatement(astNode);
@@ -471,7 +471,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyBreakStatementTree breakStatement = treeMaker.breakStatement(astNode);
     assertThat(breakStatement).isNotNull();
     assertThat(breakStatement.breakKeyword().value()).isEqualTo("break");
-    assertThat(breakStatement.children()).isEmpty();
+    assertThat(breakStatement.children()).hasSize(1);
   }
 
   @Test
@@ -481,7 +481,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyContinueStatementTree continueStatement = treeMaker.continueStatement(astNode);
     assertThat(continueStatement).isNotNull();
     assertThat(continueStatement.continueKeyword().value()).isEqualTo("continue");
-    assertThat(continueStatement.children()).isEmpty();
+    assertThat(continueStatement.children()).hasSize(1);
   }
 
   @Test
@@ -497,7 +497,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyAliasedNameTree importedName1 = importStatement.modules().get(0);
     assertThat(importedName1.dottedName().names()).hasSize(1);
     assertThat(importedName1.dottedName().names().get(0).name()).isEqualTo("foo");
-    assertThat(importStatement.children()).hasSize(1);
+    assertThat(importStatement.children()).hasSize(2);
 
     astNode = p.parse("import foo as f");
     importStatement = (PyImportNameTree) treeMaker.importStatement(astNode);
@@ -513,7 +513,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(importedName1.dottedName().names().get(0).name()).isEqualTo("foo");
     assertThat(importedName1.asKeyword().value()).isEqualTo("as");
     assertThat(importedName1.alias().name()).isEqualTo("f");
-    assertThat(importStatement.children()).hasSize(1);
+    assertThat(importStatement.children()).hasSize(2);
 
     astNode = p.parse("import foo.bar");
     importStatement = (PyImportNameTree) treeMaker.importStatement(astNode);
@@ -524,7 +524,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(importedName1.dottedName().names()).hasSize(2);
     assertThat(importedName1.dottedName().names().get(0).name()).isEqualTo("foo");
     assertThat(importedName1.dottedName().names().get(1).name()).isEqualTo("bar");
-    assertThat(importStatement.children()).hasSize(1);
+    assertThat(importStatement.children()).hasSize(2);
 
     astNode = p.parse("import foo, bar");
     importStatement = (PyImportNameTree) treeMaker.importStatement(astNode);
@@ -537,7 +537,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyAliasedNameTree importedName2 = importStatement.modules().get(1);
     assertThat(importedName2.dottedName().names()).hasSize(1);
     assertThat(importedName2.dottedName().names().get(0).name()).isEqualTo("bar");
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(3);
   }
 
   @Test
@@ -559,14 +559,14 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(aliasedNameTree.asKeyword()).isNull();
     assertThat(aliasedNameTree.alias()).isNull();
     assertThat(aliasedNameTree.dottedName().names().get(0).name()).isEqualTo("f");
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(4);
 
     astNode = p.parse("from .foo import f");
     importStatement = (PyImportFromTree) treeMaker.importStatement(astNode);
     assertThat(importStatement.dottedPrefixForModule()).hasSize(1);
     assertThat(importStatement.dottedPrefixForModule().get(0).value()).isEqualTo(".");
     assertThat(importStatement.module().names().get(0).name()).isEqualTo("foo");
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(5);
 
     astNode = p.parse("from ..foo import f");
     importStatement = (PyImportFromTree) treeMaker.importStatement(astNode);
@@ -574,14 +574,14 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(importStatement.dottedPrefixForModule().get(0).value()).isEqualTo(".");
     assertThat(importStatement.dottedPrefixForModule().get(1).value()).isEqualTo(".");
     assertThat(importStatement.module().names().get(0).name()).isEqualTo("foo");
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(6);
 
     astNode = p.parse("from . import f");
     importStatement = (PyImportFromTree) treeMaker.importStatement(astNode);
     assertThat(importStatement.dottedPrefixForModule()).hasSize(1);
     assertThat(importStatement.dottedPrefixForModule().get(0).value()).isEqualTo(".");
     assertThat(importStatement.module()).isNull();
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(4);
 
     astNode = p.parse("from foo import f as g");
     importStatement = (PyImportFromTree) treeMaker.importStatement(astNode);
@@ -590,7 +590,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(aliasedNameTree.asKeyword().value()).isEqualTo("as");
     assertThat(aliasedNameTree.alias().name()).isEqualTo("g");
     assertThat(aliasedNameTree.dottedName().names().get(0).name()).isEqualTo("f");
-    assertThat(importStatement.children()).hasSize(2);
+    assertThat(importStatement.children()).hasSize(4);
 
     astNode = p.parse("from foo import f as g, h");
     importStatement = (PyImportFromTree) treeMaker.importStatement(astNode);
@@ -599,7 +599,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(aliasedNameTree1.asKeyword().value()).isEqualTo("as");
     assertThat(aliasedNameTree1.alias().name()).isEqualTo("g");
     assertThat(aliasedNameTree1.dottedName().names().get(0).name()).isEqualTo("f");
-    assertThat(importStatement.children()).hasSize(3);
+    assertThat(importStatement.children()).hasSize(5);
 
     PyAliasedNameTree aliasedNameTree2 = importStatement.importedNames().get(1);
     assertThat(aliasedNameTree2.asKeyword()).isNull();
@@ -611,7 +611,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(importStatement.importedNames()).isEmpty();
     assertThat(importStatement.isWildcardImport()).isTrue();
     assertThat(importStatement.wildcard().value()).isEqualTo("*");
-    assertThat(importStatement.children()).hasSize(1);
+    assertThat(importStatement.children()).hasSize(4);
   }
 
   @Test
@@ -622,7 +622,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(globalStatement.globalKeyword().value()).isEqualTo("global");
     assertThat(globalStatement.variables()).hasSize(1);
     assertThat(globalStatement.variables().get(0).name()).isEqualTo("foo");
-    assertThat(globalStatement.children()).hasSize(1);
+    assertThat(globalStatement.children()).hasSize(2);
 
     astNode = p.parse("global foo, bar");
     globalStatement = treeMaker.globalStatement(astNode);
@@ -630,7 +630,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(globalStatement.variables()).hasSize(2);
     assertThat(globalStatement.variables().get(0).name()).isEqualTo("foo");
     assertThat(globalStatement.variables().get(1).name()).isEqualTo("bar");
-    assertThat(globalStatement.children()).hasSize(2);
+    assertThat(globalStatement.children()).hasSize(3);
   }
 
   @Test
@@ -641,7 +641,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(nonlocalStatement.nonlocalKeyword().value()).isEqualTo("nonlocal");
     assertThat(nonlocalStatement.variables()).hasSize(1);
     assertThat(nonlocalStatement.variables().get(0).name()).isEqualTo("foo");
-    assertThat(nonlocalStatement.children()).hasSize(1);
+    assertThat(nonlocalStatement.children()).hasSize(2);
 
     astNode = p.parse("nonlocal foo, bar");
     nonlocalStatement = treeMaker.nonlocalStatement(astNode);
@@ -649,7 +649,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(nonlocalStatement.variables()).hasSize(2);
     assertThat(nonlocalStatement.variables().get(0).name()).isEqualTo("foo");
     assertThat(nonlocalStatement.variables().get(1).name()).isEqualTo("bar");
-    assertThat(nonlocalStatement.children()).hasSize(2);
+    assertThat(nonlocalStatement.children()).hasSize(3);
   }
 
   @Test
@@ -661,7 +661,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(functionDefTree.name().name()).isEqualTo("func");
     assertThat(functionDefTree.body().statements()).hasSize(1);
     assertThat(functionDefTree.body().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(functionDefTree.children()).hasSize(3);
+    assertThat(functionDefTree.children()).hasSize(6);
     assertThat(functionDefTree.parameters()).isNull();
     assertThat(functionDefTree.isMethodDefinition()).isFalse();
     assertThat(functionDefTree.docstring()).isNull();
@@ -732,7 +732,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(annotation.getKind()).isEqualTo(Tree.Kind.TYPE_ANNOTATION);
     assertThat(annotation.colonToken().value()).isEqualTo(":");
     assertThat(((PyNameTree) annotation.expression()).name()).isEqualTo("int");
-    assertThat(annotation.children()).hasSize(1);
+    assertThat(annotation.children()).hasSize(2);
     assertThat(parameters.get(1).typeAnnotation()).isNull();
 
     functionDefTree = parse("def func(a, ((b, c), d)): pass", treeMaker::funcDefStatement);
@@ -743,7 +743,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(tupleParam.closingParenthesis().value()).isEqualTo(")");
     assertThat(tupleParam.parameters()).extracting(Tree::getKind).containsExactly(Tree.Kind.TUPLE_PARAMETER, Tree.Kind.PARAMETER);
     assertThat(tupleParam.commas()).extracting(PyToken::value).containsExactly(",");
-    assertThat(tupleParam.children()).hasSize(2);
+    assertThat(tupleParam.children()).hasSize(3);
 
     functionDefTree = parse("def func(x : int, y):\n  \"\"\"\n" +
       "This is a function docstring\n" +
@@ -798,7 +798,7 @@ public class PythonTreeMakerTest extends RuleTest {
       "\tpass");
     classDefTree = treeMaker.classDefStatement(astNode);
     assertThat(classDefTree.docstring().value()).isEqualTo("\"\"\"This is a docstring\"\"\"");
-    assertThat(classDefTree.children()).hasSize(3);
+    assertThat(classDefTree.children()).hasSize(5);
   }
 
   @Test
@@ -813,7 +813,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyForStatementTree.elseBody()).isNull();
     assertThat(pyForStatementTree.isAsync()).isFalse();
     assertThat(pyForStatementTree.asyncKeyword()).isNull();
-    assertThat(pyForStatementTree.children()).hasSize(4);
+    assertThat(pyForStatementTree.children()).hasSize(7);
 
     astNode = p.parse("for foo in bar:\n  pass\nelse:\n  pass");
     pyForStatementTree = treeMaker.forStatement(astNode);
@@ -823,7 +823,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyForStatementTree.body().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
     assertThat(pyForStatementTree.elseBody().statements()).hasSize(1);
     assertThat(pyForStatementTree.elseBody().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(pyForStatementTree.children()).hasSize(4);
+    assertThat(pyForStatementTree.children()).hasSize(9);
 
     assertThat(pyForStatementTree.forKeyword().value()).isEqualTo("for");
     assertThat(pyForStatementTree.inKeyword().value()).isEqualTo("in");
@@ -841,7 +841,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(whileStatement.body().statements()).hasSize(1);
     assertThat(whileStatement.body().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
     assertThat(whileStatement.elseBody()).isNull();
-    assertThat(whileStatement.children()).hasSize(3);
+    assertThat(whileStatement.children()).hasSize(4);
 
     astNode = p.parse("while foo:\n  pass\nelse:\n  pass");
     whileStatement = treeMaker.whileStatement(astNode);
@@ -850,7 +850,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(whileStatement.body().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
     assertThat(whileStatement.elseBody().statements()).hasSize(1);
     assertThat(whileStatement.elseBody().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(whileStatement.children()).hasSize(3);
+    assertThat(whileStatement.children()).hasSize(7);
 
     assertThat(whileStatement.whileKeyword().value()).isEqualTo("while");
     assertThat(whileStatement.colon().value()).isEqualTo(":");
@@ -884,12 +884,12 @@ public class PythonTreeMakerTest extends RuleTest {
     PyNameTree lhs = (PyNameTree) pyAssignmentStatement.lhsExpressions().get(0).expressions().get(0);
     assertThat(assigned.name()).isEqualTo("y");
     assertThat(lhs.name()).isEqualTo("x");
-    assertThat(pyAssignmentStatement.children()).hasSize(2);
+    assertThat(pyAssignmentStatement.children()).hasSize(3);
 
     astNode = p.parse("x = y = z");
     pyAssignmentStatement = treeMaker.assignment(astNode);
     assertThat(pyAssignmentStatement.equalTokens()).hasSize(2);
-    assertThat(pyAssignmentStatement.children()).hasSize(3);
+    assertThat(pyAssignmentStatement.children()).hasSize(5);
     assigned = (PyNameTree) pyAssignmentStatement.assignedValue();
     lhs = (PyNameTree) pyAssignmentStatement.lhsExpressions().get(0).expressions().get(0);
     PyNameTree lhs2 = (PyNameTree) pyAssignmentStatement.lhsExpressions().get(1).expressions().get(0);
@@ -899,7 +899,7 @@ public class PythonTreeMakerTest extends RuleTest {
 
     astNode = p.parse("a,b = x");
     pyAssignmentStatement = treeMaker.assignment(astNode);
-    assertThat(pyAssignmentStatement.children()).hasSize(2);
+    assertThat(pyAssignmentStatement.children()).hasSize(3);
     assigned = (PyNameTree) pyAssignmentStatement.assignedValue();
     List<PyExpressionTree> expressions = pyAssignmentStatement.lhsExpressions().get(0).expressions();
     assertThat(assigned.name()).isEqualTo("x");
@@ -908,14 +908,14 @@ public class PythonTreeMakerTest extends RuleTest {
 
     astNode = p.parse("x = a,b");
     pyAssignmentStatement = treeMaker.assignment(astNode);
-    assertThat(pyAssignmentStatement.children()).hasSize(2);
+    assertThat(pyAssignmentStatement.children()).hasSize(3);
     expressions = pyAssignmentStatement.lhsExpressions().get(0).expressions();
     assertThat(expressions.get(0).getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(pyAssignmentStatement.assignedValue().getKind()).isEqualTo(Tree.Kind.TUPLE);
 
     astNode = p.parse("x = yield 1");
     pyAssignmentStatement = treeMaker.assignment(astNode);
-    assertThat(pyAssignmentStatement.children()).hasSize(2);
+    assertThat(pyAssignmentStatement.children()).hasSize(3);
     expressions = pyAssignmentStatement.lhsExpressions().get(0).expressions();
     assertThat(expressions.get(0).getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(pyAssignmentStatement.assignedValue().getKind()).isEqualTo(Tree.Kind.YIELD_EXPR);
@@ -923,7 +923,7 @@ public class PythonTreeMakerTest extends RuleTest {
     // FIXME: lhs expression list shouldn't allow yield expressions. We need to change the grammar
     astNode = p.parse("x = yield 1 = y");
     pyAssignmentStatement = treeMaker.assignment(astNode);
-    assertThat(pyAssignmentStatement.children()).hasSize(3);
+    assertThat(pyAssignmentStatement.children()).hasSize(5);
     List<PyExpressionListTree> lhsExpressions = pyAssignmentStatement.lhsExpressions();
     assertThat(lhsExpressions.get(1).expressions().get(0).getKind()).isEqualTo(Tree.Kind.YIELD_EXPR);
     assertThat(pyAssignmentStatement.assignedValue().getKind()).isEqualTo(Tree.Kind.NAME);
@@ -937,7 +937,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(annAssign.firstToken().value()).isEqualTo("x");
     assertThat(annAssign.lastToken().value()).isEqualTo("1");
     assertThat(annAssign.getKind()).isEqualTo(Tree.Kind.ANNOTATED_ASSIGNMENT);
-    assertThat(annAssign.children()).hasSize(3);
+    assertThat(annAssign.children()).hasSize(5);
     assertThat(annAssign.variable().getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(((PyNameTree) annAssign.variable()).name()).isEqualTo("x");
     assertThat(annAssign.assignedValue().getKind()).isEqualTo(Tree.Kind.NUMERIC_LITERAL);
@@ -963,7 +963,7 @@ public class PythonTreeMakerTest extends RuleTest {
     AstNode astNode = p.parse("x += y");
     PyCompoundAssignmentStatementTree pyCompoundAssignmentStatement = treeMaker.compoundAssignment(astNode);
     assertThat(pyCompoundAssignmentStatement.getKind()).isEqualTo(Tree.Kind.COMPOUND_ASSIGNMENT);
-    assertThat(pyCompoundAssignmentStatement.children()).hasSize(2);
+    assertThat(pyCompoundAssignmentStatement.children()).hasSize(3);
     assertThat(pyCompoundAssignmentStatement.compoundAssignmentToken().value()).isEqualTo("+=");
     assertThat(pyCompoundAssignmentStatement.lhsExpression().getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(pyCompoundAssignmentStatement.rhsExpression().getKind()).isEqualTo(Tree.Kind.NAME);
@@ -974,7 +974,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyCompoundAssignmentStatement.firstToken().value()).isEqualTo("x");
     assertThat(pyCompoundAssignmentStatement.lastToken().value()).isEqualTo("1");
     assertThat(pyCompoundAssignmentStatement.getKind()).isEqualTo(Tree.Kind.COMPOUND_ASSIGNMENT);
-    assertThat(pyCompoundAssignmentStatement.children()).hasSize(2);
+    assertThat(pyCompoundAssignmentStatement.children()).hasSize(3);
     assertThat(pyCompoundAssignmentStatement.compoundAssignmentToken().value()).isEqualTo("+=");
     assertThat(pyCompoundAssignmentStatement.lhsExpression().getKind()).isEqualTo(Tree.Kind.TUPLE);
     assertThat(pyCompoundAssignmentStatement.rhsExpression().getKind()).isEqualTo(Tree.Kind.NUMERIC_LITERAL);
@@ -983,7 +983,7 @@ public class PythonTreeMakerTest extends RuleTest {
     astNode = p.parse("x += yield y");
     pyCompoundAssignmentStatement = treeMaker.compoundAssignment(astNode);
     assertThat(pyCompoundAssignmentStatement.getKind()).isEqualTo(Tree.Kind.COMPOUND_ASSIGNMENT);
-    assertThat(pyCompoundAssignmentStatement.children()).hasSize(2);
+    assertThat(pyCompoundAssignmentStatement.children()).hasSize(3);
     assertThat(pyCompoundAssignmentStatement.compoundAssignmentToken().value()).isEqualTo("+=");
     assertThat(pyCompoundAssignmentStatement.lhsExpression().getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(pyCompoundAssignmentStatement.rhsExpression().getKind()).isEqualTo(Tree.Kind.YIELD_EXPR);
@@ -1010,7 +1010,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(tryStatement.exceptClauses().get(0).lastToken().value()).isEqualTo("pass");
     assertThat(tryStatement.exceptClauses().get(0).exceptKeyword().value()).isEqualTo("except");
     assertThat(tryStatement.exceptClauses().get(0).body().statements()).hasSize(1);
-    assertThat(tryStatement.children()).hasSize(4);
+    assertThat(tryStatement.children()).hasSize(3);
 
 
     astNode = p.parse("try: pass\nexcept Error: pass\nexcept Error: pass");
@@ -1019,7 +1019,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(tryStatement.elseClause()).isNull();
     assertThat(tryStatement.finallyClause()).isNull();
     assertThat(tryStatement.exceptClauses()).hasSize(2);
-    assertThat(tryStatement.children()).hasSize(5);
+    assertThat(tryStatement.children()).hasSize(4);
 
     astNode = p.parse("try: pass\nexcept Error: pass\nfinally: pass");
     tryStatement = treeMaker.tryStatement(astNode);
@@ -1052,7 +1052,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(exceptClause.asKeyword().value()).isEqualTo("as");
     assertThat(exceptClause.commaToken()).isNull();
     assertThat(exceptClause.exceptionInstance()).isNotNull();
-    assertThat(tryStatement.children()).hasSize(4);
+    assertThat(tryStatement.children()).hasSize(3);
 
     astNode = p.parse("try: pass\nexcept Error, e: pass");
     tryStatement = treeMaker.tryStatement(astNode);
@@ -1062,7 +1062,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(exceptClause.asKeyword()).isNull();
     assertThat(exceptClause.commaToken().value()).isEqualTo(",");
     assertThat(exceptClause.exceptionInstance()).isNotNull();
-    assertThat(tryStatement.children()).hasSize(4);
+    assertThat(tryStatement.children()).hasSize(3);
   }
 
   @Test
@@ -1077,7 +1077,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyForStatementTree.body().statements()).hasSize(1);
     assertThat(pyForStatementTree.body().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
     assertThat(pyForStatementTree.elseBody()).isNull();
-    assertThat(pyForStatementTree.children()).hasSize(4);
+    assertThat(pyForStatementTree.children()).hasSize(8);
 
     PyWithStatementTree withStatement = parse("async with foo : pass", treeMaker::withStatement);
     assertThat(withStatement.isAsync()).isTrue();
@@ -1088,7 +1088,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyWithItemTree.expression()).isNull();
     assertThat(withStatement.statements().statements()).hasSize(1);
     assertThat(withStatement.statements().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(withStatement.children()).hasSize(2);
+    assertThat(withStatement.children()).hasSize(4);
   }
 
   @Test
@@ -1106,7 +1106,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyWithItemTree.expression()).isNull();
     assertThat(withStatement.statements().statements()).hasSize(1);
     assertThat(withStatement.statements().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(withStatement.children()).hasSize(2);
+    assertThat(withStatement.children()).hasSize(4);
 
 
     withStatement = parse("with foo as bar, qix : pass", treeMaker::withStatement);
@@ -1125,7 +1125,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(pyWithItemTree.expression()).isNull();
     assertThat(withStatement.statements().statements()).hasSize(1);
     assertThat(withStatement.statements().statements().get(0).is(Tree.Kind.PASS_STMT)).isTrue();
-    assertThat(withStatement.children()).hasSize(3);
+    assertThat(withStatement.children()).hasSize(5);
   }
 
   @Test
@@ -1155,7 +1155,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(callExpression.arguments()).isEmpty();
     PyNameTree name = (PyNameTree) callExpression.callee();
     assertThat(name.name()).isEqualTo("foo");
-    assertThat(callExpression.children()).hasSize(2);
+    assertThat(callExpression.children()).hasSize(3);
     assertThat(callExpression.leftPar().value()).isEqualTo("(");
     assertThat(callExpression.rightPar().value()).isEqualTo(")");
 
@@ -1168,7 +1168,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(sndArg.name()).isEqualTo("y");
     name = (PyNameTree) callExpression.callee();
     assertThat(name.name()).isEqualTo("foo");
-    assertThat(callExpression.children()).hasSize(2);
+    assertThat(callExpression.children()).hasSize(4);
 
     callExpression = parse("foo.bar()", treeMaker::callExpression);
     assertThat(callExpression.argumentList()).isNull();
@@ -1177,7 +1177,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(callExpression.lastToken().value()).isEqualTo(")");
     assertThat(callee.name().name()).isEqualTo("bar");
     assertThat(((PyNameTree) callee.qualifier()).name()).isEqualTo("foo");
-    assertThat(callExpression.children()).hasSize(2);
+    assertThat(callExpression.children()).hasSize(3);
   }
 
   @Test
@@ -1210,7 +1210,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyExpressionTree qualifier = qualifiedExpression.qualifier();
     assertThat(qualifier).isInstanceOf(PyNameTree.class);
     assertThat(((PyNameTree) qualifier).name()).isEqualTo("foo");
-    assertThat(qualifiedExpression.children()).hasSize(2);
+    assertThat(qualifiedExpression.children()).hasSize(3);
 
     qualifiedExpression = parse("foo.bar.baz", treeMaker::qualifiedExpression);
     assertThat(qualifiedExpression.name().name()).isEqualTo("baz");
@@ -1224,7 +1224,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(qualExpr.qualifier()).isInstanceOf(PyNameTree.class);
     PyNameTree name = (PyNameTree) qualExpr.qualifier();
     assertThat(name.name()).isEqualTo("foo");
-    assertThat(qualifiedExpression.children()).hasSize(2);
+    assertThat(qualifiedExpression.children()).hasSize(3);
   }
 
   @Test
@@ -1237,7 +1237,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(name.name()).isEqualTo("foo");
     assertThat(argumentTree.starToken()).isNull();
     assertThat(argumentTree.starStarToken()).isNull();
-    assertThat(argumentTree.children()).hasSize(2);
+    assertThat(argumentTree.children()).hasSize(1);
 
     argumentTree = parse("*foo", treeMaker::argument);
     assertThat(argumentTree.equalToken()).isNull();
@@ -1265,7 +1265,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(name.name()).isEqualTo("foo");
     assertThat(argumentTree.starToken()).isNull();
     assertThat(argumentTree.starStarToken()).isNull();
-    assertThat(argumentTree.children()).hasSize(2);
+    assertThat(argumentTree.children()).hasSize(3);
   }
 
   @Test
@@ -1277,11 +1277,11 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(simplePlus.operator().value()).isEqualTo("+");
     assertThat(simplePlus.rightOperand()).isInstanceOf(PyNameTree.class);
     assertThat(simplePlus.getKind()).isEqualTo(Tree.Kind.PLUS);
-    assertThat(simplePlus.children()).hasSize(2);
+    assertThat(simplePlus.children()).hasSize(3);
 
     PyBinaryExpressionTree compoundPlus = binaryExpression("a + b - c");
     assertThat(compoundPlus.leftOperand()).isInstanceOf(PyBinaryExpressionTree.class);
-    assertThat(compoundPlus.children()).hasSize(2);
+    assertThat(compoundPlus.children()).hasSize(3);
     assertThat(compoundPlus.operator().value()).isEqualTo("-");
     assertThat(compoundPlus.rightOperand()).isInstanceOf(PyNameTree.class);
     assertThat(compoundPlus.getKind()).isEqualTo(Tree.Kind.MINUS);
@@ -1358,7 +1358,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(starred.getKind()).isEqualTo(Tree.Kind.STARRED_EXPR);
     assertThat(starred.starToken().value()).isEqualTo("*");
     assertThat(starred.expression().getKind()).isEqualTo(Tree.Kind.NAME);
-    assertThat(starred.children()).hasSize(1);
+    assertThat(starred.children()).hasSize(2);
   }
 
   @Test
@@ -1368,7 +1368,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(expr.getKind()).isEqualTo(Tree.Kind.AWAIT);
     assertThat(expr.awaitToken().value()).isEqualTo("await");
     assertThat(expr.expression().getKind()).isEqualTo(Tree.Kind.NAME);
-    assertThat(expr.children()).hasSize(1);
+    assertThat(expr.children()).hasSize(2);
 
     PyBinaryExpressionTree awaitWithPower = binaryExpression("await a ** 3");
     assertThat(awaitWithPower.getKind()).isEqualTo(Tree.Kind.POWER);
@@ -1386,7 +1386,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(((PyNameTree) expr.subscripts().expressions().get(0)).name()).isEqualTo("a");
     assertThat(expr.leftBracket().value()).isEqualTo("[");
     assertThat(expr.rightBracket().value()).isEqualTo("]");
-    assertThat(expr.children()).hasSize(2);
+    assertThat(expr.children()).hasSize(4);
 
     PySubscriptionExpressionTree multipleSubscripts = (PySubscriptionExpressionTree) parse("x[a, 42]", treeMaker::expression);
     assertThat(multipleSubscripts.subscripts().expressions()).extracting(Tree::getKind)
@@ -1402,7 +1402,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(expr.object().getKind()).isEqualTo(Tree.Kind.NAME);
     assertThat(expr.leftBracket().value()).isEqualTo("[");
     assertThat(expr.rightBracket().value()).isEqualTo("]");
-    assertThat(expr.children()).hasSize(2);
+    assertThat(expr.children()).hasSize(4);
     assertThat(expr.sliceList().getKind()).isEqualTo(Tree.Kind.SLICE_LIST);
     assertThat(expr.sliceList().children()).hasSize(1);
     assertThat(expr.sliceList().slices().get(0).getKind()).isEqualTo(Tree.Kind.SLICE_ITEM);
@@ -1430,7 +1430,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(((PyNameTree) slice.stride()).name()).isEqualTo("c");
     assertThat(slice.boundSeparator().value()).isEqualTo(":");
     assertThat(slice.strideSeparator().value()).isEqualTo(":");
-    assertThat(slice.children()).hasSize(3);
+    assertThat(slice.children()).hasSize(5);
 
     PySliceItemTree trivial = parse(":", treeMaker::sliceItem);
     assertThat(trivial.lowerBound()).isNull();
@@ -1471,21 +1471,21 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(lambdaExpressionTree.colonToken().value()).isEqualTo(":");
 
     assertThat(lambdaExpressionTree.parameters().nonTuple()).hasSize(1);
-    assertThat(lambdaExpressionTree.children()).hasSize(2);
+    assertThat(lambdaExpressionTree.children()).hasSize(4);
 
     lambdaExpressionTree = parse("lambda x, y: x", treeMaker::lambdaExpression);
     assertThat(lambdaExpressionTree.parameters().nonTuple()).hasSize(2);
-    assertThat(lambdaExpressionTree.children()).hasSize(2);
+    assertThat(lambdaExpressionTree.children()).hasSize(4);
 
     lambdaExpressionTree = parse("lambda x = 'foo': x", treeMaker::lambdaExpression);
     assertThat(lambdaExpressionTree.parameters().all()).extracting(Tree::getKind).containsExactly(Tree.Kind.PARAMETER);
     assertThat(lambdaExpressionTree.parameters().nonTuple().get(0).name().name()).isEqualTo("x");
-    assertThat(lambdaExpressionTree.children()).hasSize(2);
+    assertThat(lambdaExpressionTree.children()).hasSize(4);
 
     lambdaExpressionTree = parse("lambda (x, y): x", treeMaker::lambdaExpression);
     assertThat(lambdaExpressionTree.parameters().all()).extracting(Tree::getKind).containsExactly(Tree.Kind.TUPLE_PARAMETER);
     assertThat(((PyTupleParameterTree) lambdaExpressionTree.parameters().all().get(0)).parameters()).hasSize(2);
-    assertThat(lambdaExpressionTree.children()).hasSize(2);
+    assertThat(lambdaExpressionTree.children()).hasSize(4);
 
     lambdaExpressionTree = parse("lambda *a, **b: 42", treeMaker::lambdaExpression);
     assertThat(lambdaExpressionTree.parameters().nonTuple()).hasSize(2);
@@ -1608,7 +1608,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(expressions.get(0).is(Tree.Kind.NUMERIC_LITERAL)).isTrue();
     assertThat(listLiteralTree.leftBracket()).isNotNull();
     assertThat(listLiteralTree.rightBracket()).isNotNull();
-    assertThat(listLiteralTree.children()).hasSize(1);
+    assertThat(listLiteralTree.children()).hasSize(3);
   }
 
 
@@ -1631,7 +1631,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(forClause.inToken().value()).isEqualTo("in");
     assertThat(forClause.iterable().getKind()).isEqualTo(Tree.Kind.LIST_LITERAL);
     assertThat(forClause.nestedClause()).isNull();
-    assertThat(forClause.children()).hasSize(3);
+    assertThat(forClause.children()).hasSize(4);
   }
 
   @Test
@@ -1665,7 +1665,7 @@ public class PythonTreeMakerTest extends RuleTest {
     setRootRule(PythonGrammar.TEST);
     PyParenthesizedExpressionTree parenthesized = (PyParenthesizedExpressionTree) parse("(42)", treeMaker::expression);
     assertThat(parenthesized.getKind()).isEqualTo(Tree.Kind.PARENTHESIZED);
-    assertThat(parenthesized.children()).hasSize(1);
+    assertThat(parenthesized.children()).hasSize(3);
     assertThat(parenthesized.leftParenthesis().value()).isEqualTo("(");
     assertThat(parenthesized.rightParenthesis().value()).isEqualTo(")");
     assertThat(parenthesized.expression().getKind()).isEqualTo(Tree.Kind.NUMERIC_LITERAL);
@@ -1713,12 +1713,12 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(empty.commas()).isEmpty();
     assertThat(empty.leftParenthesis().value()).isEqualTo("(");
     assertThat(empty.rightParenthesis().value()).isEqualTo(")");
-    assertThat(empty.children()).hasSize(0);
+    assertThat(empty.children()).hasSize(2);
 
     PyTupleTree singleValue = parseTuple("(a,)");
     assertThat(singleValue.elements()).extracting(Tree::getKind).containsExactly(Tree.Kind.NAME);
     assertThat(singleValue.commas()).extracting(PyToken::value).containsExactly(",");
-    assertThat(singleValue.children()).hasSize(1);
+    assertThat(singleValue.children()).hasSize(4);
 
     assertThat(parseTuple("(a,b)").elements()).hasSize(2);
   }
@@ -1809,7 +1809,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(comprehension.keyExpression().getKind()).isEqualTo(Tree.Kind.MINUS);
     assertThat(comprehension.valueExpression().getKind()).isEqualTo(Tree.Kind.PLUS);
     assertThat(comprehension.comprehensionFor().loopExpression().getKind()).isEqualTo(Tree.Kind.TUPLE);
-    assertThat(comprehension.children()).hasSize(3);
+    assertThat(comprehension.children()).hasSize(4);
     assertThat(comprehension.firstToken().value()).isEqualTo("{");
     assertThat(comprehension.lastToken().value()).isEqualTo("}");
   }
@@ -1863,7 +1863,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(reprExpressionTree.closingBacktick().value()).isEqualTo("`");
     assertThat(reprExpressionTree.expressionList().expressions()).hasSize(1);
     assertThat(reprExpressionTree.expressionList().expressions().get(0).getKind()).isEqualTo(Tree.Kind.NUMERIC_LITERAL);
-    assertThat(reprExpressionTree.children()).hasSize(1);
+    assertThat(reprExpressionTree.children()).hasSize(3);
 
     reprExpressionTree = (PyReprExpressionTree) parse("`x, y`", treeMaker::expression);
     assertThat(reprExpressionTree.getKind()).isEqualTo(Tree.Kind.REPR);
@@ -1878,7 +1878,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyEllipsisExpressionTree ellipsisExpressionTree = (PyEllipsisExpressionTree) parse("...", treeMaker::expression);
     assertThat(ellipsisExpressionTree.getKind()).isEqualTo(Tree.Kind.ELLIPSIS);
     assertThat(ellipsisExpressionTree.ellipsis()).extracting(PyToken::value).containsExactly(".", ".", ".");
-    assertThat(ellipsisExpressionTree.children()).isEmpty();
+    assertThat(ellipsisExpressionTree.children()).hasSize(3);
   }
 
   @Test
@@ -1887,7 +1887,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyNoneExpressionTree noneExpressionTree = (PyNoneExpressionTree) parse("None", treeMaker::expression);
     assertThat(noneExpressionTree.getKind()).isEqualTo(Tree.Kind.NONE);
     assertThat(noneExpressionTree.none().value()).isEqualTo("None");
-    assertThat(noneExpressionTree.children()).isEmpty();
+    assertThat(noneExpressionTree.children()).hasSize(1);
   }
 
   private void assertUnaryExpression(String operator, Tree.Kind kind) {
@@ -1897,7 +1897,7 @@ public class PythonTreeMakerTest extends RuleTest {
     PyUnaryExpressionTree unary = (PyUnaryExpressionTree) parse;
     assertThat(unary.expression().is(Tree.Kind.NUMERIC_LITERAL)).isTrue();
     assertThat(unary.operator().value()).isEqualTo(operator);
-    assertThat(unary.children()).hasSize(1);
+    assertThat(unary.children()).hasSize(2);
   }
 
   private <T extends Tree> T parse(String code, Function<AstNode, T> func) {


### PR DESCRIPTION
Replacing the currently used sslr Token by a PyToken wrapper extending Tree.

This allows to consider tokens as actual nodes of the Strongly typed AST and returning them when calling the Tree::children method.