### PR TITLE
minor fixes (flask_wtf.CSRFProtect imports, csrf.init_app for unknown symbols)

### DIFF
--- a/python-checks/src/test/java/org/sonar/python/checks/hotspots/CsrfDisabledCheckTest.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/hotspots/CsrfDisabledCheckTest.java
@@ -64,4 +64,11 @@ public class CsrfDisabledCheckTest {
   public void testExemptAsFunction() {
     testFile("flask/exemptAsFunction.py");
   }
+
+  @Test
+  public void fixupTestsMoreRobustCSRFProtect() { testFile("flask/fixupTestsMoreRobustCSRFProtect.py"); }
+
+  @Test
+  public void fixupCsrfInGlobalScope() { testFile("flask/fixupCsrfInGlobalScope.py"); }
+
 }

--- a/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/django/settings.py
+++ b/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/django/settings.py
@@ -2,7 +2,7 @@ MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
 #    'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-] # Noncompliant {{Make sure not using CSRF protection (django.middleware.csrf.CsrfViewMiddleware) is safe here.}}
+] # Noncompliant {{Make sure disabling CSRF protection is safe here.}}
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',

--- a/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/fixupCsrfInGlobalScope.py
+++ b/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/fixupCsrfInGlobalScope.py
@@ -1,0 +1,10 @@
+from flask import Flask
+from flask_wtf import CSRFProtect
+csrf = CSRFProtect()
+def create_app():
+   app = Flask(__name__) # Compliant
+   csrf.init_app(app)
+
+def create_app_noncompliant():
+   app2 = Flask(__name__) # Noncompliant
+

--- a/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/fixupTestsMoreRobustCSRFProtect.py
+++ b/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/fixupTestsMoreRobustCSRFProtect.py
@@ -1,0 +1,24 @@
+def csrfInitAppShouldWorkEvenIfCsrfSymbolIsNotFound():
+  from flask import Flask
+  app = Flask(__name__) # Compliant
+  csrf.init_app(app) # Unknown symbol, but looks similar enough to CSRFProtect.
+
+def csrfInitAppShouldWorkEvenIfCsrfSymbolIsNotFoundUppercase():
+  from flask import Flask
+  app = Flask(__name__) # Compliant
+  CSRF.init_app(app) # Unknown symbol, but looks similar enough to CSRFProtect.
+
+def csrfInitAppShouldCheckTheQualifier():
+  from flask import Flask
+  app = Flask(__name__) # Noncompliant {{Make sure disabling CSRF protection is safe here.}}
+  #     ^^^^^^^^^^^^^^^
+  somethingUnrelated.init_app(app) # insufficient
+  tooLong.csrf.init_app(app) # insufficient
+  csrf.do_something_else(app) # insufficient
+
+def csrfProtectCanBeImportedFromFlaskWtfDirectly():
+  from flask import Flask
+  from flask_wtf import CSRFProtect
+  app = Flask(__name__) # Compliant
+  CSRFProtect(app)
+

--- a/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/global.py
+++ b/python-checks/src/test/resources/checks/hotspots/csrfDisabledCheck/flask/global.py
@@ -3,7 +3,7 @@ def misconfiguredFlaskExamples():
   from flask_wtf.csrf import CSRFProtect
   # from flask_wtf import csrf
 
-  app1 = Flask(__name__) # Noncompliant {{Make sure not using CSRFProtect is safe here.}}
+  app1 = Flask(__name__) # Noncompliant {{Make sure disabling CSRF protection is safe here.}}
   #      ^^^^^^^^^^^^^^^
 
   app2 = Flask(__name__)


### PR DESCRIPTION
 * add flask_wtf.CSRFProtect to FQNs that deactivate the issue message
 * loosen the requirements on csrf.init_app invocations - allow purely lexical matches
 * further standardize issue messages