### PR TITLE
SONARPY-1064 Enable test checks to run on project test files

### DIFF
--- a/its/plugin/it-python-plugin-test/profiles/profile-python-test-rules.xml
+++ b/its/plugin/it-python-plugin-test/profiles/profile-python-test-rules.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<profile>
+  <name>python-test-rules-profile</name>
+  <language>py</language>
+  <rules>
+    <rule>
+      <repositoryKey>python</repositoryKey>
+      <key>S5905</key>
+      <priority>INFO</priority>
+    </rule>
+    <rule>
+      <repositoryKey>python</repositoryKey>
+      <key>S3923</key>
+      <priority>INFO</priority>
+    </rule>
+  </rules>
+</profile>

--- a/its/plugin/it-python-plugin-test/projects/test_code/src/some_code.py
+++ b/its/plugin/it-python-plugin-test/projects/test_code/src/some_code.py
@@ -1,0 +1,6 @@
+def foo():
+    assert (a, b)  # Issue here (S5905 runs on all files)
+    if True:  # Issue here (S3923 runs on main files)
+        print("hello")
+    else:
+        print("hello")

--- a/its/plugin/it-python-plugin-test/projects/test_code/tests/test_my_code.py
+++ b/its/plugin/it-python-plugin-test/projects/test_code/tests/test_my_code.py
@@ -1,0 +1,7 @@
+def test_something():
+    assert 1 == 2
+    assert (a, b)  # Issue here (S5905)
+    if True:  # No issue here (S3923 doesn't run on test files)
+      print("hello")
+    else:
+      print("hello")

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
@@ -84,11 +84,6 @@ public class MetricsTest {
   }
 
   @Test
-  public void test_files_highlighted() {
-    assertThat(buildResult.getLogs()).contains("Starting test sources highlighting");
-  }
-
-  @Test
   public void project_level() {
     // Size
     assertThat(getProjectMeasureAsInt(NCLOC)).isEqualTo(6);

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestRulesTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestRulesTest.java
@@ -1,0 +1,77 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2012-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package com.sonar.python.it.plugin;
+
+import com.sonar.orchestrator.Orchestrator;
+import com.sonar.orchestrator.build.SonarScanner;
+import java.io.File;
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.sonarqube.ws.Issues;
+import org.sonarqube.ws.client.issues.SearchRequest;
+
+import static com.sonar.python.it.plugin.Tests.newWsClient;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TestRulesTest {
+
+  @ClassRule
+  public static Orchestrator orchestrator = Tests.ORCHESTRATOR;
+  private static final String PROJECT_KEY = "test-rules";
+  private static final String PROJECT_NAME = "Test Rules";
+
+  @BeforeClass
+  public static void prepare() {
+    orchestrator.getServer().provisionProject(PROJECT_KEY, PROJECT_NAME);
+    orchestrator.getServer().associateProjectToQualityProfile(PROJECT_KEY, "py", "python-test-rules-profile");
+    SonarScanner build = SonarScanner.create()
+      .setProjectDir(new File("projects/test_code"))
+      .setProjectKey(PROJECT_KEY)
+      .setProjectName(PROJECT_NAME)
+      .setProjectVersion("1.0")
+      .setSourceDirs("src")
+      .setTestDirs("tests");
+    orchestrator.executeBuild(build);
+  }
+
+  @Test
+  public void test_rules_run_on_test_files() {
+    List<Issues.Issue> testRuleIssues = issues("python:S5905");
+    List<Issues.Issue> mainRuleIssues = issues("python:S3923");
+    assertThat(testRuleIssues).hasSize(2);
+    assertThat(mainRuleIssues).hasSize(1);
+    assertIssue(testRuleIssues.get(0), 2, "Fix this assertion on a tuple literal.", "test-rules:src/some_code.py");
+    assertIssue(testRuleIssues.get(1), 3, "Fix this assertion on a tuple literal.", "test-rules:tests/test_my_code.py");
+    assertIssue(mainRuleIssues.get(0), 3, "Remove this if statement or edit its code blocks so that they're not all the same.", "test-rules:src/some_code.py");
+  }
+
+  private void assertIssue(Issues.Issue issue, int expectedLine, String expectedMessage, String expectedComponent) {
+    assertThat(issue.getLine()).isEqualTo(expectedLine);
+    assertThat(issue.getMessage()).isEqualTo(expectedMessage);
+    assertThat(issue.getComponent()).isEqualTo(expectedComponent);
+  }
+
+  private static List<Issues.Issue> issues(String rulekey) {
+    return newWsClient().issues().search(new SearchRequest().setRules(singletonList(rulekey))).getIssuesList();
+  }
+}

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/Tests.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/Tests.java
@@ -70,6 +70,7 @@ public final class Tests {
     // Custom rules plugin
     .addPlugin(FileLocation.byWildcardMavenFilename(new File("../python-custom-rules-plugin/target"), "python-custom-rules-plugin-*.jar"))
     .restoreProfileAtStartup(FileLocation.of("profiles/profile-python-custom-rules.xml"))
+    .restoreProfileAtStartup(FileLocation.of("profiles/profile-python-test-rules.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/no_rule.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/pylint.xml"))
     .restoreProfileAtStartup(FileLocation.of("profiles/nosonar.xml"))

--- a/python-checks/src/main/java/org/sonar/python/checks/tests/AssertOnTupleLiteralCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/tests/AssertOnTupleLiteralCheck.java
@@ -39,4 +39,9 @@ public class AssertOnTupleLiteralCheck extends PythonSubscriptionCheck {
       }
     });
   }
