### PR TITLE
SONARPY-1169 Support except* syntax

### DIFF
--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/tree/ExceptClause.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/tree/ExceptClause.java
@@ -39,6 +39,9 @@ public interface ExceptClause extends Tree {
   Token exceptKeyword();
 
   @CheckForNull
+  Token starToken();
+
+  @CheckForNull
   Expression exception();
 
   @CheckForNull

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/tree/Tree.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/tree/Tree.java
@@ -90,6 +90,8 @@ public interface Tree {
 
     EXCEPT_CLAUSE(ExceptClause.class),
 
+    EXCEPT_GROUP_CLAUSE(ExceptClause.class),
+
     EXEC_STMT(ExecStatement.class),
 
     EXPRESSION_LIST(ExpressionList.class),

--- a/python-frontend/src/main/java/org/sonar/python/api/PythonGrammar.java
+++ b/python-frontend/src/main/java/org/sonar/python/api/PythonGrammar.java
@@ -465,7 +465,7 @@ public enum PythonGrammar implements GrammarRuleKey {
         b.optional("finally", ":", SUITE)),
       b.sequence("finally", ":", SUITE)));
 
-    b.rule(EXCEPT_CLAUSE).is("except", b.optional(TEST, b.optional(b.firstOf("as", ","), TEST)));
+    b.rule(EXCEPT_CLAUSE).is("except", b.optional("*"), b.optional(TEST, b.optional(b.firstOf("as", ","), TEST)));
 
     b.rule(WITH_STMT).is(b.firstOf(
       b.sequence("with", "(", WITH_ITEM, b.zeroOrMore(",", WITH_ITEM), b.optional(","), ")", ":", SUITE),

--- a/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
@@ -132,11 +132,7 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
 
   @Override
   public Kind getKind() {
-    if (this.starToken != null) {
-      return Kind.EXCEPT_GROUP_CLAUSE;
-    } else {
-      return Kind.EXCEPT_CLAUSE;
-    }
+    return this.starToken != null ? Kind.EXCEPT_GROUP_CLAUSE : Kind.EXCEPT_CLAUSE;
   }
 
   @Override

--- a/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
@@ -34,6 +34,7 @@ import org.sonar.plugins.python.api.tree.Tree;
 
 public class ExceptClauseImpl extends PyTree implements ExceptClause {
   private final Token exceptKeyword;
+  private final Token starToken;
   private final Token colon;
   private final Token newLine;
   private final Token indent;
@@ -44,8 +45,10 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
   private final Token commaToken;
   private final Expression exceptionInstance;
 
-  public ExceptClauseImpl(Token exceptKeyword, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body, @Nullable Token dedent) {
+  public ExceptClauseImpl(Token exceptKeyword, @Nullable Token starToken, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body,
+                          @Nullable Token dedent) {
     this.exceptKeyword = exceptKeyword;
+    this.starToken = starToken;
     this.colon = colon;
     this.newLine = newLine;
     this.indent = indent;
@@ -57,9 +60,10 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
     this.exceptionInstance = null;
   }
 
-  public ExceptClauseImpl(Token exceptKeyword, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body, @Nullable Token dedent,
-                          Expression exception, @Nullable Token asNode, @Nullable Token commaNode, Expression exceptionInstance) {
+  public ExceptClauseImpl(Token exceptKeyword, @Nullable Token starToken, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body,
+                          @Nullable Token dedent, Expression exception, @Nullable Token asNode, @Nullable Token commaNode, Expression exceptionInstance) {
     this.exceptKeyword = exceptKeyword;
+    this.starToken = starToken;
     this.colon = colon;
     this.newLine = newLine;
     this.indent = indent;
@@ -71,8 +75,10 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
     this.exceptionInstance = exceptionInstance;
   }
 
-  public ExceptClauseImpl(Token exceptKeyword, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body, @Nullable Token dedent, Expression exception) {
+  public ExceptClauseImpl(Token exceptKeyword, @Nullable Token starToken, Token colon, @Nullable Token newLine, @Nullable Token indent, StatementList body,
+                          @Nullable Token dedent, Expression exception) {
     this.exceptKeyword = exceptKeyword;
+    this.starToken = starToken;
     this.colon = colon;
     this.newLine = newLine;
     this.indent = indent;
@@ -87,6 +93,12 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
   @Override
   public Token exceptKeyword() {
     return exceptKeyword;
+  }
+
+  @CheckForNull
+  @Override
+  public Token starToken() {
+    return starToken;
   }
 
   @Override
@@ -130,7 +142,7 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
 
   @Override
   public List<Tree> computeChildren() {
-    return Stream.of(exceptKeyword, exception, asKeyword, commaToken, exceptionInstance, colon, newLine, indent, body, dedent)
+    return Stream.of(exceptKeyword, starToken, exception, asKeyword, commaToken, exceptionInstance, colon, newLine, indent, body, dedent)
       .filter(Objects::nonNull).collect(Collectors.toList());
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/ExceptClauseImpl.java
@@ -132,7 +132,11 @@ public class ExceptClauseImpl extends PyTree implements ExceptClause {
 
   @Override
   public Kind getKind() {
-    return Kind.EXCEPT_CLAUSE;
+    if (this.starToken != null) {
+      return Kind.EXCEPT_GROUP_CLAUSE;
+    } else {
+      return Kind.EXCEPT_CLAUSE;
+    }
   }
 
   @Override

--- a/python-frontend/src/main/java/org/sonar/python/tree/PythonTreeMaker.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/PythonTreeMaker.java
@@ -748,16 +748,13 @@ public class PythonTreeMaker {
   public void checkExceptClauses(List<ExceptClause> excepts) {
     if (excepts.isEmpty()) return;
 
-    boolean isFirstExceptGroup = excepts.get(0).starToken() != null;
+    Tree.Kind firstExceptKind = excepts.get(0).getKind();
     for (ExceptClause except : excepts) {
-      boolean isCurrentExceptGroup = except.starToken() != null;
-      if (isFirstExceptGroup != isCurrentExceptGroup) {
+      if (firstExceptKind != except.getKind()) {
         recognitionException(except.exceptKeyword().line(), "Try statement cannot contain both except and except* clauses");
-        return;
       }
-      if (isCurrentExceptGroup && except.exception() == null) {
-        recognitionException(except.exceptKeyword().line(), "Except* statement must specify the type of the expected exception");
-        return;
+      if (except.is(Tree.Kind.EXCEPT_GROUP_CLAUSE) && except.exception() == null) {
+        recognitionException(except.exceptKeyword().line(), "except* clause must specify the type of the expected exception");
       }
     }
   }

--- a/python-frontend/src/main/java/org/sonar/python/tree/PythonTreeMaker.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/PythonTreeMaker.java
@@ -726,6 +726,7 @@ public class PythonTreeMaker {
         return exceptClause(except, getStatementListFromSuite(suite));
       })
       .collect(Collectors.toList());
+    checkExceptClauses(exceptClauseTrees);
     FinallyClause finallyClause = null;
     AstNode finallyNode = astNode.getFirstChild(PythonKeyword.FINALLY);
     if (finallyNode != null) {
@@ -742,6 +743,23 @@ public class PythonTreeMaker {
     }
     return new TryStatementImpl(tryKeyword, colon, suiteNewLine(firstSuite), suiteIndent(firstSuite), body, suiteDedent(firstSuite),
       exceptClauseTrees, finallyClause, elseClauseTree);
+  }
+
+  public void checkExceptClauses(List<ExceptClause> excepts) {
+    if (excepts.isEmpty()) return;
+
+    boolean isFirstExceptGroup = excepts.get(0).starToken() != null;
+    for (ExceptClause except : excepts) {
+      boolean isCurrentExceptGroup = except.starToken() != null;
+      if (isFirstExceptGroup != isCurrentExceptGroup) {
+        recognitionException(except.exceptKeyword().line(), "Try statement cannot contain both except and except* clauses");
+        return;
+      }
+      if (isCurrentExceptGroup && except.exception() == null) {
+        recognitionException(except.exceptKeyword().line(), "Except* statement must specify the type of the expected exception");
+        return;
+      }
+    }
   }
 
   public WithStatement withStatement(AstNode astNode) {
@@ -785,12 +803,13 @@ public class PythonTreeMaker {
     Token colon = toPyToken(except.getNextSibling().getToken());
     AstNode suite = except.getNextSibling().getNextSibling();
     Token exceptKeyword = toPyToken(except.getFirstChild(PythonKeyword.EXCEPT).getToken());
+    Token star = except.getFirstChild(PythonPunctuator.MUL) == null ? null : toPyToken(except.getFirstChild(PythonPunctuator.MUL).getToken());
     Token indent = suite.getFirstChild(PythonTokenType.INDENT) == null ? null : toPyToken(suite.getFirstChild(PythonTokenType.INDENT).getToken());
     Token newLine = suite.getFirstChild(PythonTokenType.INDENT) == null ? null : toPyToken(suite.getFirstChild(PythonTokenType.NEWLINE).getToken());
     Token dedent = suite.getFirstChild(PythonTokenType.DEDENT) == null ? null : toPyToken(suite.getFirstChild(PythonTokenType.DEDENT).getToken());
     AstNode exceptionNode = except.getFirstChild(PythonGrammar.TEST);
     if (exceptionNode == null) {
-      return new ExceptClauseImpl(exceptKeyword, colon, newLine, indent, body, dedent);
+      return new ExceptClauseImpl(exceptKeyword, star, colon, newLine, indent, body, dedent);
     }
     AstNode asNode = except.getFirstChild(PythonKeyword.AS);
     AstNode commaNode = except.getFirstChild(PythonPunctuator.COMMA);
@@ -798,9 +817,9 @@ public class PythonTreeMaker {
       Expression exceptionInstance = expression(except.getLastChild(PythonGrammar.TEST));
       Token asNodeToken = asNode != null ? toPyToken(asNode.getToken()) : null;
       Token commaNodeToken = commaNode != null ? toPyToken(commaNode.getToken()) : null;
-      return new ExceptClauseImpl(exceptKeyword, colon, newLine, indent, body, dedent, expression(exceptionNode), asNodeToken, commaNodeToken, exceptionInstance);
+      return new ExceptClauseImpl(exceptKeyword, star, colon, newLine, indent, body, dedent, expression(exceptionNode), asNodeToken, commaNodeToken, exceptionInstance);
     }
-    return new ExceptClauseImpl(exceptKeyword, colon, newLine, indent, body, dedent, expression(exceptionNode));
+    return new ExceptClauseImpl(exceptKeyword, star, colon, newLine, indent, body, dedent, expression(exceptionNode));
   }
 
 

--- a/python-frontend/src/test/java/org/sonar/python/parser/compound/statements/ExceptClauseTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/parser/compound/statements/ExceptClauseTest.java
@@ -37,6 +37,7 @@ public class ExceptClauseTest extends RuleTest {
   public void ok() {
     assertThat(p).matches("except")
       .matches("except TEST")
+      .matches("except* TEST")
       .matches("except TEST as TEST")
       .matches("except TEST , TEST");
   }

--- a/python-frontend/src/test/java/org/sonar/python/parser/compound/statements/TryStatementTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/parser/compound/statements/TryStatementTest.java
@@ -41,7 +41,8 @@ public class TryStatementTest extends RuleTest {
       .matches("try : pass\nexcept e : pass\nelse : pass")
       .matches("try : pass\nexcept e : pass\nfinally : pass")
       .matches("try : pass\nexcept e : pass\nelse : pass\nfinally : pass")
-      .matches("try : pass\nfinally : pass");
+      .matches("try : pass\nfinally : pass")
+      .matches("try : pass\nexcept* e : pass");
   }
 
 }

--- a/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
@@ -117,6 +117,7 @@ import org.sonar.python.api.PythonTokenType;
 import org.sonar.python.parser.RuleTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 
 public class PythonTreeMakerTest extends RuleTest {
@@ -2586,25 +2587,35 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(exceptClause.starToken()).isNotNull();
     assertThat(exceptClause.starToken().value()).isEqualTo("*");
     assertThat(exceptClause.exception().is(Kind.NAME)).isTrue();
-    assertThat(exceptClause.exception().is(Kind.NAME)).isTrue();
 
-    try {
-      parse("try:pass\nexcept* OSError:pass\nexcept IOError:pass", treeMaker::fileInput);
-      fail("Parse of try except with a mix of except/except* should not be successful.");
-    } catch (RecognitionException e) {
-      assertThat(e.getLine()).isEqualTo(3);
-      assertThat(e.getMessage()).isEqualTo("Parse error at line 3: Try statement cannot contain both except and except* clauses.");
-      assertThat(e).hasMessage("Parse error at line 3: Try statement cannot contain both except and except* clauses.");
-    }
+    assertThatThrownBy(() -> parse("try:pass\nexcept* OSError:pass\nexcept IOError:pass", treeMaker::fileInput))
+      .isInstanceOf(RecognitionException.class)
+      .hasMessage("Parse error at line 3: Try statement cannot contain both except and except* clauses.");
 
-    try {
-      parse("try:pass\nexcept*:pass", treeMaker::fileInput);
-      fail("Parse of try except with an except* and empty exception should not be successful.");
-    } catch (RecognitionException e) {
-      assertThat(e.getLine()).isEqualTo(2);
-      assertThat(e.getMessage()).isEqualTo("Parse error at line 2: Except* statement must specify the type of the expected exception.");
-      assertThat(e).hasMessage("Parse error at line 2: Except* statement must specify the type of the expected exception.");
-    }
+    assertThatThrownBy(() -> parse("try:pass\nexcept*:pass", treeMaker::fileInput))
+      .isInstanceOf(RecognitionException.class)
+      .hasMessage("Parse error at line 2: except* clause must specify the type of the expected exception.");
+  }
+
+  @Test
+  public void except_group_multiple() {
+    FileInput tree = parse("try:pass\nexcept* OSError:pass\nexcept* ValueError:pass", treeMaker::fileInput);
+    TryStatement tryStatement = (TryStatement) tree.statements().statements().get(0);
+    assertThat(tryStatement.exceptClauses()).hasSize(2);
+
+    ExceptClause exceptClause1 = tryStatement.exceptClauses().get(0);
+    assertThat(exceptClause1.getKind()).isEqualTo(Kind.EXCEPT_GROUP_CLAUSE);
+    assertThat(exceptClause1.starToken()).isNotNull();
+    assertThat(exceptClause1.starToken().value()).isEqualTo("*");
+    assertThat(exceptClause1.exception().is(Kind.NAME)).isTrue();
+    assertThat(((Name) exceptClause1.exception()).name()).isEqualTo("OSError");
+
+    ExceptClause exceptClause2 = tryStatement.exceptClauses().get(1);
+    assertThat(exceptClause2.getKind()).isEqualTo(Kind.EXCEPT_GROUP_CLAUSE);
+    assertThat(exceptClause2.starToken()).isNotNull();
+    assertThat(exceptClause2.starToken().value()).isEqualTo("*");
+    assertThat(exceptClause2.exception().is(Kind.NAME)).isTrue();
+    assertThat(((Name) exceptClause2.exception()).name()).isEqualTo("ValueError");
   }
 
   public String fileContent(File file) {

--- a/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
@@ -1345,6 +1345,7 @@ public class PythonTreeMakerTest extends RuleTest {
     assertThat(tryStatement.elseClause()).isNull();
     assertThat(tryStatement.finallyClause()).isNull();
     assertThat(tryStatement.exceptClauses()).hasSize(1);
+    assertThat(tryStatement.exceptClauses().get(0).getKind()).isEqualTo(Kind.EXCEPT_CLAUSE);
     assertThat(tryStatement.exceptClauses().get(0).firstToken().value()).isEqualTo("except");
     assertThat(tryStatement.exceptClauses().get(0).lastToken().value()).isEqualTo("pass");
     assertThat(tryStatement.exceptClauses().get(0).exceptKeyword().value()).isEqualTo("except");
@@ -2581,6 +2582,7 @@ public class PythonTreeMakerTest extends RuleTest {
     TryStatement tryStatement = (TryStatement) tree.statements().statements().get(0);
     assertThat(tryStatement.exceptClauses()).hasSize(1);
     ExceptClause exceptClause = tryStatement.exceptClauses().get(0);
+    assertThat(exceptClause.getKind()).isEqualTo(Kind.EXCEPT_GROUP_CLAUSE);
     assertThat(exceptClause.starToken()).isNotNull();
     assertThat(exceptClause.starToken().value()).isEqualTo("*");
     assertThat(exceptClause.exception().is(Kind.NAME)).isTrue();


### PR DESCRIPTION
The * character is already defined in PythonPunctuator as MUL, it does not seems possible to have to Punctuator with the same character, as from my understanding when it generate the AST, it take the first corresponding character as such.
So for now I let it as it and used this MUL punctuator, open for suggestion !
