### PR TITLE
Simplify required header format for S1451 on ruling

### DIFF
--- a/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
@@ -53,12 +53,7 @@ public class PythonRulingTest {
   public static void prepare_quality_profile() {
     ProfileGenerator.RulesConfiguration parameters = new ProfileGenerator.RulesConfiguration()
       .add("CommentRegularExpression", "message", "The regular expression matches this comment")
-      .add("S1451","headerFormat" , "# Copyright 2004 by Harry Zuzan. All rights reserved.\n" +
-        "# Copyright 2016 by Adam Kurkiewicz. All rights reserved.\n" +
-        "# This file is part of the Biopython distribution and governed by your\n" +
-        "# choice of the \"Biopython License Agreement\" or the \"BSD 3-Clause License\".\n" +
-        "# Please see the LICENSE file that should have been included as part of this\n" +
-        "# package.");
+      .add("S1451","headerFormat" , "# Copyright 2004 by Harry Zuzan. All rights reserved.");
     String serverUrl = ORCHESTRATOR.getServer().getUrl();
     File profileFile = ProfileGenerator.generateProfile(serverUrl, "py", "python", parameters, Collections.emptySet());
     ORCHESTRATOR.getServer().restoreProfile(FileLocation.of(profileFile));


### PR DESCRIPTION
The previous header format used in the ruling test to validate S1451 was using hard-coded `\n` eol characters which were only valid if the analyzed file used unix-like line endings. This caused problem on Windows machines while not being necessary for the test, so I only kept the first line of the header, which is enough for the test.