### PR TITLE
SONARPY-183 Count module-level docstrings as comment, not code.

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
@@ -50,7 +50,7 @@ public class FileLinesVisitor extends PythonSubscriptionCheck {
    * Tree.Kind.ELSE_CLAUSE is not in this list to avoid counting else: lines as executables.
    * This is to replicate behavior of some python coverage tools (like what is done by coveralls).
    */
-  private static final List<Tree.Kind> EXECUTABLE_LINES = Arrays.asList(Tree.Kind.ASSIGNMENT_STMT, Tree.Kind.COMPOUND_ASSIGNMENT, Tree.Kind.EXPRESSION_STMT, Tree.Kind.IMPORT_STMT,
+  private static final List<Tree.Kind> EXECUTABLE_LINES = Arrays.asList(Tree.Kind.ASSIGNMENT_STMT, Tree.Kind.COMPOUND_ASSIGNMENT, Tree.Kind.EXPRESSION_STMT, Tree.Kind.FILE_INPUT, Tree.Kind.IMPORT_STMT,
     Tree.Kind.IMPORT_NAME, Tree.Kind.IMPORT_FROM, Tree.Kind.CONTINUE_STMT, Tree.Kind.BREAK_STMT, Tree.Kind.YIELD_STMT, Tree.Kind.RETURN_STMT, Tree.Kind.PRINT_STMT,
     Tree.Kind.PASS_STMT, Tree.Kind.FOR_STMT, Tree.Kind.WHILE_STMT, Tree.Kind.IF_STMT, Tree.Kind.RAISE_STMT, Tree.Kind.TRY_STMT, Tree.Kind.EXCEPT_CLAUSE,
     Tree.Kind.EXEC_STMT, Tree.Kind.ASSERT_STMT, Tree.Kind.DEL_STMT, Tree.Kind.GLOBAL_STMT, Tree.Kind.CLASSDEF, Tree.Kind.FUNCDEF);
@@ -70,18 +70,17 @@ public class FileLinesVisitor extends PythonSubscriptionCheck {
 
   @Override
   public void initialize(Context context) {
-    context.registerSyntaxNodeConsumer(Tree.Kind.FILE_INPUT, ctx -> visitFile(ctx));
+    context.registerSyntaxNodeConsumer(Tree.Kind.FILE_INPUT, ctx -> visitFile());
     EXECUTABLE_LINES.forEach(kind -> context.registerSyntaxNodeConsumer(kind, this::visitNode));
     context.registerSyntaxNodeConsumer(Tree.Kind.TOKEN, ctx -> visitToken((Token) ctx.syntaxNode()));
   }
 
-  private void visitFile(SubscriptionContext ctx) {
+  private void visitFile() {
     noSonar.clear();
     linesOfCode.clear();
     linesOfComments.clear();
     linesOfDocstring.clear();
     executableLines.clear();
-    visitNode(ctx);
   }
 
   private void visitNode(SubscriptionContext ctx) {

--- a/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
@@ -50,10 +50,10 @@ public class FileLinesVisitor extends PythonSubscriptionCheck {
    * Tree.Kind.ELSE_CLAUSE is not in this list to avoid counting else: lines as executables.
    * This is to replicate behavior of some python coverage tools (like what is done by coveralls).
    */
-  private static final List<Tree.Kind> EXECUTABLE_LINES = Arrays.asList(Tree.Kind.ASSIGNMENT_STMT, Tree.Kind.COMPOUND_ASSIGNMENT, Tree.Kind.EXPRESSION_STMT, Tree.Kind.FILE_INPUT, Tree.Kind.IMPORT_STMT,
+  private static final List<Tree.Kind> EXECUTABLE_LINES = Arrays.asList(Tree.Kind.ASSIGNMENT_STMT, Tree.Kind.COMPOUND_ASSIGNMENT, Tree.Kind.EXPRESSION_STMT, Tree.Kind.IMPORT_STMT,
     Tree.Kind.IMPORT_NAME, Tree.Kind.IMPORT_FROM, Tree.Kind.CONTINUE_STMT, Tree.Kind.BREAK_STMT, Tree.Kind.YIELD_STMT, Tree.Kind.RETURN_STMT, Tree.Kind.PRINT_STMT,
     Tree.Kind.PASS_STMT, Tree.Kind.FOR_STMT, Tree.Kind.WHILE_STMT, Tree.Kind.IF_STMT, Tree.Kind.RAISE_STMT, Tree.Kind.TRY_STMT, Tree.Kind.EXCEPT_CLAUSE,
-    Tree.Kind.EXEC_STMT, Tree.Kind.ASSERT_STMT, Tree.Kind.DEL_STMT, Tree.Kind.GLOBAL_STMT, Tree.Kind.CLASSDEF, Tree.Kind.FUNCDEF);
+    Tree.Kind.EXEC_STMT, Tree.Kind.ASSERT_STMT, Tree.Kind.DEL_STMT, Tree.Kind.GLOBAL_STMT, Tree.Kind.CLASSDEF, Tree.Kind.FUNCDEF, Tree.Kind.FILE_INPUT);
 
   private Set<Integer> noSonar = new HashSet<>();
   private Set<Integer> linesOfCode = new HashSet<>();

--- a/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/metrics/FileLinesVisitor.java
@@ -70,17 +70,18 @@ public class FileLinesVisitor extends PythonSubscriptionCheck {
 
   @Override
   public void initialize(Context context) {
-    context.registerSyntaxNodeConsumer(Tree.Kind.FILE_INPUT, ctx -> visitFile());
+    context.registerSyntaxNodeConsumer(Tree.Kind.FILE_INPUT, ctx -> visitFile(ctx));
     EXECUTABLE_LINES.forEach(kind -> context.registerSyntaxNodeConsumer(kind, this::visitNode));
     context.registerSyntaxNodeConsumer(Tree.Kind.TOKEN, ctx -> visitToken((Token) ctx.syntaxNode()));
   }
 
-  private void visitFile() {
+  private void visitFile(SubscriptionContext ctx) {
     noSonar.clear();
     linesOfCode.clear();
     linesOfComments.clear();
     linesOfDocstring.clear();
     executableLines.clear();
+    visitNode(ctx);
   }
 
   private void visitNode(SubscriptionContext ctx) {

--- a/python-frontend/src/test/java/org/sonar/python/FileLinesVisitorTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/FileLinesVisitorTest.java
@@ -36,11 +36,11 @@ public class FileLinesVisitorTest {
     TestPythonVisitorRunner.scanFile(new File(BASE_DIR, "file_lines.py"), visitor);
 
     assertThat(visitor.getLinesOfCode()).hasSize(12);
-    assertThat(visitor.getLinesOfCode()).containsOnly(2, 4, 7, 8, 9, 10, 11, 12, 14, 15, 17, 21);
+    assertThat(visitor.getLinesOfCode()).containsOnly(6, 8, 11, 12, 13, 14, 15, 16, 18, 19, 21, 25);
 
-    assertThat(visitor.getCommentLineCount()).isEqualTo(9);
+    assertThat(visitor.getCommentLineCount()).isEqualTo(13);
 
-    assertThat(visitor.getLinesWithNoSonar()).containsOnly(11);
+    assertThat(visitor.getLinesWithNoSonar()).containsOnly(15);
   }
 
   @Test

--- a/python-frontend/src/test/resources/metrics/file_lines.py
+++ b/python-frontend/src/test/resources/metrics/file_lines.py
@@ -1,4 +1,8 @@
 # comment
+"""A module-level docstring.
+
+Following PEP-257.
+"""
 if 2 > 1:
 	
 	print "b"     # end of line comment


### PR DESCRIPTION
Closes SONARPY-183.

Module-level docstrings should be counted as comments.

The `if (tree.is(Tree.Kind.FILE_INPUT))` case in  `FileLinesVisitor` never happened. Module-level docstrings were therefore seen as code instead of comments. As a result, a long module-level docstring required extra comments elsewhere in the file to maintain the right comment density.

This is fixed by adding `Tree.Kind.FILE_INPUT` to `EXECUTABLE_LINES`. Test case is updated to prevent regression.