+
+  @Override
+  public CheckScope scope() {
+    return CheckScope.ALL;
+  }
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/tests/SkippedTestNoReasonCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/tests/SkippedTestNoReasonCheck.java
@@ -57,6 +57,11 @@ public class SkippedTestNoReasonCheck extends PythonSubscriptionCheck {
     });
   }
 
+  @Override
+  public CheckScope scope() {
+    return CheckScope.ALL;
+  }
+
   private static void checkDecoratorSkipWithoutReason(SubscriptionContext ctx, Decorator decorator) {
     Expression expression = decorator.expression();
     Symbol symbol = getSymbolFromExpression(expression);

--- a/python-checks/src/test/java/org/sonar/python/checks/tests/AssertOnTupleLiteralCheckTest.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/tests/AssertOnTupleLiteralCheckTest.java
@@ -20,12 +20,20 @@
 package org.sonar.python.checks.tests;
 
 import org.junit.Test;
+import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AssertOnTupleLiteralCheckTest {
   
   @Test
   public void test() {
     PythonCheckVerifier.verify("src/test/resources/checks/tests/assertOnTupleLiteral.py", new AssertOnTupleLiteralCheck());
+  }
+
+  @Test
+  public void test_scope() {
+    assertThat(new AssertOnTupleLiteralCheck().scope()).isEqualTo(PythonCheck.CheckScope.ALL);
   }
 }

--- a/python-checks/src/test/java/org/sonar/python/checks/tests/SkippedTestNoReasonCheckTest.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/tests/SkippedTestNoReasonCheckTest.java
@@ -20,7 +20,10 @@
 package org.sonar.python.checks.tests;
 
 import org.junit.Test;
+import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class SkippedTestNoReasonCheckTest {
 
@@ -32,6 +35,11 @@ public class SkippedTestNoReasonCheckTest {
   @Test
   public void testWithImport() {
     PythonCheckVerifier.verify("src/test/resources/checks/tests/skippedTestNoReasonWithImport.py", new SkippedTestNoReasonCheck());
+  }
+
+  @Test
+  public void test_scope() {
+    assertThat(new SkippedTestNoReasonCheck().scope()).isEqualTo(PythonCheck.CheckScope.ALL);
   }
 
 }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonCheck.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonCheck.java
@@ -85,4 +85,14 @@ public interface PythonCheck {
       return check;
     }
   }
+
+  enum CheckScope {
+    MAIN,
+    TEST,
+    ALL
+  }
+
+  default CheckScope scope() {
+    return CheckScope.MAIN;
+  }
 }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonCheck.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonCheck.java
