### PR TITLE
SONARPY-1222 Disable cache to prepare for SQ 9.8 release

### DIFF
--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -34,6 +34,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -95,6 +96,7 @@ public class PythonPrAnalysisTest {
   }
 
   @Test
+  @Ignore
   public void pr_analysis_logs() throws IOException {
     File tempDirectory = temporaryFolder.newFolder();
     File litsDifferencesFile = FileLocation.of("target/differences").getFile();
@@ -113,6 +115,7 @@ public class PythonPrAnalysisTest {
   }
 
   @Test
+  @Ignore
   public void pr_analysis_issues() throws IOException {
     File tempDirectory = temporaryFolder.newFolder();
     File litsDifferencesFile = FileLocation.of("target/differences").getFile();

--- a/python-frontend/src/main/java/org/sonar/python/caching/CacheContextImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/caching/CacheContextImpl.java
@@ -55,7 +55,7 @@ public class CacheContextImpl implements CacheContext {
 
   public static CacheContextImpl of(SensorContext context) {
     if (!context.runtime().getProduct().equals(SonarProduct.SONARLINT) && context.runtime().getApiVersion().isGreaterThanOrEqual(Version.create(9, 7))) {
-      return new CacheContextImpl(context.isCacheEnabled(), new PythonWriteCacheImpl(context.nextCache()), new PythonReadCacheImpl(context.previousCache()));
+      return new CacheContextImpl(false, new PythonWriteCacheImpl(context.nextCache()), new PythonReadCacheImpl(context.previousCache()));
     }
     return new CacheContextImpl(false, new DummyCache(), new DummyCache());
   }

--- a/python-frontend/src/test/java/org/sonar/python/caching/CacheContextImplTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/caching/CacheContextImplTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.caching;
 
+import org.junit.Ignore;
 import org.junit.Test;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
@@ -36,6 +37,7 @@ public class CacheContextImplTest {
   private static final Version VERSION_WITHOUT_CACHING = Version.create(9, 6);
 
   @Test
+  @Ignore
   public void cache_context_of_enabled_cache() {
     SensorContext sensorContext = sensorContext(SonarProduct.SONARQUBE, VERSION_WITH_CACHING, true);
 

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -35,6 +35,7 @@ import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.sonar.api.SonarProduct;
@@ -657,6 +658,7 @@ public class PythonSensorTest {
 
 
   @Test
+  @Ignore
   public void test_using_cache() {
     activeRules = new ActiveRulesBuilder()
       .addRule(new NewActiveRule.Builder()
@@ -689,6 +691,7 @@ public class PythonSensorTest {
   }
 
   @Test
+  @Ignore
   public void test_scan_without_parsing_test_file() {
     activeRules = new ActiveRulesBuilder()
       .addRule(new NewActiveRule.Builder()


### PR DESCRIPTION
Goal is to disable caching for SonarPython 3.21 which will be integrated into SonarQube 9.8 release.
This feature could break SonarSecurity and Dataflow bug detection for Python, since the version of these analyzers to be integrated in 9.8 do not implement the required caching APIs.