### PR TITLE
Avoid copying symbols that come from the project table and fix bug for ambiguous descriptors with null FQN

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/index/DescriptorUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/DescriptorUtils.java
@@ -117,6 +117,7 @@ public class DescriptorUtils {
     )).collect(Collectors.toList());
   }
 
+  // TODO SONARPY-958: Cleanup the symbol construction from descriptors by extracting this logic in a builder class
   public static Symbol symbolFromDescriptor(Descriptor descriptor, ProjectLevelSymbolTable projectLevelSymbolTable,
                                             @Nullable String localSymbolName, Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn) {
     if (createdSymbolsByDescriptor.containsKey(descriptor)) {
@@ -180,7 +181,7 @@ public class DescriptorUtils {
             return createdSymbolsByFqn.get(superClassFqn);
           }
           Symbol symbol = projectLevelSymbolTable.getSymbol(superClassFqn, null, createdSymbolsByDescriptor, createdSymbolsByFqn);
-          symbol = symbol != null ? symbol : ((SymbolImpl) typeshedSymbolWithFQN(superClassFqn)).copyWithoutUsages();
+          symbol = symbol != null ? symbol : typeshedSymbolWithFQN(superClassFqn);
           createdSymbolsByFqn.put(superClassFqn, symbol);
           return symbol;
         }

--- a/python-frontend/src/main/java/org/sonar/python/index/DescriptorUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/DescriptorUtils.java
@@ -20,6 +20,7 @@
 package org.sonar.python.index;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -117,42 +118,50 @@ public class DescriptorUtils {
   }
 
   public static Symbol symbolFromDescriptor(Descriptor descriptor, ProjectLevelSymbolTable projectLevelSymbolTable,
-                                            @Nullable String localSymbolName, Map<String, Symbol> createdSymbols) {
-    // The symbol generated from the descriptor will not have the descriptor name if an alias (localSymbolName) is defined
-    if (createdSymbols.containsKey(descriptor.fullyQualifiedName())) {
-      return createdSymbols.get(descriptor.fullyQualifiedName());
+                                            @Nullable String localSymbolName, Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn) {
+    if (createdSymbolsByDescriptor.containsKey(descriptor)) {
+      return createdSymbolsByDescriptor.get(descriptor);
+    } else if (descriptor.fullyQualifiedName() != null && createdSymbolsByFqn.containsKey(descriptor.fullyQualifiedName())) {
+      return createdSymbolsByFqn.get(descriptor.fullyQualifiedName());
     }
+    // The symbol generated from the descriptor will not have the descriptor name if an alias (localSymbolName) is defined
     String symbolName = localSymbolName != null ? localSymbolName : descriptor.name();
     switch (descriptor.kind()) {
       case CLASS:
-        return createClassSymbol(descriptor, projectLevelSymbolTable, createdSymbols, symbolName);
+        return createClassSymbol(descriptor, projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolsByFqn, symbolName);
       case FUNCTION:
-        return createFunctionSymbol((FunctionDescriptor) descriptor, projectLevelSymbolTable, createdSymbols, symbolName);
+        return createFunctionSymbol((FunctionDescriptor) descriptor, projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolsByFqn, symbolName);
       case VARIABLE:
         return new SymbolImpl(symbolName, descriptor.fullyQualifiedName());
       case AMBIGUOUS:
-        Set<Symbol> alternatives = ((AmbiguousDescriptor) descriptor).alternatives().stream()
-          .map(a -> DescriptorUtils.symbolFromDescriptor(a, projectLevelSymbolTable, symbolName, createdSymbols))
-          .collect(Collectors.toSet());
-        return new AmbiguousSymbolImpl(symbolName, descriptor.fullyQualifiedName(), alternatives);
+        Set<Symbol> alternatives = new HashSet<>();
+        AmbiguousSymbolImpl ambiguousSymbol = new AmbiguousSymbolImpl(symbolName, descriptor.fullyQualifiedName(), alternatives);
+        createdSymbolsByDescriptor.put(descriptor, ambiguousSymbol);
+        alternatives.addAll(((AmbiguousDescriptor) descriptor).alternatives().stream()
+          .map(a -> DescriptorUtils.symbolFromDescriptor(a, projectLevelSymbolTable, symbolName, createdSymbolsByDescriptor, createdSymbolsByFqn))
+          .collect(Collectors.toSet()));
+        return ambiguousSymbol;
       default:
         throw new IllegalStateException(String.format("Error while creating a Symbol from a Descriptor: Unexpected descriptor kind: %s", descriptor.kind()));
     }
   }
 
-  private static ClassSymbolImpl createClassSymbol(Descriptor descriptor, ProjectLevelSymbolTable projectLevelSymbolTable, Map<String, Symbol> createdSymbols, String symbolName) {
+  private static ClassSymbolImpl createClassSymbol(Descriptor descriptor, ProjectLevelSymbolTable projectLevelSymbolTable, Map<Descriptor, Symbol> createdSymbolsByDescriptor,
+    Map<String, Symbol> createdSymbolByFqn, String symbolName) {
     ClassDescriptor classDescriptor = (ClassDescriptor) descriptor;
     ClassSymbolImpl classSymbol = new ClassSymbolImpl((ClassDescriptor) descriptor, symbolName);
-    createdSymbols.put(descriptor.fullyQualifiedName(), classSymbol);
-    addSuperClasses(classSymbol, classDescriptor, projectLevelSymbolTable, createdSymbols);
-    addMembers(classSymbol, classDescriptor, projectLevelSymbolTable, createdSymbols);
+    createdSymbolsByDescriptor.put(descriptor, classSymbol);
+    createdSymbolByFqn.put(descriptor.fullyQualifiedName(), classSymbol);
+    addSuperClasses(classSymbol, classDescriptor, projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolByFqn);
+    addMembers(classSymbol, classDescriptor, projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolByFqn);
     return classSymbol;
   }
 
   private static void addMembers(ClassSymbolImpl classSymbol, ClassDescriptor classDescriptor,
-                                 ProjectLevelSymbolTable projectLevelSymbolTable, Map<String, Symbol> createdSymbols) {
+                                 ProjectLevelSymbolTable projectLevelSymbolTable, Map<Descriptor, Symbol> createdSymbolsByDescriptor,
+    Map<String , Symbol> createdSymbolsByFqn) {
     classSymbol.addMembers(classDescriptor.members().stream()
-      .map(memberFqn -> DescriptorUtils.symbolFromDescriptor(memberFqn, projectLevelSymbolTable, null, createdSymbols))
+      .map(memberFqn -> DescriptorUtils.symbolFromDescriptor(memberFqn, projectLevelSymbolTable, null, createdSymbolsByDescriptor, createdSymbolsByFqn))
       .map(member -> {
         if (member instanceof FunctionSymbolImpl) {
           ((FunctionSymbolImpl) member).setOwner(classSymbol);
@@ -163,15 +172,16 @@ public class DescriptorUtils {
   }
 
   private static void addSuperClasses(ClassSymbolImpl classSymbol, ClassDescriptor classDescriptor,
-                                      ProjectLevelSymbolTable projectLevelSymbolTable, Map<String, Symbol> createdSymbols) {
+                                      ProjectLevelSymbolTable projectLevelSymbolTable, Map<Descriptor, Symbol> createdSymbolsByDescriptor,
+    Map<String, Symbol> createdSymbolsByFqn) {
     classDescriptor.superClasses().stream()
       .map(superClassFqn -> {
-          if (createdSymbols.containsKey(superClassFqn)) {
-            return createdSymbols.get(superClassFqn);
+          if (createdSymbolsByFqn.containsKey(superClassFqn)) {
+            return createdSymbolsByFqn.get(superClassFqn);
           }
-          Symbol symbol = projectLevelSymbolTable.getSymbol(superClassFqn, null, createdSymbols);
-          symbol = symbol != null ? symbol : typeshedSymbolWithFQN(superClassFqn);
-          createdSymbols.put(superClassFqn, symbol);
+          Symbol symbol = projectLevelSymbolTable.getSymbol(superClassFqn, null, createdSymbolsByDescriptor, createdSymbolsByFqn);
+          symbol = symbol != null ? symbol : ((SymbolImpl) typeshedSymbolWithFQN(superClassFqn)).copyWithoutUsages();
+          createdSymbolsByFqn.put(superClassFqn, symbol);
           return symbol;
         }
       )
@@ -179,31 +189,32 @@ public class DescriptorUtils {
   }
 
   private static FunctionSymbolImpl createFunctionSymbol(FunctionDescriptor functionDescriptor, ProjectLevelSymbolTable projectLevelSymbolTable,
-                                                         Map<String, Symbol> createdSymbols, String symbolName) {
+                                                         Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn,
+                                                         String symbolName) {
     FunctionSymbolImpl functionSymbol = new FunctionSymbolImpl(functionDescriptor, symbolName);
-    addParameters(functionSymbol, functionDescriptor, projectLevelSymbolTable, createdSymbols);
+    addParameters(functionSymbol, functionDescriptor, projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolsByFqn);
     return functionSymbol;
   }
 
   private static void addParameters(FunctionSymbolImpl functionSymbol, FunctionDescriptor functionDescriptor,
-                                    ProjectLevelSymbolTable projectLevelSymbolTable, Map<String, Symbol> createdSymbols) {
+                                    ProjectLevelSymbolTable projectLevelSymbolTable, Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn) {
     functionDescriptor.parameters().stream().map(parameterDescriptor -> {
       FunctionSymbolImpl.ParameterImpl parameter = new FunctionSymbolImpl.ParameterImpl(parameterDescriptor);
-      setParameterType(parameter, parameterDescriptor.annotatedType(), projectLevelSymbolTable, createdSymbols);
+      setParameterType(parameter, parameterDescriptor.annotatedType(), projectLevelSymbolTable, createdSymbolsByDescriptor, createdSymbolsByFqn);
       return parameter;
     }).forEach(functionSymbol::addParameter);
   }
 
-  private static void setParameterType(FunctionSymbolImpl.ParameterImpl parameter, String annotatedType,
-                                       ProjectLevelSymbolTable projectLevelSymbolTable, Map<String, Symbol> createdSymbols) {
+  private static void setParameterType(FunctionSymbolImpl.ParameterImpl parameter, String annotatedType, ProjectLevelSymbolTable projectLevelSymbolTable,
+                                       Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn) {
     InferredType declaredType;
     if (parameter.isKeywordVariadic()) {
       declaredType = InferredTypes.DICT;
     } else if (parameter.isPositionalVariadic()) {
       declaredType = InferredTypes.TUPLE;
     } else {
-      Symbol existingSymbol = createdSymbols.get(annotatedType);
-      Symbol typeSymbol = existingSymbol != null ? existingSymbol : projectLevelSymbolTable.getSymbol(annotatedType, null, createdSymbols);
+      Symbol existingSymbol = createdSymbolsByFqn.get(annotatedType);
+      Symbol typeSymbol = existingSymbol != null ? existingSymbol : projectLevelSymbolTable.getSymbol(annotatedType, null, createdSymbolsByDescriptor, createdSymbolsByFqn);
       String annotatedTypeName = parameter.annotatedTypeName();
       if (typeSymbol == null && annotatedTypeName != null) {
         typeSymbol = typeshedSymbolWithFQN(annotatedTypeName);

--- a/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
@@ -137,24 +137,26 @@ public class ProjectLevelSymbolTable {
   }
 
   public Symbol getSymbol(@Nullable String fullyQualifiedName, @Nullable String localSymbolName) {
-    return getSymbol(fullyQualifiedName, localSymbolName, new HashMap<>());
+    return getSymbol(fullyQualifiedName, localSymbolName, new HashMap<>(), new HashMap<>());
   }
 
-  public Symbol getSymbol(@Nullable String fullyQualifiedName, @Nullable String localSymbolName, Map<String, Symbol> createdSymbols) {
+  public Symbol getSymbol(@Nullable String fullyQualifiedName, @Nullable String localSymbolName,
+                          Map<Descriptor, Symbol> createdSymbolsByDescriptor, Map<String, Symbol> createdSymbolsByFqn) {
     if (fullyQualifiedName == null) return null;
     Descriptor descriptor = globalDescriptorsByFQN().get(fullyQualifiedName);
-    return descriptor == null ? null : DescriptorUtils.symbolFromDescriptor(descriptor, this, localSymbolName, createdSymbols);
+    return descriptor == null ? null : DescriptorUtils.symbolFromDescriptor(descriptor, this, localSymbolName, createdSymbolsByDescriptor, createdSymbolsByFqn);
   }
 
   @CheckForNull
   public Set<Symbol> getSymbolsFromModule(@Nullable String moduleName) {
     Set<Descriptor> descriptors = globalDescriptorsByModuleName.get(moduleName);
-    Map<String, Symbol> createdSymbols = new HashMap<>();
     if (descriptors == null) {
       return null;
     }
+    Map<Descriptor, Symbol> createdSymbolsByDescriptor = new HashMap<>();
+    Map<String, Symbol> createdSymbolsByFqn = new HashMap<>();
     return descriptors.stream()
-      .map(desc -> DescriptorUtils.symbolFromDescriptor(desc, this, null, createdSymbols)).collect(Collectors.toSet());
+      .map(desc -> DescriptorUtils.symbolFromDescriptor(desc, this, null, createdSymbolsByDescriptor, createdSymbolsByFqn)).collect(Collectors.toSet());
   }
 
   public boolean isDjangoView(@Nullable String fqn) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
@@ -82,15 +82,14 @@ class Scope {
 
   void createSymbolsFromWildcardImport(Set<Symbol> importedSymbols, ImportFrom importFrom) {
     importedSymbols.forEach(symbol -> {
-      Symbol importedSymbol = copySymbol(symbol.name(), symbol);
-      if (!isExistingSymbol(importedSymbol.name())) {
-        symbols.add(importedSymbol);
-        symbolsByName.put(symbol.name(), importedSymbol);
-        ((SymbolImpl) importedSymbol).addUsage(importFrom, Usage.Kind.IMPORT);
+      if (!isExistingSymbol(symbol.name())) {
+        symbols.add(symbol);
+        symbolsByName.put(symbol.name(), symbol);
+        ((SymbolImpl) symbol).addUsage(importFrom, Usage.Kind.IMPORT);
       } else {
         SymbolImpl originalSymbol = resolve(symbol.name());
         if (originalSymbol != null) {
-          resetSymbolInfo(importedSymbol.fullyQualifiedName(), originalSymbol);
+          resetSymbolInfo(symbol.fullyQualifiedName(), originalSymbol);
           originalSymbol.addUsage(importFrom, Usage.Kind.IMPORT);
         }
       }
@@ -123,7 +122,7 @@ class Scope {
     }
   }
 
-  private Symbol copySymbol(String symbolName, Symbol symbol) {
+  public Symbol copySymbol(String symbolName, Symbol symbol) {
     return copySymbol(symbolName, symbol, new HashSet<>());
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
@@ -365,7 +365,8 @@ public class SymbolTableBuilder extends BaseTreeVisitor {
       if (importFrom.isWildcardImport()) {
         Set<Symbol> importedModuleSymbols = projectLevelSymbolTable.getSymbolsFromModule(moduleName);
         if (importedModuleSymbols == null && moduleName != null && !moduleName.equals(fullyQualifiedModuleName)) {
-          importedModuleSymbols = TypeShed.symbolsForModule(moduleName);
+          importedModuleSymbols = TypeShed.symbolsForModule(moduleName).stream()
+            .map(importedSymbol -> currentScope().copySymbol(importedSymbol.name(), importedSymbol)).collect(Collectors.toSet());
         }
         if (importedModuleSymbols != null && !importedModuleSymbols.isEmpty()) {
           currentScope().createSymbolsFromWildcardImport(importedModuleSymbols, importFrom);

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolUtils.java
@@ -286,6 +286,6 @@ public class SymbolUtils {
     String[] fqnSplitByDot = fullyQualifiedName.split("\\.");
     String localName = fqnSplitByDot[fqnSplitByDot.length - 1];
     Symbol symbol = TypeShed.symbolWithFQN(fullyQualifiedName);
-    return symbol == null ? new SymbolImpl(localName, fullyQualifiedName) : symbol;
+    return symbol == null ? new SymbolImpl(localName, fullyQualifiedName) : ((SymbolImpl) symbol).copyWithoutUsages();
   }
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ClassSymbolImplTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ClassSymbolImplTest.java
@@ -241,7 +241,7 @@ public class ClassSymbolImplTest {
     ClassSymbolImpl classSymbol = new ClassSymbolImpl(classSymbol(protobuf));
     assertThat(classSymbol.name()).isEqualTo("A");
     assertThat(classSymbol.fullyQualifiedName()).isEqualTo("mod.A");
-    assertThat(classSymbol.superClasses()).containsExactly(TypeShed.typeShedClass("object"));
+    assertThat(classSymbol.superClasses()).extracting(Symbol::fullyQualifiedName).containsExactly("object");
     assertThat(classSymbol.hasDecorators()).isTrue();
     assertThat(classSymbol.hasMetaClass()).isTrue();
     assertThat(classSymbol.metaclassFQN()).isEqualTo("abc.ABCMeta");

--- a/python-frontend/src/test/java/org/sonar/python/types/TypeShedTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/TypeShedTest.java
@@ -66,7 +66,7 @@ public class TypeShedTest {
     assertThat(intClass.hasUnresolvedTypeHierarchy()).isFalse();
     assertThat(intClass.usages()).isEmpty();
     assertThat(intClass.declaredMembers()).allMatch(member -> member.usages().isEmpty());
-    assertThat(TypeShed.typeShedClass("bool").superClasses()).containsExactly(intClass);
+    assertThat(TypeShed.typeShedClass("bool").superClasses()).extracting(Symbol::fullyQualifiedName).containsExactly("int");
   }
 
   @Test
@@ -342,7 +342,7 @@ public class TypeShedTest {
       .containsExactlyInAnyOrder(tuple(Kind.CLASS, "mod.Base"), tuple(Kind.CLASS, "mod.C"), tuple(Kind.CLASS, "mod.D"));
 
     ClassSymbol C = (ClassSymbol) symbols.get("mod.C");
-    assertThat(C.superClasses()).containsExactly(TypeShed.typeShedClass("str"));
+    assertThat(C.superClasses()).extracting(Symbol::fullyQualifiedName).containsExactly("str");
     ClassSymbol D = (ClassSymbol) symbols.get("mod.D");
     assertThat(D.superClasses()).extracting(Symbol::kind, Symbol::fullyQualifiedName)
       .containsExactly(tuple(Kind.OTHER, "NOT_EXISTENT"));


### PR DESCRIPTION
Thanks to descriptors, symbols from the project symbol table are always new and shouldn't require any copy logic (`copyWithoutUsage` or `copySymbol`).

This PR also fix a bug when a descriptor within an ambiguous descriptor has a `null` FQN and cannot be retrieved properly by `createdSymbols`.