@@ -88,7 +88,6 @@ public interface PythonCheck {
 
   enum CheckScope {
     MAIN,
-    TEST,
     ALL
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/PythonCheckTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/PythonCheckTest.java
@@ -125,4 +125,11 @@ public class PythonCheckTest {
     assertThat(secondSecondaryLocation.endLine()).isEqualTo(4);
     assertThat(secondSecondaryLocation.endLineOffset()).isEqualTo(5);
   }
+
+
+  @Test
+  public void test_scope() {
+    PythonVisitorCheck check = new PythonVisitorCheck() {};
+    assertThat(check.scope()).isEqualTo(PythonCheck.CheckScope.MAIN);
+  }
 }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
@@ -140,10 +140,7 @@ public class PythonScanner extends Scanner {
     if (checkScope == PythonCheck.CheckScope.ALL) {
       return true;
     }
-    if (checkScope == PythonCheck.CheckScope.MAIN) {
-      return fileType == InputFile.Type.MAIN;
-    }
-    return fileType == InputFile.Type.TEST;
+    return fileType == InputFile.Type.MAIN;
   }
 
   // visible for testing

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
@@ -97,11 +97,14 @@ public class PythonScanner extends Scanner {
   protected void scanFile(InputFile inputFile) {
     PythonFile pythonFile = SonarQubePythonFile.create(inputFile);
     PythonVisitorContext visitorContext;
+    InputFile.Type fileType = inputFile.type();
     try {
       AstNode astNode = parser.parse(pythonFile.content());
       FileInput parse = new PythonTreeMaker().fileInput(astNode);
       visitorContext = new PythonVisitorContext(parse, pythonFile, getWorkingDirectory(context), indexer.packageName(inputFile), indexer.projectLevelSymbolTable());
-      saveMeasures(inputFile, visitorContext);
+      if (fileType == InputFile.Type.MAIN) {
+        saveMeasures(inputFile, visitorContext);
+      }
     } catch (RecognitionException e) {
       visitorContext = new PythonVisitorContext(pythonFile, e);
       LOG.error("Unable to parse file: " + inputFile);
@@ -114,6 +117,9 @@ public class PythonScanner extends Scanner {
     }
     List<PythonSubscriptionCheck> checksBasedOnTree = new ArrayList<>();
     for (PythonCheck check : checks.all()) {
+      if (!isCheckApplicable(check, fileType)) {
+        continue;
+      }
       if (check instanceof PythonSubscriptionCheck) {
         checksBasedOnTree.add((PythonSubscriptionCheck) check);
       } else {
@@ -127,6 +133,17 @@ public class PythonScanner extends Scanner {
       new SymbolVisitor(context.newSymbolTable().onFile(inputFile)).visitFileInput(visitorContext.rootTree());
       new PythonHighlighter(context, inputFile).scanFile(visitorContext);
     }
+  }
+
+  boolean isCheckApplicable(PythonCheck pythonCheck, InputFile.Type fileType) {
+    PythonCheck.CheckScope checkScope = pythonCheck.scope();
+    if (checkScope == PythonCheck.CheckScope.ALL) {
+      return true;
+    }
+    if (checkScope == PythonCheck.CheckScope.MAIN) {
+      return fileType == InputFile.Type.MAIN;
+    }
+    return fileType == InputFile.Type.TEST;
   }
 
   // visible for testing

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -437,6 +437,7 @@ public class PythonSensorTest {
     assertThat(context.allIssues()).hasSize(1);
     Issue issue = context.allIssues().iterator().next();
     assertThat(issue.primaryLocation().inputComponent()).isEqualTo(inputFile);
+    assertThat(issue.ruleKey().rule()).isEqualTo("S5905");
   }
 
   @Test

--- a/sonar-python-plugin/src/test/resources/org/sonar/plugins/python/sensor/test_file.py
+++ b/sonar-python-plugin/src/test/resources/org/sonar/plugins/python/sensor/test_file.py
@@ -1,0 +1,3 @@
+def test_func(x):
+    x = 42
+    assert (a, b)


### PR DESCRIPTION
Some coverage is missing; it will be more convenient to add it when we merge a rule whose scope is `TEST`, such as [SONARPY-763](https://sonarsource.atlassian.net/browse/SONARPY-763) (Note: I believe we should specify explicitly which test rule can or cannot be run on main files, depending on our expectations of risk of FPs).