### PR TITLE
Compute main files FQNs after setting the project base dir path

### DIFF
--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
@@ -56,7 +56,6 @@ public class SonarQubePythonIndexer extends PythonIndexer {
     inputFiles.forEach(f -> {
       if (f.type().equals(InputFile.Type.MAIN)) {
         mainFiles.add(f);
-        inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename()));
       } else {
         testFiles.add(f);
       }
@@ -67,6 +66,7 @@ public class SonarQubePythonIndexer extends PythonIndexer {
   @Override
   public void buildOnce(SensorContext context) {
     this.projectBaseDirAbsolutePath = context.fileSystem().baseDir().getAbsolutePath();
+    mainFiles.forEach(f ->  inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename())));
     LOG.debug("Input files for indexing: " + mainFiles);
     if (shouldOptimizeAnalysis(context)) {
       computeGlobalSymbolsUsingCache(context);


### PR DESCRIPTION
The computation of fully qualified names requires that `projectBaseDirAbsolutePath` is set, so that the base directory of the project is not considered as part of fully qualified names within the project even when containing an `__init__.py` file.
This PR will fix an inconsistency in FQNs computation that may cause NullPointerException in some cases.