### PR TITLE
SONARPY-355 add testcase to empty nested block checked.

### DIFF
--- a/python-checks/src/test/resources/checks/emptyNestedBlock.py
+++ b/python-checks/src/test/resources/checks/emptyNestedBlock.py
@@ -47,3 +47,9 @@ def empty_function():
 
 class empty_class:
     pass
+# Noncompliant@+2
+if condition1:
+    pass
+# just a comment
+elif condition2:
+    foo()


### PR DESCRIPTION
This was fixed by new handling of comment, dedent and newline in strongly typed AST