### PR TITLE
Revert "SONARPY-1165 Infer types of Typeshed class attributes (#1232)"

### DIFF
--- a/its/ruling/src/test/resources/expected/python-S5655.json
+++ b/its/ruling/src/test/resources/expected/python-S5655.json
@@ -1,7 +1,4 @@
 {
-'project:django-2.2.3/django/db/migrations/questioner.py':[
-51,
-],
 'project:mypy-0.782/test-data/stdlib-samples/3.2/pprint.py':[
 67,
 71,

--- a/its/ruling/src/test/resources/expected/python-S5717.json
+++ b/its/ruling/src/test/resources/expected/python-S5717.json
@@ -84,9 +84,6 @@
 197,
 197,
 ],
-'project:twisted-12.1.0/twisted/python/modules.py':[
-547,
-],
 'project:twisted-12.1.0/twisted/python/usage.py':[
 849,
 849,

--- a/its/ruling/src/test/resources/expected_extended/scikit-learn/python-S5644.json
+++ b/its/ruling/src/test/resources/expected_extended/scikit-learn/python-S5644.json
@@ -1,6 +1,0 @@
-{
-'scikit-learn:sklearn/tree/tests/test_tree.py':[
-2207,
-2301,
-],
-}

--- a/python-checks/src/test/resources/checks/argumentType.py
+++ b/python-checks/src/test/resources/checks/argumentType.py
@@ -207,9 +207,3 @@ def duck_typing_no_member():
 
   a_function(Parent())  # OK, still duck type compatible with ChildA
   another_function(Parent())  # Noncompliant
-
-
-def special_form_types():
-  import collections.abc as collections_abc
-  class A: ...
-  isinstance(A(), collections_abc.Callable) # OK

--- a/python-checks/src/test/resources/checks/incompatibleOperands/arithmetic.py
+++ b/python-checks/src/test/resources/checks/incompatibleOperands/arithmetic.py
@@ -71,10 +71,6 @@ def builtin_noncompliant():
 
   -'1'  # Noncompliant
 
-  from queue import Queue
-  q = Queue()
-  q.maxsize + 'other' # Noncompliant
-
 
 def builtin_compliant():
   1 + int("1")

--- a/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
@@ -140,7 +140,7 @@ class Scope {
           .collect(Collectors.toSet());
         return new AmbiguousSymbolImpl(symbolName, symbol.fullyQualifiedName(), alternativeSymbols);
       default:
-        SymbolImpl copiedSymbol = ((SymbolImpl) symbol).copyWithoutUsages(symbolName);
+        SymbolImpl copiedSymbol = new SymbolImpl(symbolName, symbol.fullyQualifiedName(), symbol.annotatedTypeName());
         for (Map.Entry<String, Symbol> kv: ((SymbolImpl) symbol).getChildrenSymbolByName().entrySet()) {
           copiedSymbol.addChildSymbol(((SymbolImpl) kv.getValue()).copyWithoutUsages());
         }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolImpl.java
@@ -53,20 +53,18 @@ public class SymbolImpl implements Symbol {
   private Kind kind;
   private InferredType inferredType = InferredTypes.anyType();
   private String annotatedTypeName = null;
-
-  /**
-   * Represents type deserialized from typeshed or from a custom stub.
-   * This will be lazily converted to an InferredType
-   */
-  private SymbolsProtos.Type deserializedType = null;
-
-  private boolean hasReadDeserializedType = false;
-
   protected Set<String> validForPythonVersions = Collections.emptySet();
 
   public SymbolImpl(String name, @Nullable String fullyQualifiedName) {
     this.name = name;
     this.fullyQualifiedName = fullyQualifiedName;
+    this.kind = Kind.OTHER;
+  }
+
+  public SymbolImpl(String name, @Nullable String fullyQualifiedName, @Nullable String annotatedTypeName) {
+    this.name = name;
+    this.fullyQualifiedName = fullyQualifiedName;
+    this.annotatedTypeName = annotatedTypeName;
     this.kind = Kind.OTHER;
   }
 
@@ -77,7 +75,6 @@ public class SymbolImpl implements Symbol {
     if (!fqn.isEmpty()) {
       this.annotatedTypeName = TypeShed.normalizedFqn(fqn);
     }
-    this.deserializedType = varSymbol.getTypeAnnotation();
     this.validForPythonVersions = new HashSet<>(varSymbol.getValidForList());
     this.kind = Kind.OTHER;
   }
@@ -144,24 +141,7 @@ public class SymbolImpl implements Symbol {
     childrenSymbolByName.put(symbol.name(), symbol);
   }
 
-
-  /**
-   * Note that, for symbols that have been deserialized from protobuf, we compute their type lazily.
-   *
-   * <pre>
-   *   a_var : Foo
-   *   ...
-   *   class Foo: ...
-   * </pre>
-   *
-   * Here, {@code a_var} has type {@code Foo}, which is defined later.
-   * Hence, by resolving types lazily, we avoid having to topologically sort dependencies between types declaration and their usages.
-   */
   public InferredType inferredType() {
-    if (!hasReadDeserializedType && deserializedType != null) {
-      inferredType = InferredTypes.fromTypeshedProtobuf(deserializedType);
-      hasReadDeserializedType = true;
-    }
     return inferredType;
   }
 
@@ -179,15 +159,7 @@ public class SymbolImpl implements Symbol {
   }
 
   public SymbolImpl copyWithoutUsages() {
-    return copyWithoutUsages(name());
-  }
-
-  public SymbolImpl copyWithoutUsages(String name) {
-    SymbolImpl copiedSymbol = new SymbolImpl(name, fullyQualifiedName());
-    copiedSymbol.annotatedTypeName = annotatedTypeName;
-    copiedSymbol.deserializedType = deserializedType;
-    copiedSymbol.hasReadDeserializedType = hasReadDeserializedType;
-    return copiedSymbol;
+    return new SymbolImpl(name(), fullyQualifiedName, annotatedTypeName);
   }
 
   public void removeUsages() {

--- a/python-frontend/src/main/java/org/sonar/python/tree/QualifiedExpressionImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/QualifiedExpressionImpl.java
@@ -22,16 +22,12 @@ package org.sonar.python.tree;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.Expression;
 import org.sonar.plugins.python.api.tree.Name;
 import org.sonar.plugins.python.api.tree.QualifiedExpression;
 import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.plugins.python.api.tree.TreeVisitor;
-import org.sonar.plugins.python.api.types.InferredType;
-import org.sonar.python.semantic.SymbolImpl;
-import org.sonar.python.types.InferredTypes;
 
 public class QualifiedExpressionImpl extends PyTree implements QualifiedExpression {
   private final Name name;
@@ -72,12 +68,5 @@ public class QualifiedExpressionImpl extends PyTree implements QualifiedExpressi
   @Override
   public List<Tree> computeChildren() {
     return Stream.of(qualifier, dotToken, name).collect(Collectors.toList());
-  }
-
-  @Override
-  public InferredType type() {
-    Symbol symbol = name.symbol();
-    if (symbol == null) return InferredTypes.anyType();
-    return ((SymbolImpl) symbol).inferredType();
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
@@ -169,11 +169,6 @@ public class InferredTypes {
     switch (type.getKind()) {
       case INSTANCE:
         String typeName = type.getFullyQualifiedName();
-        // _SpecialForm is the type used for some special types, like Callable, Union, TypeVar, ...
-        // It comes from CPython impl: https://github.com/python/cpython/blob/e39ae6bef2c357a88e232dcab2e4b4c0f367544b/Lib/typing.py#L439
-        // This doesn't seem to be very precisely specified in typeshed, because it has special semantic.
-        // To avoid FPs, we treat it as ANY
-        if ("typing._SpecialForm".equals(typeName)) return anyType();
         return typeName.isEmpty() ? anyType() : runtimeType(TypeShed.symbolWithFQN(typeName));
       case TYPE_ALIAS:
         return fromTypeshedProtobuf(type.getArgs(0));

--- a/python-frontend/src/test/java/org/sonar/python/types/InferredTypesTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/InferredTypesTest.java
@@ -382,14 +382,6 @@ public class InferredTypesTest {
     assertThat(getBuiltinsTypeCategory()).isNotEmpty();
   }
 
-  @Test
-  public void special_form_should_be_treated_as_any() {
-    assertThat(lastExpression(
-      "import collections.abc as collections_abc",
-      "collections_abc.Callable" // has type typing._SpecialForm
-    ).type()).isEqualTo(anyType());
-  }
-
   private static InferredType protobufType(String protobuf) throws TextFormat.ParseException {
     SymbolsProtos.Type.Builder builder = SymbolsProtos.Type.newBuilder();
     TextFormat.merge(protobuf, builder);

--- a/python-frontend/src/test/java/org/sonar/python/types/TypeInferenceTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/TypeInferenceTest.java
@@ -600,25 +600,4 @@ public class TypeInferenceTest {
       "  x"
     ).type()).isEqualTo(anyType());
   }
-
-  @Test
-  public void typeshed_attributes() {
-    assertThat(lastExpression(
-      "def f():",
-      "  e = OSError()",
-      "  e.errno.bit_length()"
-    ).type()).isEqualTo(INT);
-  }
-
-  @Test
-  public void user_defined_attributes() {
-    assertThat(lastExpression(
-      "class Foo:",
-      "  attr: int",
-      "def f():",
-      "  e = Foo()",
-      "  e.attr.bit_length()"
-    ).type()).isEqualTo(anyType());
-  }
-
 }


### PR DESCRIPTION
This reverts commit 87248fc71077187aaf7f490214e1205cef775742.

This commit has been reverted because there are some regressions on sonar-security