### PR TITLE
SONARPY-861 Show 'custom rules' documentation only in SonarQube

### DIFF
--- a/sonar-python-plugin/src/main/resources/static/documentation.md
+++ b/sonar-python-plugin/src/main/resources/static/documentation.md
@@ -28,6 +28,7 @@ Examples:
   * `sonar.python.version=3.8` 
   * `sonar.python.version=2.7, 3.7, 3.8, 3.9`
 
+<!-- sonarqube -->
 ## Custom Rules
 
 ### Overview


### PR DESCRIPTION
Closing tag is already present at the end of the file