### PR TITLE
SONARPY-1345 Fix stack overflow when a nested class inherits from a class with the same name

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
@@ -22,6 +22,7 @@ package org.sonar.python.tree;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -145,21 +146,22 @@ public class TreeUtils {
   }
 
   public static List<String> getParentClassesFQN(ClassDef classDef) {
-    return getParentClasses(TreeUtils.getClassSymbolFromDef(classDef)).stream()
+    return getParentClasses(TreeUtils.getClassSymbolFromDef(classDef), new HashSet<>()).stream()
       .map(Symbol::fullyQualifiedName)
       .filter(Objects::nonNull)
       .collect(Collectors.toList());
   }
 
-  private static List<Symbol> getParentClasses(@Nullable ClassSymbol classSymbol) {
+  private static List<Symbol> getParentClasses(@Nullable ClassSymbol classSymbol, Set<ClassSymbol> visitedSymbols) {
     List<Symbol> superClasses = new ArrayList<>();
-    if (classSymbol == null) {
+    if (classSymbol == null || visitedSymbols.contains(classSymbol)) {
       return superClasses;
     }
+    visitedSymbols.add(classSymbol);
     for (Symbol symbol : classSymbol.superClasses()) {
       superClasses.add(symbol);
       if (symbol instanceof ClassSymbol) {
-        superClasses.addAll(getParentClasses((ClassSymbol) symbol));
+        superClasses.addAll(getParentClasses((ClassSymbol) symbol, visitedSymbols));
       }
     }
     return superClasses;


### PR DESCRIPTION
The root cause of this problem is not trivial to fix: our symbol table builder works in two phases: the first records all "write" usages, and the second records all "read" usages. This is because it is possible to have "read" usages appear before the corresponding "write" (e.g, calling a function defined later in the code from another function body).

This leads to an implicit hoisting of symbols which is not always correct. In this case, the class symbol that is being defined ends up being considered as its supertype.
SONARPY-1350 was created to fix this. This PR prevents the stack overflow from happening, but doesn't fix the incorrect semantic resolution.