### PR TITLE
SONARPY-1150 Drop deprecated methods from 'AbstractCdkResourceCheck'

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
@@ -65,29 +65,13 @@ public abstract class AbstractCdkResourceCheck extends PythonSubscriptionCheck {
     fqnCallConsumers.put(fqn, consumer);
   }
 
-  protected static Optional<ArgumentTrace> getArgument(SubscriptionContext ctx, CallExpression callExpression, String argumentName) {
+  protected static Optional<ExpressionTrace> getArgument(SubscriptionContext ctx, CallExpression callExpression, String argumentName) {
     return callExpression.arguments().stream()
       .map(RegularArgument.class::cast)
       .filter(regularArgument -> regularArgument.keywordArgument() != null)
       .filter(regularArgument -> argumentName.equals(regularArgument.keywordArgument().name()))
-      .map(regularArgument -> ArgumentTrace.build(ctx, regularArgument.expression()))
+      .map(regularArgument -> ExpressionTrace.build(ctx, regularArgument.expression()))
       .findAny();
-  }
-
-  /**
-   * For compatibility with other classes and branches.
-   * TODO Can be removed at the end of the sprint to reduce complexity.
-   */
-  public static class ArgumentTrace extends ExpressionTrace {
-    private ArgumentTrace(SubscriptionContext ctx, List<Expression> trace) {
-      super(ctx, trace);
-    }
-
-    protected static ArgumentTrace build(SubscriptionContext ctx, Expression expression) {
-      List<Expression> trace = new ArrayList<>();
-      buildTrace(expression, trace);
-      return new ArgumentTrace(ctx, trace);
-    }
   }
 
   static class ExpressionTrace {
@@ -185,7 +169,7 @@ public abstract class AbstractCdkResourceCheck extends PythonSubscriptionCheck {
         return true;
       }
 
-      Optional<AbstractCdkResourceCheck.ArgumentTrace> argTrace = getArgument(ctx, (CallExpression) expression, argName);
+      Optional<AbstractCdkResourceCheck.ExpressionTrace> argTrace = getArgument(ctx, (CallExpression) expression, argName);
       if (argTrace.isEmpty()) {
         return true;
       }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
@@ -59,21 +59,10 @@ public abstract class AbstractCdkResourceCheck extends PythonSubscriptionCheck {
       .ifPresent(consumer -> consumer.accept(ctx, node));
   }
 
-  // TODO should be abstract when resourceFqn and visitResourceConstructor are dropped
-  protected void registerFqnConsumer() {
-    checkFqn(resourceFqn(), this::visitResourceConstructor);
-  }
+  protected abstract void registerFqnConsumer();
 
   protected void checkFqn(String fqn, BiConsumer<SubscriptionContext, CallExpression> consumer) {
     fqnCallConsumers.put(fqn, consumer);
-  }
-
-  protected String resourceFqn() {
-    throw new UnsupportedOperationException("Override at least resourceFqn or registerFqnConsumer");
-  }
-
-  protected void visitResourceConstructor(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    throw new UnsupportedOperationException("When using resourceFqn override this method");
   }
 
   protected static Optional<ArgumentTrace> getArgument(SubscriptionContext ctx, CallExpression callExpression, String argumentName) {

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractCdkResourceCheck.java
@@ -19,23 +19,24 @@
  */
 package org.sonar.python.checks.cdk;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Predicate;
 import org.sonar.plugins.python.api.PythonSubscriptionCheck;
 import org.sonar.plugins.python.api.SubscriptionCheck;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.CallExpression;
-import org.sonar.plugins.python.api.tree.Expression;
-import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.Tree;
-import org.sonar.python.tree.TreeUtils;
 
-import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
-
+/**
+ * Since most CDK related checks check arguments of method calls or object initializations,
+ * this abstract class can be used to register CallExpression consumers for various fully qualified names.
+ * For this purpose the method {@link #checkFqn(String, BiConsumer)} or {@link #checkFqns(Collection, BiConsumer)}
+ * must be called in the {@link #registerFqnConsumer()} method which has to be implemented.
+ */
 public abstract class AbstractCdkResourceCheck extends PythonSubscriptionCheck {
 
   private final Map<String, BiConsumer<SubscriptionContext, CallExpression>> fqnCallConsumers = new HashMap<>();
@@ -56,8 +57,18 @@ public abstract class AbstractCdkResourceCheck extends PythonSubscriptionCheck {
 
   protected abstract void registerFqnConsumer();
 
+  /**
+   * Register a consumer for a single FQN
+   */
   protected void checkFqn(String fqn, BiConsumer<SubscriptionContext, CallExpression> consumer) {
     fqnCallConsumers.put(fqn, consumer);
+  }
+
+  /**
+   * Register a consumer for multiple FQNs
+   */
+  protected void checkFqns(Collection<String> suffixes, BiConsumer<SubscriptionContext, CallExpression> consumer) {
+    suffixes.forEach(suffix -> checkFqn(suffix, consumer));
   }
 
 

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractS3BucketCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/AbstractS3BucketCheck.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.checks.cdk;
 
+import java.util.function.BiConsumer;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
 
@@ -27,14 +28,9 @@ public abstract class AbstractS3BucketCheck extends AbstractCdkResourceCheck {
   protected static final String S3_BUCKET_FQN = "aws_cdk.aws_s3.Bucket";
 
   @Override
-  protected String resourceFqn() {
-    return S3_BUCKET_FQN;
+  protected void registerFqnConsumer() {
+    checkFqn(S3_BUCKET_FQN, this.visitBucketConstructor());
   }
 
-  @Override
-  protected void visitResourceConstructor(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    visitBucketConstructor(ctx, resourceConstructor);
-  }
-
-  abstract void visitBucketConstructor(SubscriptionContext ctx, CallExpression bucket);
+  abstract BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor();
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
@@ -1,0 +1,64 @@
+package org.sonar.python.checks.cdk;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.function.Predicate;
+import org.sonar.plugins.python.api.SubscriptionContext;
+import org.sonar.plugins.python.api.tree.CallExpression;
+import org.sonar.plugins.python.api.tree.Expression;
+import org.sonar.plugins.python.api.tree.Token;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.tree.TreeUtils;
+
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
+public class CdkPredicate {
+
+  private CdkPredicate() {
+
+  }
+
+  public static Predicate<Expression> isFalse() {
+    return expression -> Optional.ofNullable(expression.firstToken()).map(Token::value).filter("False"::equals).isPresent();
+  }
+
+  public static Predicate<Expression> isNone() {
+    return expression -> expression.is(Tree.Kind.NONE);
+  }
+
+  public static Predicate<Expression> isFqn(String fqnValue) {
+    return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
+      .filter(fqnValue::equals)
+      .isPresent();
+  }
+
+  /**
+   * @return Predicate which tests if expression is a string and is equal the expected value
+   */
+  public static Predicate<Expression> isStringValue(String expectedValue) {
+    return expression -> CdkUtils.getStringValue(expression).filter(expectedValue::equals).isPresent();
+  }
+
+  public static Predicate<Expression> isSensitiveMethod(SubscriptionContext ctx, String methodFqn, String argName, Predicate<Expression> sensitiveValuePredicate) {
+    return expression -> {
+      if (!isFqn(methodFqn).test(expression)) {
+        return false;
+      }
+      if (!expression.is(Tree.Kind.CALL_EXPR)) {
+        return true;
+      }
+
+      Optional<CdkUtils.ExpressionTrace> argTrace = getArgument(ctx, (CallExpression) expression, argName);
+      if (argTrace.isEmpty()) {
+        return true;
+      }
+
+      return argTrace.filter(trace -> trace.hasExpression(sensitiveValuePredicate)).isPresent();
+    };
+  }
+
+  public static Predicate<Expression> startsWith(String expected) {
+    return e -> CdkUtils.getStringValue(e).filter(str -> str.toLowerCase(Locale.ROOT).startsWith(expected)).isPresent();
+  }
+
+}

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
@@ -37,14 +37,23 @@ public class CdkPredicate {
 
   }
 
+  /**
+   * @return Predicate which tests if expression is boolean literal and is set to `false`
+   */
   public static Predicate<Expression> isFalse() {
     return expression -> Optional.ofNullable(expression.firstToken()).map(Token::value).filter("False"::equals).isPresent();
   }
 
+  /**
+   * @return Predicate which tests if expression is `none`
+   */
   public static Predicate<Expression> isNone() {
     return expression -> expression.is(Tree.Kind.NONE);
   }
 
+  /**
+   * @return Predicate which tests if expression is a fully qualified name (FQN) and is equal the expected FQN
+   */
   public static Predicate<Expression> isFqn(String fqnValue) {
     return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
       .filter(fqnValue::equals)
@@ -54,10 +63,19 @@ public class CdkPredicate {
   /**
    * @return Predicate which tests if expression is a string and is equal the expected value
    */
-  public static Predicate<Expression> isStringValue(String expectedValue) {
-    return expression -> CdkUtils.getStringValue(expression).filter(expectedValue::equals).isPresent();
+  public static Predicate<Expression> isString(String expectedValue) {
+    return expression -> CdkUtils.getString(expression).filter(expectedValue::equals).isPresent();
   }
 
+  /**
+   * @return Predicate which tests if expression is a string and starts with the expected value
+   */
+  public static Predicate<Expression> startsWith(String expected) {
+    return expression -> CdkUtils.getString(expression).filter(str -> str.toLowerCase(Locale.ROOT).startsWith(expected)).isPresent();
+  }
+
+  // TODO refactor this overloaded predicate method
+  // FIXME we should not raise on a FQN which is not a method call when we want to check for a sensitive method call
   public static Predicate<Expression> isSensitiveMethod(SubscriptionContext ctx, String methodFqn, String argName, Predicate<Expression> sensitiveValuePredicate) {
     return expression -> {
       if (!isFqn(methodFqn).test(expression)) {
@@ -74,10 +92,6 @@ public class CdkPredicate {
 
       return argTrace.filter(trace -> trace.hasExpression(sensitiveValuePredicate)).isPresent();
     };
-  }
-
-  public static Predicate<Expression> startsWith(String expected) {
-    return e -> CdkUtils.getStringValue(e).filter(str -> str.toLowerCase(Locale.ROOT).startsWith(expected)).isPresent();
   }
 
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.checks.cdk;
 
+import java.util.Collection;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -57,6 +58,15 @@ public class CdkPredicate {
   public static Predicate<Expression> isFqn(String fqnValue) {
     return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
       .filter(fqnValue::equals)
+      .isPresent();
+  }
+
+  /**
+   * @return Predicate which tests if expression is a fully qualified name (FQN) and part of the FQN list
+   */
+  public static Predicate<Expression> isFqnOf(Collection<String> fqnValues) {
+    return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
+      .filter(fqnValues::contains)
       .isPresent();
   }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.python.checks.cdk;
 
 import java.util.Locale;

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
@@ -1,0 +1,159 @@
+package org.sonar.python.checks.cdk;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import javax.annotation.CheckForNull;
+import org.sonar.plugins.python.api.PythonCheck;
+import org.sonar.plugins.python.api.SubscriptionContext;
+import org.sonar.plugins.python.api.tree.CallExpression;
+import org.sonar.plugins.python.api.tree.DictionaryLiteral;
+import org.sonar.plugins.python.api.tree.DictionaryLiteralElement;
+import org.sonar.plugins.python.api.tree.Expression;
+import org.sonar.plugins.python.api.tree.KeyValuePair;
+import org.sonar.plugins.python.api.tree.ListLiteral;
+import org.sonar.plugins.python.api.tree.Name;
+import org.sonar.plugins.python.api.tree.NumericLiteral;
+import org.sonar.plugins.python.api.tree.RegularArgument;
+import org.sonar.plugins.python.api.tree.StringLiteral;
+import org.sonar.plugins.python.api.tree.Tree;
+import org.sonar.python.checks.Expressions;
+
+public class CdkUtils {
+
+  public CdkUtils() {
+  }
+
+  public static Optional<Integer> getIntValue(Expression expression) {
+    try {
+      return Optional.of((int)((NumericLiteral) expression).valueAsLong());
+    } catch (ClassCastException e) {
+      return Optional.empty();
+    }
+  }
+
+  public static Optional<String> getStringValue(Expression expression) {
+    try {
+      return Optional.of(((StringLiteral) expression).trimmedQuotesValue());
+    } catch (ClassCastException e) {
+      return Optional.empty();
+    }
+  }
+
+  protected static Optional<ExpressionTrace> getArgument(SubscriptionContext ctx, CallExpression callExpression, String argumentName) {
+    return callExpression.arguments().stream()
+      .map(RegularArgument.class::cast)
+      .filter(regularArgument -> regularArgument.keywordArgument() != null)
+      .filter(regularArgument -> argumentName.equals(regularArgument.keywordArgument().name()))
+      .map(regularArgument -> ExpressionTrace.build(ctx, regularArgument.expression()))
+      .findAny();
+  }
+
+  public static Optional<ListLiteral> getArgumentList(SubscriptionContext ctx, CallExpression call, String argumentName) {
+    return getArgument(ctx, call, argumentName)
+      .flatMap(arg -> arg.getExpression(e -> e.is(Tree.Kind.LIST_LITERAL)))
+      .map(ListLiteral.class::cast);
+
+  }
+
+  public static class ExpressionTrace {
+
+    private static final String TAIL_MESSAGE = "Propagated setting.";
+
+    private final SubscriptionContext ctx;
+    private final List<Expression> trace;
+
+    private ExpressionTrace(SubscriptionContext ctx, List<Expression> trace) {
+      this.ctx = ctx;
+      this.trace = Collections.unmodifiableList(trace);
+    }
+    protected static ExpressionTrace build(SubscriptionContext ctx, Expression expression) {
+      List<Expression> trace = new ArrayList<>();
+      buildTrace(expression, trace);
+      return new ExpressionTrace(ctx, trace);
+    }
+
+    static void buildTrace(Expression expression, List<Expression> trace) {
+      trace.add(expression);
+      if (expression.is(Tree.Kind.NAME)) {
+        Expression singleAssignedValue = Expressions.singleAssignedValue(((Name) expression));
+        if (singleAssignedValue != null && !trace.contains(singleAssignedValue)) {
+          buildTrace(singleAssignedValue, trace);
+        }
+      }
+    }
+
+    public void addIssue(String primaryMessage) {
+      PythonCheck.PreciseIssue issue = ctx.addIssue(trace.get(0).parent(), primaryMessage);
+      trace.stream().skip(1).forEach(expression -> issue.secondary(expression.parent(), TAIL_MESSAGE));
+    }
+
+    public void addIssueIf(Predicate<Expression> predicate, String primaryMessage) {
+      if (hasExpression(predicate)) {
+        addIssue(primaryMessage);
+      }
+    }
+
+    public void addIssueIf(Predicate<Expression> predicate, String primaryMessage, CallExpression call) {
+      if (hasExpression(predicate)) {
+        ctx.addIssue(call.callee(), primaryMessage);
+      }
+    }
+
+    public boolean hasExpression(Predicate<Expression> predicate) {
+      return trace.stream().anyMatch(predicate);
+    }
+
+    public Optional<Expression> getExpression(Predicate<Expression> predicate) {
+      return trace.stream().filter(predicate).findFirst();
+    }
+
+    public List<Expression> trace() {
+      return trace;
+    }
+  }
+
+  // ---------------------------------------------------------------------------------------
+  // Dictionary related utils
+  // ---------------------------------------------------------------------------------------
+
+  @CheckForNull
+  public static KeyValuePair getKeyValuePair(DictionaryLiteralElement element) {
+    return element.is(Tree.Kind.KEY_VALUE_PAIR) ? (KeyValuePair) element : null;
+  }
+
+  public static List<DictionaryLiteral> getDictionaryInList(SubscriptionContext ctx, ListLiteral listeners) {
+    return getListElements(ctx, listeners).stream()
+      .map(elm -> elm.getExpression(expr -> expr.is(Tree.Kind.DICTIONARY_LITERAL)))
+      .flatMap(Optional::stream)
+      .map(DictionaryLiteral.class::cast)
+      .collect(Collectors.toList());
+  }
+
+  private static List<ExpressionTrace> getListElements(SubscriptionContext ctx, ListLiteral list) {
+    return list.elements().expressions().stream()
+      .map(expression -> ExpressionTrace.build(ctx, expression))
+      .collect(Collectors.toList());
+  }
+
+  /**
+   * Dataclass to store a resolved KeyValuePair structure
+   */
+  static class ResolvedKeyValuePair {
+
+    final ExpressionTrace key;
+    final ExpressionTrace value;
+
+    private ResolvedKeyValuePair(ExpressionTrace key, ExpressionTrace value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    static ResolvedKeyValuePair build(SubscriptionContext ctx, KeyValuePair pair) {
+      return new ResolvedKeyValuePair(ExpressionTrace.build(ctx, pair.key()), ExpressionTrace.build(ctx, pair.value()));
+    }
+  }
+}

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
@@ -1,3 +1,22 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2022 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
 package org.sonar.python.checks.cdk;
 
 import java.util.ArrayList;

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
@@ -43,7 +43,7 @@ import org.sonar.python.checks.Expressions;
 
 public class CdkUtils {
 
-  public CdkUtils() {
+  private CdkUtils() {
   }
 
   public static Optional<Integer> getIntValue(Expression expression) {

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkUtils.java
@@ -58,6 +58,9 @@ public class CdkUtils {
     }
   }
 
+  /**
+   * Resolve a particular argument of a call or get an empty optional if the argument is not set.
+   */
   protected static Optional<ExpressionTrace> getArgument(SubscriptionContext ctx, CallExpression callExpression, String argumentName) {
     return callExpression.arguments().stream()
       .map(RegularArgument.class::cast)
@@ -67,10 +70,20 @@ public class CdkUtils {
       .findAny();
   }
 
+  /**
+   * Resolve the key and value of a dictionary element or get an empty optional if the element is an UnpackingExpression.
+   */
   public static Optional<ResolvedKeyValuePair> getKeyValuePair(SubscriptionContext ctx, DictionaryLiteralElement element) {
     return element.is(Tree.Kind.KEY_VALUE_PAIR) ? Optional.of(ResolvedKeyValuePair.build(ctx, (KeyValuePair) element)) : Optional.empty();
   }
 
+  /**
+   * The expression trace reflects the complete flow of a value across the code.
+   * It serves as a resolution path from the use of the expression up to the value assignment.
+   * For example, if the value of an argument expression did not occur directly in the function call, the value can be traced back.
+   * The trace allows on the one hand to check the assigned value
+   * and on the other hand to display the assignment path of the relevant value when creating an issue.
+   */
   static class ExpressionTrace {
 
     private static final String TAIL_MESSAGE = "Propagated setting.";

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
@@ -26,19 +26,20 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
-import javax.annotation.CheckForNull;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
 import org.sonar.plugins.python.api.tree.DictionaryLiteral;
-import org.sonar.plugins.python.api.tree.DictionaryLiteralElement;
 import org.sonar.plugins.python.api.tree.Expression;
-import org.sonar.plugins.python.api.tree.KeyValuePair;
 import org.sonar.plugins.python.api.tree.ListLiteral;
-import org.sonar.plugins.python.api.tree.NumericLiteral;
-import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.tree.TreeUtils;
+
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkPredicate.isFqn;
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+import static org.sonar.python.checks.cdk.CdkPredicate.isStringValue;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgumentList;
 
 public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
 
@@ -116,7 +117,7 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
     // or `aws_cdk.aws_elasticloadbalancing.LoadBalancingProtocol.HTTP`.
     checkFqn(Elb.prefix("LoadBalancer"), (ctx, call) ->
       getArgumentList(ctx, call, LISTENERS).ifPresent(
-        listeners -> getDictionaryInList(ctx, listeners)
+        listeners -> CdkUtils.getDictionaryInList(ctx, listeners)
           .forEach(dict -> checkLoadBalancerListenerDict(ctx, dict))));
 
 
@@ -124,7 +125,7 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
     // that contains a dict with a `protocol` argument set to `http` or `tcp`.
     checkFqn(Elb.prefix("CfnLoadBalancer"), (ctx, call) ->
       getArgumentList(ctx, call, LISTENERS).ifPresent(
-        listeners -> getDictionaryInList(ctx, listeners)
+        listeners -> CdkUtils.getDictionaryInList(ctx, listeners)
           .forEach(dict -> checkCfnLoadBalancerListenerDict(ctx, dict))));
 
     // Raise an issue if a CfnLoadBalancer is instantiated with the `protocol` argument set to `http` or `tcp`.
@@ -191,53 +192,12 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
   }
 
   private static void checkKeyValuePair(SubscriptionContext ctx, DictionaryLiteral dict, String key, Predicate<Expression> expected) {
-    dict.elements().stream().map(ClearTextProtocolsCheckPart::getKeyValuePair).filter(Objects::nonNull)
-      .map(pair -> ResolvedKeyValuePair.build(ctx, pair))
+    dict.elements().stream().map(CdkUtils::getKeyValuePair).filter(Objects::nonNull)
+      .map(pair -> CdkUtils.ResolvedKeyValuePair.build(ctx, pair))
       .filter(pair -> pair.key.hasExpression(isStringValue(key)))
       .forEach(pair -> pair.value.addIssueIf(expected, LB_MESSAGE));
   }
 
-  // ---------------------------------------------------------------------------------------
-  // General expression utils
-  // ---------------------------------------------------------------------------------------
-
-  private static Optional<Integer> getIntValue(Expression expression) {
-    try {
-      return Optional.of((int)((NumericLiteral) expression).valueAsLong());
-    } catch (ClassCastException e) {
-      return Optional.empty();
-    }
-  }
-
-  private static Optional<ListLiteral> getArgumentList(SubscriptionContext ctx, CallExpression call, String argumentName) {
-    return getArgument(ctx, call, argumentName)
-      .flatMap(arg -> arg.getExpression(e -> e.is(Tree.Kind.LIST_LITERAL)))
-      .map(ListLiteral.class::cast);
-
-  }
-
-  // ---------------------------------------------------------------------------------------
-  // Rule related utils
-  // ---------------------------------------------------------------------------------------
-
-  @CheckForNull
-  public static KeyValuePair getKeyValuePair(DictionaryLiteralElement element) {
-    return element.is(Tree.Kind.KEY_VALUE_PAIR) ? (KeyValuePair) element : null;
-  }
-
-  private static List<DictionaryLiteral> getDictionaryInList(SubscriptionContext ctx, ListLiteral listeners) {
-    return getListElements(ctx, listeners).stream()
-      .map(elm -> elm.getExpression(expr -> expr.is(Tree.Kind.DICTIONARY_LITERAL)))
-      .flatMap(Optional::stream)
-      .map(DictionaryLiteral.class::cast)
-      .collect(Collectors.toList());
-  }
-
-  private static List<ExpressionTrace> getListElements(SubscriptionContext ctx, ListLiteral list) {
-    return list.elements().expressions().stream()
-      .map(expression -> ExpressionTrace.build(ctx, expression))
-      .collect(Collectors.toList());
-  }
 
   // ---------------------------------------------------------------------------------------
   // General predicates
@@ -258,7 +218,7 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
    * @return Predicate which tests if expression is a string and is listed in sensitive transport protocol list
    */
   private static Predicate<Expression> isSensitiveTransportProtocol(Collection<String> transportProtocols) {
-    return expression -> getStringValue(expression).filter(transportProtocols::contains).isPresent();
+    return expression -> CdkUtils.getStringValue(expression).filter(transportProtocols::contains).isPresent();
   }
 
   /**
@@ -273,24 +233,8 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
    * @return Predicate which tests if expression is an integer and is in sensitive port list
    */
   private static Predicate<Expression> isHttpProtocolPort() {
-    return expression -> getIntValue(expression).filter(HTTP_PROTOCOL_PORTS::contains).isPresent();
+    return expression -> CdkUtils.getIntValue(expression).filter(HTTP_PROTOCOL_PORTS::contains).isPresent();
   }
 
-  /**
-   * Dataclass to store a resolved KeyValuePair structure
-   */
-  static class ResolvedKeyValuePair {
 
-    final ExpressionTrace key;
-    final ExpressionTrace value;
-
-    private ResolvedKeyValuePair(ExpressionTrace key, ExpressionTrace value) {
-      this.key = key;
-      this.value = value;
-    }
-
-    static ResolvedKeyValuePair build(SubscriptionContext ctx, KeyValuePair pair) {
-      return new ResolvedKeyValuePair(ExpressionTrace.build(ctx, pair.key()), ExpressionTrace.build(ctx, pair.value()));
-    }
-  }
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.sonar.plugins.python.api.SubscriptionContext;
@@ -94,12 +93,6 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
 
   private static final Set<Integer> HTTP_PROTOCOL_PORTS = Set.of(80, 8080, 8000, 8008);
 
-  /**
-   * Register a consumer for multiple FQNs
-   */
-  private void checkFqns(Collection<String> suffixes, BiConsumer<SubscriptionContext, CallExpression> consumer) {
-    suffixes.forEach(suffix -> checkFqn(suffix, consumer));
-  }
 
   @Override
   protected void registerFqnConsumer() {

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledEFSEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledEFSEncryptionCheck.java
@@ -21,6 +21,9 @@ package org.sonar.python.checks.cdk;
 
 import org.sonar.check.Rule;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+
 @Rule(key = "S6332")
 public class DisabledEFSEncryptionCheck extends AbstractCdkResourceCheck {
 
@@ -30,12 +33,12 @@ public class DisabledEFSEncryptionCheck extends AbstractCdkResourceCheck {
   @Override
   protected void registerFqnConsumer() {
     checkFqn("aws_cdk.aws_efs.FileSystem", (ctx, fileSystem) ->
-      getArgument(ctx, fileSystem, "encrypted").ifPresent(
+      CdkUtils.getArgument(ctx, fileSystem, "encrypted").ifPresent(
         encrypted -> encrypted.addIssueIf(isFalse(), MESSAGE)
       ));
 
     checkFqn("aws_cdk.aws_efs.CfnFileSystem", (ctx, fileSystem) ->
-      getArgument(ctx, fileSystem, "encrypted").ifPresentOrElse(
+      CdkUtils.getArgument(ctx, fileSystem, "encrypted").ifPresentOrElse(
         encrypted -> encrypted.addIssueIf(isFalse().or(isNone()), MESSAGE),
         () -> ctx.addIssue(fileSystem.callee(), OMITTING_MESSAGE)
       ));

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledESDomainEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledESDomainEncryptionCheck.java
@@ -118,6 +118,6 @@ public class DisabledESDomainEncryptionCheck extends AbstractCdkResourceCheck {
   }
 
   private static Predicate<KeyValuePair> isValueFalse(SubscriptionContext ctx) {
-    return keyValuePair -> ArgumentTrace.build(ctx, keyValuePair.value()).hasExpression(isFalse());
+    return keyValuePair -> ExpressionTrace.build(ctx, keyValuePair.value()).hasExpression(isFalse());
   }
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
@@ -19,13 +19,14 @@
  */
 package org.sonar.python.checks.cdk;
 
-import java.util.Locale;
 import java.util.Optional;
-import java.util.function.Predicate;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
-import org.sonar.plugins.python.api.tree.Expression;
+
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+import static org.sonar.python.checks.cdk.CdkPredicate.startsWith;
 
 @Rule(key = "S6303")
 public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
@@ -48,8 +49,8 @@ public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
   }
 
   protected void checkDatabaseArguments(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    Optional<ExpressionTrace> argEncrypted = getArgument(ctx, resourceConstructor, ARG_ENCRYPTED);
-    Optional<ExpressionTrace> argEncryptionKey = getArgument(ctx, resourceConstructor, ARG_ENCRYPTION_KEY);
+    Optional<CdkUtils.ExpressionTrace> argEncrypted = CdkUtils.getArgument(ctx, resourceConstructor, ARG_ENCRYPTED);
+    Optional<CdkUtils.ExpressionTrace> argEncryptionKey = CdkUtils.getArgument(ctx, resourceConstructor, ARG_ENCRYPTION_KEY);
 
     if (argEncrypted.isEmpty() && argEncryptionKey.isEmpty()) {
       ctx.addIssue(resourceConstructor.callee(), DB_OMITTING_MESSAGE);
@@ -66,19 +67,15 @@ public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
   }
 
   protected void checkCfnDatabaseArguments(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    getArgument(ctx, resourceConstructor, ARG_ENCRYPTED).ifPresentOrElse(
+    CdkUtils.getArgument(ctx, resourceConstructor, ARG_ENCRYPTED).ifPresentOrElse(
       argumentTrace -> argumentTrace.addIssueIf(isFalse(), UNENCRYPTED_MESSAGE),
       () -> ctx.addIssue(resourceConstructor.callee(), CFNDB_OMITTING_MESSAGE)
     );
   }
 
   protected boolean isEngineAurora(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    return getArgument(ctx, resourceConstructor, "engine")
+    return CdkUtils.getArgument(ctx, resourceConstructor, "engine")
       .filter(argumentTrace -> argumentTrace.hasExpression(startsWith("aurora"))).isPresent();
-  }
-
-  protected Predicate<Expression> startsWith(String expected) {
-    return e -> getStringValue(e).filter(str -> str.toLowerCase(Locale.ROOT).startsWith(expected)).isPresent();
   }
 }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
@@ -26,8 +26,6 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
 import org.sonar.plugins.python.api.tree.Expression;
-import org.sonar.plugins.python.api.tree.StringLiteral;
-import org.sonar.plugins.python.api.tree.Tree;
 
 @Rule(key = "S6303")
 public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
@@ -50,8 +48,8 @@ public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
   }
 
   protected void checkDatabaseArguments(SubscriptionContext ctx, CallExpression resourceConstructor) {
-    Optional<ArgumentTrace> argEncrypted = getArgument(ctx, resourceConstructor, ARG_ENCRYPTED);
-    Optional<ArgumentTrace> argEncryptionKey = getArgument(ctx, resourceConstructor, ARG_ENCRYPTION_KEY);
+    Optional<ExpressionTrace> argEncrypted = getArgument(ctx, resourceConstructor, ARG_ENCRYPTED);
+    Optional<ExpressionTrace> argEncryptionKey = getArgument(ctx, resourceConstructor, ARG_ENCRYPTION_KEY);
 
     if (argEncrypted.isEmpty() && argEncryptionKey.isEmpty()) {
       ctx.addIssue(resourceConstructor.callee(), DB_OMITTING_MESSAGE);

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledRDSEncryptionCheck.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.checks.cdk;
 
+import java.util.List;
 import java.util.Optional;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
@@ -38,9 +39,9 @@ public class DisabledRDSEncryptionCheck extends AbstractCdkResourceCheck {
 
   @Override
   protected void registerFqnConsumer() {
-    checkFqn("aws_cdk.aws_rds.DatabaseCluster", this::checkDatabaseArguments);
-    checkFqn("aws_cdk.aws_rds.DatabaseInstance", this::checkDatabaseArguments);
-    checkFqn("aws_cdk.aws_rds.CfnDBCluster", this::checkCfnDatabaseArguments);
+    checkFqns(List.of("aws_cdk.aws_rds.DatabaseCluster", "aws_cdk.aws_rds.DatabaseInstance", "aws_cdk.aws_rds.CfnDBCluster"),
+      this::checkDatabaseArguments);
+
     checkFqn("aws_cdk.aws_rds.CfnDBInstance", (subscriptionContext, callExpression) -> {
       if (!isEngineAurora(subscriptionContext, callExpression)) {
         checkCfnDatabaseArguments(subscriptionContext, callExpression);

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledSNSTopicEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/DisabledSNSTopicEncryptionCheck.java
@@ -24,6 +24,9 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
 @Rule(key = "S6327")
 public class DisabledSNSTopicEncryptionCheck extends AbstractCdkResourceCheck {
   private static final String OMITTING_MESSAGE = "Omitting \"%s\" disables SNS topics encryption. Make sure it is safe here.";
@@ -38,8 +41,7 @@ public class DisabledSNSTopicEncryptionCheck extends AbstractCdkResourceCheck {
     return (ctx, callExpression) -> getArgument(ctx, callExpression, argMasterKeyName)
       .ifPresentOrElse(
         argMasterKey -> argMasterKey.addIssueIf(isNone(), omittingMessage(argMasterKeyName)),
-        () -> ctx.addIssue(callExpression.callee(), omittingMessage(argMasterKeyName))
-      );
+        () -> ctx.addIssue(callExpression.callee(), omittingMessage(argMasterKeyName)));
   }
 
   private static String omittingMessage(String argName) {

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.checks.cdk;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -43,7 +42,7 @@ public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
 
   private static final String BLOCK_PUBLIC_ACCESS_FQN = "aws_cdk.aws_s3.BlockPublicAccess";
   private static final String BLOCK_ACLS_FQN = BLOCK_PUBLIC_ACCESS_FQN + ".BLOCK_ACLS";
-  private static final List<String> BLOCK_PUBLIC_ACCESS_ARGUMENTS = Arrays.asList(
+  private static final List<String> BLOCK_PUBLIC_ACCESS_ARGUMENTS = List.of(
     "block_public_acls",
     "ignore_public_acls",
     "block_public_policy",

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
@@ -32,6 +32,9 @@ import org.sonar.plugins.python.api.tree.Expression;
 import org.sonar.plugins.python.api.tree.QualifiedExpression;
 import org.sonar.plugins.python.api.tree.Tree;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
 @Rule(key = "S6281")
 public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
 
@@ -49,7 +52,7 @@ public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
   @Override
   BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
     return (ctx, bucket) -> {
-      Optional<ExpressionTrace> blockPublicAccess = getArgument(ctx, bucket, "block_public_access");
+      Optional<CdkUtils.ExpressionTrace> blockPublicAccess = getArgument(ctx, bucket, "block_public_access");
       if (blockPublicAccess.isPresent()) {
         checkBlockPublicAccess(ctx, blockPublicAccess.get());
       } else {
@@ -58,7 +61,7 @@ public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
     };
   }
 
-  private static void checkBlockPublicAccess(SubscriptionContext ctx, ExpressionTrace blockPublicAccess) {
+  private static void checkBlockPublicAccess(SubscriptionContext ctx, CdkUtils.ExpressionTrace blockPublicAccess) {
     blockPublicAccess.addIssueIf(S3BucketBlockPublicAccessCheck::blocksAclsOnly, MESSAGE);
     blockPublicAccess.trace().stream().filter(CallExpression.class::isInstance).map(CallExpression.class::cast)
       .filter(S3BucketBlockPublicAccessCheck::isBlockPublicAccessConstructor)

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketBlockPublicAccessCheck.java
@@ -49,7 +49,7 @@ public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
   @Override
   BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
     return (ctx, bucket) -> {
-      Optional<ArgumentTrace> blockPublicAccess = getArgument(ctx, bucket, "block_public_access");
+      Optional<ExpressionTrace> blockPublicAccess = getArgument(ctx, bucket, "block_public_access");
       if (blockPublicAccess.isPresent()) {
         checkBlockPublicAccess(ctx, blockPublicAccess.get());
       } else {
@@ -58,7 +58,7 @@ public class S3BucketBlockPublicAccessCheck extends AbstractS3BucketCheck {
     };
   }
 
-  private static void checkBlockPublicAccess(SubscriptionContext ctx, ArgumentTrace blockPublicAccess) {
+  private static void checkBlockPublicAccess(SubscriptionContext ctx, ExpressionTrace blockPublicAccess) {
     blockPublicAccess.addIssueIf(S3BucketBlockPublicAccessCheck::blocksAclsOnly, MESSAGE);
     blockPublicAccess.trace().stream().filter(CallExpression.class::isInstance).map(CallExpression.class::cast)
       .filter(S3BucketBlockPublicAccessCheck::isBlockPublicAccessConstructor)

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketGrantedAccessCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketGrantedAccessCheck.java
@@ -22,6 +22,7 @@ package org.sonar.python.checks.cdk;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
@@ -71,7 +72,7 @@ public class S3BucketGrantedAccessCheck extends AbstractS3BucketCheck {
     symbol
       .map(Symbol::fullyQualifiedName)
       .filter(S3_BUCKET_FQNS::contains)
-      .ifPresent(s -> visitBucketConstructor(ctx, node));
+      .ifPresent(s -> visitBucketConstructor().accept(ctx, node));
 
     if (isAwsCdkImported) {
       symbol
@@ -82,8 +83,8 @@ public class S3BucketGrantedAccessCheck extends AbstractS3BucketCheck {
   }
 
   @Override
-  void visitBucketConstructor(SubscriptionContext ctx, CallExpression bucket) {
-    getArgument(ctx, bucket, "access_control")
+  BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
+    return (ctx, bucket) -> getArgument(ctx, bucket, "access_control")
       .ifPresent(argument -> argument.addIssueIf(this::isSensitivePolicy, getSensitivePolicyMessage(argument)));
   }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketServerEncryptionCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketServerEncryptionCheck.java
@@ -39,11 +39,11 @@ public class S3BucketServerEncryptionCheck extends AbstractS3BucketCheck {
   @Override
   BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
     return (ctx, bucket) -> {
-      Optional<ArgumentTrace> optEncryptionType = getArgument(ctx, bucket, "encryption");
+      Optional<ExpressionTrace> optEncryptionType = getArgument(ctx, bucket, "encryption");
       if (optEncryptionType.isPresent()) {
         optEncryptionType.ifPresent(argumentTrace -> argumentTrace.addIssueIf(S3BucketServerEncryptionCheck::isUnencrypted, MESSAGE));
       } else {
-        Optional<ArgumentTrace> optEncryptionKey = getArgument(ctx, bucket, "encryption_key");
+        Optional<ExpressionTrace> optEncryptionKey = getArgument(ctx, bucket, "encryption_key");
         if (!optEncryptionKey.isPresent()) {
           ctx.addIssue(bucket.callee(), OMITTING_MESSAGE);
         }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
@@ -19,11 +19,13 @@
  */
 package org.sonar.python.checks.cdk;
 
-import java.util.Optional;
 import java.util.function.BiConsumer;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
+
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
 
 @Rule(key = "S6252")
 public class S3BucketVersioningCheck extends AbstractS3BucketCheck {
@@ -33,13 +35,9 @@ public class S3BucketVersioningCheck extends AbstractS3BucketCheck {
 
   @Override
   BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
-    return (ctx, bucket) -> {
-      Optional<ExpressionTrace> version = getArgument(ctx, bucket, "versioned");
-      if (version.isPresent()) {
-        version.get().addIssueIf(isFalse(), MESSAGE);
-      } else {
-        ctx.addIssue(bucket.callee(), MESSAGE_OMITTING);
-      }
-    };
+    return (ctx, bucket) ->
+      getArgument(ctx, bucket, "versioned").ifPresentOrElse(
+        version -> version.addIssueIf(isFalse(), MESSAGE),
+        () -> ctx.addIssue(bucket.callee(), MESSAGE_OMITTING));
   }
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
@@ -20,6 +20,7 @@
 package org.sonar.python.checks.cdk;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
@@ -31,12 +32,14 @@ public class S3BucketVersioningCheck extends AbstractS3BucketCheck {
   public static final String MESSAGE_OMITTING = "Omitting the \"versioned\" argument disables S3 bucket versioning. Make sure it is safe here.";
 
   @Override
-  void visitBucketConstructor(SubscriptionContext ctx, CallExpression bucket) {
-    Optional<ArgumentTrace> version = getArgument(ctx, bucket, "versioned");
-    if (version.isPresent()) {
-      version.get().addIssueIf(isFalse(), MESSAGE);
-    } else {
-      ctx.addIssue(bucket.callee(), MESSAGE_OMITTING);
-    }
+  BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
+    return (ctx, bucket) -> {
+      Optional<ArgumentTrace> version = getArgument(ctx, bucket, "versioned");
+      if (version.isPresent()) {
+        version.get().addIssueIf(isFalse(), MESSAGE);
+      } else {
+        ctx.addIssue(bucket.callee(), MESSAGE_OMITTING);
+      }
+    };
   }
 }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/S3BucketVersioningCheck.java
@@ -34,7 +34,7 @@ public class S3BucketVersioningCheck extends AbstractS3BucketCheck {
   @Override
   BiConsumer<SubscriptionContext, CallExpression> visitBucketConstructor() {
     return (ctx, bucket) -> {
-      Optional<ArgumentTrace> version = getArgument(ctx, bucket, "versioned");
+      Optional<ExpressionTrace> version = getArgument(ctx, bucket, "versioned");
       if (version.isPresent()) {
         version.get().addIssueIf(isFalse(), MESSAGE);
       } else {

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedEbsVolumeCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedEbsVolumeCheck.java
@@ -21,6 +21,9 @@ package org.sonar.python.checks.cdk;
 
 import org.sonar.check.Rule;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isFalse;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
 @Rule(key = "S6275")
 public class UnencryptedEbsVolumeCheck extends AbstractCdkResourceCheck {
 

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedSageMakerNotebookCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedSageMakerNotebookCheck.java
@@ -21,6 +21,9 @@ package org.sonar.python.checks.cdk;
 
 import org.sonar.check.Rule;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
 @Rule(key = "S6319")
 public class UnencryptedSageMakerNotebookCheck extends AbstractCdkResourceCheck {
   private static final String OMITTING_MESSAGE = "Omitting kms_key_id disables encryption of SageMaker notebook instances. Make sure it is safe here.";

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedSqsQueueCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/UnencryptedSqsQueueCheck.java
@@ -23,6 +23,10 @@ import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.SubscriptionContext;
 import org.sonar.plugins.python.api.tree.CallExpression;
 
+import static org.sonar.python.checks.cdk.CdkPredicate.isFqn;
+import static org.sonar.python.checks.cdk.CdkPredicate.isNone;
+import static org.sonar.python.checks.cdk.CdkUtils.getArgument;
+
 @Rule(key = "S6330")
 public class UnencryptedSqsQueueCheck extends AbstractCdkResourceCheck {
   private static final String UNENCRYPTED_MESSAGE = "Setting \"encryption\" to \"QueueEncryption.UNENCRYPTED\" disables SQS queues encryption. Make sure it is safe here.";

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/WeakSSLProtocolCheckPart.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/WeakSSLProtocolCheckPart.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.checks.cdk;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Predicate;
@@ -31,7 +30,7 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 import static org.sonar.python.checks.cdk.CdkPredicate.isFqn;
 import static org.sonar.python.checks.cdk.CdkPredicate.isSensitiveMethod;
-import static org.sonar.python.checks.cdk.CdkPredicate.isStringValue;
+import static org.sonar.python.checks.cdk.CdkPredicate.isString;
 
 public class WeakSSLProtocolCheckPart extends AbstractCdkResourceCheck {
   private static final String ENFORCE_MESSAGE = "Change this code to enforce TLS 1.2 or above.";
@@ -52,7 +51,7 @@ public class WeakSSLProtocolCheckPart extends AbstractCdkResourceCheck {
     // Api gateway
     checkFqn(APIGATEWAY_FQN + "DomainName", checkDomainName(isFqn(APIGATEWAY_FQN + "SecurityPolicy.TLS_1_0")));
     checkFqn(APIGATEWAYV2_FQN + "DomainName", checkDomainName(isFqn(APIGATEWAYV2_FQN + "SecurityPolicy.TLS_1_0")));
-    checkFqn(APIGATEWAY_FQN + "CfnDomainName", checkDomainName(isStringValue("TLS_1_0")));
+    checkFqn(APIGATEWAY_FQN + "CfnDomainName", checkDomainName(isString("TLS_1_0")));
 
     // OpenSearch & ElasticSearch
     checkFqn(OPENSEARCH_FQN + "Domain", checkDomain(isFqn(OPENSEARCH_FQN + "TLSSecurityPolicy.TLS_1_0")));
@@ -76,7 +75,7 @@ public class WeakSSLProtocolCheckPart extends AbstractCdkResourceCheck {
 
   private static BiConsumer<SubscriptionContext, CallExpression> checkCfnDomain(String domainOptionName) {
     return (ctx, callExpression) -> CdkUtils.getArgument(ctx, callExpression, "domain_endpoint_options").ifPresentOrElse(
-      argTrace -> argTrace.addIssueIf(isSensitiveMethod(ctx, domainOptionName, TLS_SECURITY_POLICY, isStringValue(SENSITIVE_TLS_SECURITY_POLICY))
+      argTrace -> argTrace.addIssueIf(isSensitiveMethod(ctx, domainOptionName, TLS_SECURITY_POLICY, isString(SENSITIVE_TLS_SECURITY_POLICY))
         .or(isSensitiveDictionaryTls(ctx)), ENFORCE_MESSAGE),
       () -> ctx.addIssue(callExpression.callee(), OMITTING_MESSAGE)
     );
@@ -85,14 +84,15 @@ public class WeakSSLProtocolCheckPart extends AbstractCdkResourceCheck {
   private static Predicate<Expression> isSensitiveDictionaryTls(SubscriptionContext ctx) {
     return expression -> Optional.of(expression)
       .filter(expr -> expr.is(Tree.Kind.DICTIONARY_LITERAL)).map(DictionaryLiteral.class::cast)
-      .filter(hasDictionaryKeyValue(ctx, TLS_SECURITY_POLICY, isStringValue(SENSITIVE_TLS_SECURITY_POLICY)))
+      .filter(hasDictionaryKeyValue(ctx, TLS_SECURITY_POLICY, isString(SENSITIVE_TLS_SECURITY_POLICY)))
       .isPresent();
   }
 
   private static Predicate<DictionaryLiteral> hasDictionaryKeyValue(SubscriptionContext ctx, String key, Predicate<Expression> expected) {
-    return dict -> dict.elements().stream().map(CdkUtils::getKeyValuePair).filter(Objects::nonNull)
-      .map(pair -> CdkUtils.ResolvedKeyValuePair.build(ctx, pair))
-      .filter(pair -> pair.key.hasExpression(isStringValue(key)))
+    return dict -> dict.elements().stream()
+      .map(e -> CdkUtils.getKeyValuePair(ctx, e))
+      .flatMap(Optional::stream)
+      .filter(pair -> pair.key.hasExpression(isString(key)))
       .allMatch(pair -> pair.value.hasExpression(expected));
   }
 }

--- a/python-checks/src/test/resources/checks/cdk/disabledESDomainEncryptionCheck.py
+++ b/python-checks/src/test/resources/checks/cdk/disabledESDomainEncryptionCheck.py
@@ -24,6 +24,7 @@ class DomainStack(Stack):
         aws_os.Domain(encryption_at_rest={"enabled": False}) # NonCompliant
         aws_os.Domain(encryption_at_rest={}) # NonCompliant
         aws_os.Domain(encryption_at_rest={"another_key": False}) # NonCompliant
+
         aws_os.Domain(encryption_at_rest=encryptionRestOptionDictionaryBad) # NonCompliant
         aws_os.Domain(encryption_at_rest=aws_os.EncryptionAtRestOptions(enabled=not_encrypted)) # NonCompliant
         aws_os.Domain(encryption_at_rest={"enabled": not_encrypted}) # NonCompliant


### PR DESCRIPTION
First version, the class `S3BucketGrantedAccessCheck` does not use the class `AbstractS3BucketCheck` properly, so the current adaptation is not really meaningful. Not sure if we can really adapt it as it is really different from other S3Bucket classes and from the intended use of the abstract class.