### PR TITLE
SONARPY-950 S5708 (CaughtExceptionCheck) should not report on Ambiguo…

### DIFF
--- a/its/ruling/src/test/resources/expected/python-S5708.json
+++ b/its/ruling/src/test/resources/expected/python-S5708.json
@@ -1,5 +1,0 @@
-{
-'project:django-2.2.3/django/core/mail/backends/smtp.py':[
-83,
-],
-}

--- a/python-checks/src/main/java/org/sonar/python/checks/CaughtExceptionsCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/CaughtExceptionsCheck.java
@@ -83,6 +83,6 @@ public class CaughtExceptionsCheck extends PythonSubscriptionCheck {
       return true;
     }
     ClassSymbol classSymbol = (ClassSymbol) symbol;
-    return classSymbol.isOrExtends(BASE_EXCEPTION) || classSymbol.hasUnresolvedTypeHierarchy();
+    return classSymbol.canBeOrExtend(BASE_EXCEPTION);
   }
 }

--- a/python-checks/src/test/resources/checks/caughtExceptions.py
+++ b/python-checks/src/test/resources/checks/caughtExceptions.py
@@ -55,3 +55,9 @@ def foo():
     foo = 1/0
   except exceptions:
     foo = 0
+
+  import smtplib
+  try:
+    ...
+  except smtplib.SMTPServerDisconnected:  # OK, SMTPServerDisconnected when Python version is unknown
+    ...


### PR DESCRIPTION
…us Symbols that might inherit from BaseException