### PR TITLE
SONARPY-1183 S5713 (ChildAndParentExceptionCaughtCheck) should report on except*

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/ChildAndParentExceptionCaughtCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/ChildAndParentExceptionCaughtCheck.java
@@ -38,16 +38,19 @@ import org.sonar.python.tree.TreeUtils;
 public class ChildAndParentExceptionCaughtCheck extends PythonSubscriptionCheck {
   @Override
   public void initialize(Context context) {
-    context.registerSyntaxNodeConsumer(Tree.Kind.EXCEPT_CLAUSE, ctx -> {
-      ExceptClause exceptClause = (ExceptClause) ctx.syntaxNode();
-      Map<ClassSymbol, List<Expression>> caughtExceptionsBySymbol = new HashMap<>();
-      Expression exceptionExpression = exceptClause.exception();
-      if (exceptionExpression == null) {
-        return;
-      }
-      TreeUtils.flattenTuples(exceptionExpression).forEach(e -> addExceptionExpression(e, caughtExceptionsBySymbol));
-      checkCaughtExceptions(ctx, caughtExceptionsBySymbol);
-    });
+    context.registerSyntaxNodeConsumer(Tree.Kind.EXCEPT_CLAUSE, ChildAndParentExceptionCaughtCheck::checkExceptClause);
+    context.registerSyntaxNodeConsumer(Tree.Kind.EXCEPT_GROUP_CLAUSE, ChildAndParentExceptionCaughtCheck::checkExceptClause);
+  }
+
+  private static void checkExceptClause(SubscriptionContext ctx) {
+    ExceptClause exceptClause = (ExceptClause) ctx.syntaxNode();
+    Map<ClassSymbol, List<Expression>> caughtExceptionsBySymbol = new HashMap<>();
+    Expression exceptionExpression = exceptClause.exception();
+    if (exceptionExpression == null) {
+      return;
+    }
+    TreeUtils.flattenTuples(exceptionExpression).forEach(e -> addExceptionExpression(e, caughtExceptionsBySymbol));
+    checkCaughtExceptions(ctx, caughtExceptionsBySymbol);
   }
 
   private static void checkCaughtExceptions(SubscriptionContext ctx, Map<ClassSymbol, List<Expression>> caughtExceptionsBySymbol) {

--- a/python-checks/src/test/resources/checks/childAndParentExceptionCaughtCheck.py
+++ b/python-checks/src/test/resources/checks/childAndParentExceptionCaughtCheck.py
@@ -5,11 +5,22 @@ def child_with_parent():
   #       ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^< {{Parent class.}}
       print("Foo")
 
+  try:
+      raise NotImplementedError()
+  except* (NotImplementedError, RuntimeError):  # Noncompliant {{Remove this redundant Exception class; it derives from another which is already caught.}}
+  #        ^^^^^^^^^^^^^^^^^^^  ^^^^^^^^^^^^< {{Parent class.}}
+      print("Foo")
+
 def parent_with_child():
     try:
         raise NotImplementedError()
     except (RuntimeError, NotImplementedError):  # Noncompliant {{Remove this redundant Exception class; it derives from another which is already caught.}}
         #   ^^^^^^^^^^^^> ^^^^^^^^^^^^^^^^^^^
+        print("Foo")
+
+    try:
+        raise NotImplementedError()
+    except* (RuntimeError, NotImplementedError):  # Noncompliant
         print("Foo")
 
 
@@ -20,10 +31,20 @@ def duplicate_exception_caught():
 #         ^^^^^^^^^^^^  ^^^^^^^^^^^^< {{Duplicate.}}
       print("Foo")
 
+  try:
+      raise NotImplementedError()
+  except* (RuntimeError, RuntimeError):  # Noncompliant
+      print("Foo")
+
 def multiple_parents():
   try:
       raise NotImplementedError()
   except (UnicodeDecodeError, UnicodeError, ValueError):  # Noncompliant 2
+      print("Foo")
+
+  try:
+      raise NotImplementedError()
+  except* (UnicodeDecodeError, UnicodeError, ValueError):  # Noncompliant 2
       print("Foo")
 
 def duplicate_and_parent_with_child():
@@ -32,10 +53,20 @@ def duplicate_and_parent_with_child():
   except (RuntimeError, NotImplementedError, RuntimeError):  # Noncompliant 2
       print("Foo")
 
+  try:
+      raise NotImplementedError()
+  except* (RuntimeError, NotImplementedError, RuntimeError):  # Noncompliant 2
+      print("Foo")
+
 def python2_supports_nested_tuples():
     try:
         ...
     except (ValueError, (RuntimeError, NotImplementedError)): # Noncompliant
+        ...
+
+    try:
+        ...
+    except* (ValueError, (RuntimeError, NotImplementedError)): # Noncompliant
         ...
 
 def compliant():
@@ -43,9 +74,16 @@ def compliant():
     raise NotImplementedError()
   except RuntimeError:
     print("Foo")
+
+  try:
+    raise NotImplementedError()
+  except* RuntimeError:
+    print("Foo")
+
 def unknown():
   def method():
     pass
+
   try:
     raise ValueError()
   except ((A | B), C):
@@ -53,4 +91,11 @@ def unknown():
   except (method, Exception):
     pass
   except:
+    pass
+
+  try:
+    raise ValueError()
+  except* ((A | B), C):
+    pass
+  except* (method, Exception):
     pass


### PR DESCRIPTION
As usual, slightly adapted to make it work with Python 3.11.
Duplicated test code, I didn't normalize the indent of the test file to focus only on real modification, but I can still do it If you think it's a good idea.