### PR TITLE
SONARPY-1221 Invalidate cache when the analyzer version changes

### DIFF
--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -53,7 +53,6 @@ public class PythonPrAnalysisTest {
 
   private static final String PR_ANALYSIS_PROJECT_KEY = "prAnalysis";
   private static final String INCREMENTAL_ANALYSIS_PROFILE = "incrementalPrAnalysis";
-  private static final String EXPECTED_CACHE_VERSION = "3.21-SNAPSHOT";
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -148,7 +147,7 @@ public class PythonPrAnalysisTest {
     assertThat(result.getLogs())
       .contains(expectedRecomputedLog)
       .contains(expectedRegularAnalysisLog)
-      .contains(String.format("Cache version still up to date: \"%s\".", EXPECTED_CACHE_VERSION));
+      .contains(String.format("Cache version still up to date"));
   }
 
   private void analyzeAndAssertBaseCommit(File tempFile, File litsDifferencesFile) throws IOException {

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -53,6 +53,7 @@ public class PythonPrAnalysisTest {
 
   private static final String PR_ANALYSIS_PROJECT_KEY = "prAnalysis";
   private static final String INCREMENTAL_ANALYSIS_PROFILE = "incrementalPrAnalysis";
+  private static final String EXPECTED_CACHE_VERSION = "3.21-SNAPSHOT";
 
   @Rule
   public TemporaryFolder temporaryFolder = new TemporaryFolder();
@@ -146,7 +147,8 @@ public class PythonPrAnalysisTest {
 
     assertThat(result.getLogs())
       .contains(expectedRecomputedLog)
-      .contains(expectedRegularAnalysisLog);
+      .contains(expectedRegularAnalysisLog)
+      .contains(String.format("Cache version still up to date: \"%s\".", EXPECTED_CACHE_VERSION));
   }
 
   private void analyzeAndAssertBaseCommit(File tempFile, File litsDifferencesFile) throws IOException {
@@ -177,7 +179,8 @@ public class PythonPrAnalysisTest {
       .setProperty("sonar.cpd.exclusions", "**/*")
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.internal.analysis.failFast", "true")
-      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
+      .setDebugLogs(true)
+      .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Xdebug");
   }
 
 

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -180,7 +180,7 @@ public class PythonPrAnalysisTest {
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.internal.analysis.failFast", "true")
       .setDebugLogs(true)
-      .setEnvironmentVariable("SONAR_SCANNER_OPTS", "-Xdebug");
+      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
   }
 
 

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -146,8 +146,7 @@ public class PythonPrAnalysisTest {
 
     assertThat(result.getLogs())
       .contains(expectedRecomputedLog)
-      .contains(expectedRegularAnalysisLog)
-      .contains(String.format("Cache version still up to date"));
+      .contains(expectedRegularAnalysisLog);
   }
 
   private void analyzeAndAssertBaseCommit(File tempFile, File litsDifferencesFile) throws IOException {
@@ -178,7 +177,6 @@ public class PythonPrAnalysisTest {
       .setProperty("sonar.cpd.exclusions", "**/*")
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.internal.analysis.failFast", "true")
-      .setDebugLogs(true)
       .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
   }
 

--- a/sonar-python-plugin/pom.xml
+++ b/sonar-python-plugin/pom.xml
@@ -104,6 +104,11 @@
           <sonarLintSupported>true</sonarLintSupported>
           <sonarQubeMinVersion>${sonarQubeMinVersion}</sonarQubeMinVersion>
           <jreMinVersion>${jre.min.version}</jreMinVersion>
+          <archive>
+            <manifest>
+              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+            </manifest>
+          </archive>
         </configuration>
       </plugin>
 

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -112,7 +112,7 @@ public final class PythonSensor implements Sensor {
     }
     pythonVersionParameter.ifPresent(value -> ProjectPythonVersion.setCurrentVersions(PythonVersionUtils.fromString(value)));
     CacheContext cacheContext = CacheContextImpl.of(context);
-    PythonIndexer pythonIndexer = this.indexer != null ? this.indexer : new SonarQubePythonIndexer(pythonFiles, cacheContext);
+    PythonIndexer pythonIndexer = this.indexer != null ? this.indexer : new SonarQubePythonIndexer(pythonFiles, cacheContext, context);
     PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, pythonIndexer);
     scanner.execute(pythonFiles, context);
     durationReport.stop();

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/caching/Caching.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/caching/Caching.java
@@ -43,11 +43,15 @@ public class Caching {
   public static final String IMPORTS_MAP_CACHE_KEY_PREFIX = "python:imports:";
   public static final String PROJECT_SYMBOL_TABLE_CACHE_KEY_PREFIX = "python:descriptors:";
   public static final String PROJECT_FILES_KEY = "python:files";
+  public static final String CACHE_VERSION_KEY = "python:cache_version";
 
   private static final Logger LOG = Loggers.get(Caching.class);
 
-  public Caching(CacheContext cacheContext) {
+  public final String cacheVersion;
+
+  public Caching(CacheContext cacheContext, String cacheVersion) {
     this.cacheContext = cacheContext;
+    this.cacheVersion = cacheVersion;
   }
 
   public void writeImportsMapEntry(String moduleFqn, Set<String> imports) {
@@ -59,6 +63,10 @@ public class Caching {
   public void writeFilesList(List<String> mainFiles) {
     byte[] projectFiles = String.join(";", mainFiles).getBytes(StandardCharsets.UTF_8);
     cacheContext.getWriteCache().write(PROJECT_FILES_KEY, projectFiles);
+  }
+
+  public void writeCacheVersion() {
+    cacheContext.getWriteCache().write(CACHE_VERSION_KEY, cacheVersion.getBytes(StandardCharsets.UTF_8));
   }
 
   public void writeProjectLevelSymbolTableEntry(String moduleFqn, Set<Descriptor> descriptors) {
@@ -103,6 +111,20 @@ public class Caching {
       return new HashSet<>(Arrays.asList(new String(bytes, StandardCharsets.UTF_8).split(";")));
     }
     return Collections.emptySet();
+  }
+
+  public boolean isCacheVersionUpToDate() {
+    byte[] bytes = cacheContext.getReadCache().readBytes(CACHE_VERSION_KEY);
+    if (bytes != null) {
+      String retrievedVersion = new String(bytes, StandardCharsets.UTF_8);
+      if (retrievedVersion.equals(cacheVersion)) {
+        LOG.debug("Cache version still up to date: \"{}\".", cacheVersion);
+        return true;
+      }
+      LOG.info("The cache version has changed since the previous analysis, cached data will not be used during this analysis." +
+        String.format(" Retrieved: \"%s\". Current version: \"%s\".", retrievedVersion, cacheVersion));
+    }
+    return false;
   }
 
   public boolean isCacheEnabled() {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/caching/Caching.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/caching/Caching.java
@@ -122,7 +122,7 @@ public class Caching {
         return true;
       }
       LOG.info("The cache version has changed since the previous analysis, cached data will not be used during this analysis." +
-        String.format(" Retrieved: \"%s\". Current version: \"%s\".", retrievedVersion, cacheVersion));
+        " Retrieved: \"{}\". Current version: \"{}\".", retrievedVersion, cacheVersion);
     }
     return false;
   }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
@@ -62,11 +62,11 @@ public class SonarQubePythonIndexer extends PythonIndexer {
     inputFiles.forEach(f -> {
       if (f.type().equals(InputFile.Type.MAIN)) {
         mainFiles.add(f);
+        inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename()));
       } else {
         testFiles.add(f);
       }
     });
-    mainFiles.forEach(f ->  inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename())));
   }
 
   @Override
@@ -196,8 +196,8 @@ public class SonarQubePythonIndexer extends PythonIndexer {
   private static String getImplementationVersion(Class<?> cls) {
     String implementationVersion = cls.getPackage().getImplementationVersion();
     if (implementationVersion == null) {
-      LOG.warn("Implementation version of the Python plugin not found. Cached data may not be invalidated properly.");
-      return "unknown";
+      LOG.warn("Implementation version of the Python plugin not found. Cached data may not be invalidated properly, which may lead to inaccurate analysis results.");
+      return "unknownPluginVersion";
     }
     return implementationVersion;
   }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
@@ -38,6 +38,8 @@ import org.sonar.python.semantic.DependencyGraph;
 import org.sonar.python.semantic.SymbolUtils;
 import org.sonarsource.performance.measure.PerformanceMeasure;
 
+import static org.sonar.plugins.python.api.PythonVersionUtils.PYTHON_VERSION_KEY;
+
 public class SonarQubePythonIndexer extends PythonIndexer {
 
   /**
@@ -54,7 +56,9 @@ public class SonarQubePythonIndexer extends PythonIndexer {
   private final List<InputFile> testFiles = new ArrayList<>();
   private final Map<InputFile, String> inputFileToFQN = new HashMap<>();
 
-  public SonarQubePythonIndexer(List<InputFile> inputFiles, CacheContext cacheContext) {
+  public SonarQubePythonIndexer(List<InputFile> inputFiles, CacheContext cacheContext, SensorContext context) {
+    this.projectBaseDirAbsolutePath = context.fileSystem().baseDir().getAbsolutePath();
+    this.caching = new Caching(cacheContext, getCacheVersion(context));
     inputFiles.forEach(f -> {
       if (f.type().equals(InputFile.Type.MAIN)) {
         mainFiles.add(f);
@@ -62,13 +66,11 @@ public class SonarQubePythonIndexer extends PythonIndexer {
         testFiles.add(f);
       }
     });
-    this.caching = new Caching(cacheContext);
+    mainFiles.forEach(f ->  inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename())));
   }
 
   @Override
   public void buildOnce(SensorContext context) {
-    this.projectBaseDirAbsolutePath = context.fileSystem().baseDir().getAbsolutePath();
-    mainFiles.forEach(f ->  inputFileToFQN.put(f, SymbolUtils.fullyQualifiedModuleName(packageName(f), f.filename())));
     LOG.debug("Input files for indexing: " + mainFiles);
     if (shouldOptimizeAnalysis(context)) {
       computeGlobalSymbolsUsingCache(context);
@@ -81,7 +83,8 @@ public class SonarQubePythonIndexer extends PythonIndexer {
 
   private boolean shouldOptimizeAnalysis(SensorContext context) {
     return caching.isCacheEnabled()
-      && (context.canSkipUnchangedFiles() || context.config().getBoolean(SONAR_CAN_SKIP_UNCHANGED_FILES_KEY).orElse(false));
+      && (context.canSkipUnchangedFiles() || context.config().getBoolean(SONAR_CAN_SKIP_UNCHANGED_FILES_KEY).orElse(false))
+      && caching.isCacheVersionUpToDate();
   }
 
   private void computeGlobalSymbolsUsingCache(SensorContext context) {
@@ -147,6 +150,7 @@ public class SonarQubePythonIndexer extends PythonIndexer {
     if (caching.isCacheEnabled()) {
       saveGlobalSymbolsInCache(files);
       saveMainFilesListInCache(new HashSet<>(inputFileToFQN.values()));
+      caching.writeCacheVersion();
     }
   }
 
@@ -182,5 +186,19 @@ public class SonarQubePythonIndexer extends PythonIndexer {
   @Override
   public CacheContext cacheContext() {
     return caching.cacheContext();
+  }
+
+  private static String getCacheVersion(SensorContext context) {
+    String implementationVersion = getImplementationVersion(SonarQubePythonIndexer.class);
+    return context.config().get(PYTHON_VERSION_KEY).map(v -> implementationVersion + ";" + v).orElse(implementationVersion);
+  }
+
+  private static String getImplementationVersion(Class<?> cls) {
+    String implementationVersion = cls.getPackage().getImplementationVersion();
+    if (implementationVersion == null) {
+      LOG.warn("Implementation version of the Python plugin not found. Cached data may not be invalidated properly.");
+      return "unknown";
+    }
+    return implementationVersion;
   }
 }

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -873,7 +873,7 @@ public class PythonSensorTest {
 
   TestReadCache getValidReadCache() {
     TestReadCache testReadCache = new TestReadCache();
-    testReadCache.put(CACHE_VERSION_KEY, "unknown".getBytes(UTF_8));
+    testReadCache.put(CACHE_VERSION_KEY, "unknownPluginVersion".getBytes(UTF_8));
     return testReadCache;
   }
 }

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -80,7 +80,6 @@ import org.sonar.plugins.python.indexer.TestModuleFileSystem;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
 import org.sonar.python.checks.CheckList;
 
-import org.sonar.python.index.DescriptorUtils;
 import org.sonar.python.index.VariableDescriptor;
 import org.sonarsource.sonarlint.core.analysis.api.ClientInputFile;
 import org.sonarsource.sonarlint.core.analysis.api.QuickFix;
@@ -101,6 +100,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.sonar.plugins.python.caching.Caching.CACHE_VERSION_KEY;
 import static org.sonar.python.index.DescriptorsToProtobuf.toProtobufModuleDescriptor;
 import static org.sonar.plugins.python.caching.Caching.IMPORTS_MAP_CACHE_KEY_PREFIX;
 import static org.sonar.plugins.python.caching.Caching.PROJECT_SYMBOL_TABLE_CACHE_KEY_PREFIX;
@@ -672,7 +672,7 @@ public class PythonSensorTest {
       .build();
 
     InputFile inputFile = inputFile(FILE_2, Type.MAIN, InputFile.Status.SAME);
-    TestReadCache readCache = new TestReadCache();
+    TestReadCache readCache = getValidReadCache();
     TestWriteCache writeCache = new TestWriteCache();
     writeCache.bind(readCache);
 
@@ -700,7 +700,7 @@ public class PythonSensorTest {
       .build();
 
     inputFile(FILE_TEST_FILE, Type.TEST, InputFile.Status.SAME);
-    TestReadCache readCache = new TestReadCache();
+    TestReadCache readCache = getValidReadCache();
     TestWriteCache writeCache = new TestWriteCache();
     writeCache.bind(readCache);
 
@@ -869,5 +869,11 @@ public class PythonSensorTest {
 
     context.fileSystem().add(sonarFile);
     sensor().execute(context);
+  }
+
+  TestReadCache getValidReadCache() {
+    TestReadCache testReadCache = new TestReadCache();
+    testReadCache.put(CACHE_VERSION_KEY, "unknown".getBytes(UTF_8));
+    return testReadCache;
   }
 }

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/caching/CachingTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/caching/CachingTest.java
@@ -57,6 +57,8 @@ public class CachingTest {
   @org.junit.Rule
   public LogTester logTester = new LogTester();
 
+  private final static String CACHE_VERSION = "dummyVersion";
+
 
   @Test
   public void writeProjectLevelSymbolTableEntry() throws InvalidProtocolBufferException {
@@ -66,7 +68,7 @@ public class CachingTest {
     PythonReadCache pythonReadCache = new PythonReadCacheImpl(readCache);
     CacheContextImpl cacheContext = new CacheContextImpl(true, pythonWriteCache, pythonReadCache);
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     Set<Descriptor> initialDescriptors = Set.of(
       new ClassDescriptor("C", "mod.C", Collections.emptyList(), Collections.emptySet(), false, null, false, false, null, false),
       new FunctionDescriptor("foo", "mod.foo", Collections.emptyList(), false, false, Collections.emptyList(), false, null, null),
@@ -89,7 +91,7 @@ public class CachingTest {
     PythonReadCache pythonReadCache = new PythonReadCacheImpl(readCache);
     CacheContextImpl cacheContext = new CacheContextImpl(true, pythonWriteCache, pythonReadCache);
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     Set<Descriptor> initialDescriptors = Set.of(
       new ClassDescriptor("C", "mod.C", Collections.emptyList(), Collections.emptySet(), false, null, false, false, null, false),
       new FunctionDescriptor("foo", "mod.foo", Collections.emptyList(), false, false, Collections.emptyList(), false, null, null),
@@ -107,7 +109,7 @@ public class CachingTest {
     TestReadCache readCache = new TestReadCache();
     CacheContextImpl cacheContext = new CacheContextImpl(true, new PythonWriteCacheImpl(writeCache), new PythonReadCacheImpl(readCache));
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     assertThat(caching.readProjectLevelSymbolTableEntry("unknown")).isNull();
   }
 
@@ -123,7 +125,7 @@ public class CachingTest {
     Mockito.when(pythonReadCache.read(cacheKey)).thenReturn(inputStream);
 
     CacheContextImpl cacheContext = new CacheContextImpl(true, new PythonWriteCacheImpl(writeCache), pythonReadCache);
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     assertThat(caching.readProjectLevelSymbolTableEntry("mod")).isNull();
     assertThat(logTester.logs(LoggerLevel.DEBUG)).contains("Unable to read data for key: \"python:descriptors:mod\"");
   }
@@ -135,7 +137,7 @@ public class CachingTest {
     PythonReadCache pythonReadCache = new PythonReadCacheImpl(new TestReadCache());
     CacheContextImpl cacheContext = new CacheContextImpl(true, pythonWriteCache, pythonReadCache);
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     Set<String> imports = Set.of("mod2", "pkg1.mod3", "pkg2.pkg3.mod4");
 
     String cacheKey = IMPORTS_MAP_CACHE_KEY_PREFIX + "mod";
@@ -154,7 +156,7 @@ public class CachingTest {
     PythonReadCache pythonReadCache = new PythonReadCacheImpl(readCache);
     CacheContextImpl cacheContext = new CacheContextImpl(true, pythonWriteCache, pythonReadCache);
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     Set<String> imports = Set.of("mod2", "pkg1.mod3", "pkg2.pkg3.mod4");
     String cacheKey = IMPORTS_MAP_CACHE_KEY_PREFIX + "mod";
     readCache.put(cacheKey, String.join(";", imports).getBytes(StandardCharsets.UTF_8));
@@ -167,7 +169,7 @@ public class CachingTest {
     TestReadCache readCache = new TestReadCache();
     CacheContextImpl cacheContext = new CacheContextImpl(true, new PythonWriteCacheImpl(writeCache), new PythonReadCacheImpl(readCache));
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     assertThat(caching.readImportMapEntry("unknown")).isNull();
   }
 
@@ -180,7 +182,7 @@ public class CachingTest {
     CacheContextImpl cacheContext = new CacheContextImpl(true, pythonWriteCache, pythonReadCache);
 
 
-    Caching caching = new Caching(cacheContext);
+    Caching caching = new Caching(cacheContext, CACHE_VERSION);
     String module = "mod";
     readCache.put(PROJECT_SYMBOL_TABLE_CACHE_KEY_PREFIX + "mod", new byte[] {42});
     assertThat(caching.readProjectLevelSymbolTableEntry(module)).isNull();


### PR DESCRIPTION
Two comments on this PR:
* I left the `cacheContext` as a constructor parameter to `SonarQubePythonIndexer` although it is no longer necessary (since it's only built from the `SensorContext` which is now a constructor parameter as well). The reason for that is to not hinder the testability of the `SonarQubePythonIndexer`, in which we currently inject some test cache contexts. I'm not 100% sure it's the right way to do this, though.
* In unit tests, we don't have an implementation version available. I used the `unknown` default value as if it were a valid value. The behavior of the cache versioning itself is tested in the ITs where the implementation version is actually available.