### PR TITLE
SONARPY-1325 Fix FP on S5727 when annotated return type is object

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/ComparisonToNoneCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/ComparisonToNoneCheck.java
@@ -57,7 +57,8 @@ public class ComparisonToNoneCheck extends PythonSubscriptionCheck {
   private static void checkIdentityComparison(SubscriptionContext ctx, IsExpression comparison) {
     InferredType left = comparison.leftOperand().type();
     InferredType right = comparison.rightOperand().type();
-    if (!left.isIdentityComparableWith(right) && (isNone(left) || isNone(right))) {
+    // `isObject` Removes FP when the return type of a function is an object
+    if (!left.isIdentityComparableWith(right) && (isNone(left) || isNone(right)) && !(isObject(left) || isObject(right))) {
       addIssue(ctx, comparison, "identity check", comparison.notToken() != null);
     } else if (isNone(left) && isNone(right)) {
       addIssue(ctx, comparison, "identity check", comparison.notToken() == null);
@@ -70,6 +71,11 @@ public class ComparisonToNoneCheck extends PythonSubscriptionCheck {
   }
 
   private static boolean cannotBeNone(InferredType type) {
-    return !type.canBeOrExtend(BuiltinTypes.NONE_TYPE);
+    return !type.canBeOrExtend(BuiltinTypes.NONE_TYPE) && !isObject(type);
   }
+
+  private static boolean isObject(InferredType type) {
+    return type.canOnlyBe(BuiltinTypes.OBJECT_TYPE);
+  }
+
 }

--- a/python-checks/src/test/resources/checks/comparisonToNoneCheck.py
+++ b/python-checks/src/test/resources/checks/comparisonToNoneCheck.py
@@ -1,3 +1,4 @@
+import pydoc
 def identity_check(param):
     a = None
     b = 42
@@ -13,6 +14,13 @@ def identity_check(param):
     if b is d: pass
     if None is a: pass # Noncompliant
     if None is b: pass # Noncompliant
+    obj = pydoc.locate("test")
+    if obj is not None: pass    
+    if None is not obj: pass
+
+    obj = object()
+    if obj is not None: pass # FN
+    if None is obj: pass # FN
 
 def equality_check(param):
     a = None
@@ -30,3 +38,10 @@ def equality_check(param):
     d = "abc"
     if b == d: pass
     if b != d: pass
+    obj = pydoc.locate("test")
+    if obj == None: pass
+    if None == obj: pass
+    
+    obj = object()
+    if obj == None: pass # FN
+    if None == obj: pass # FN

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/types/BuiltinTypes.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/types/BuiltinTypes.java
@@ -34,6 +34,8 @@ public class BuiltinTypes {
   public static final String EXCEPTION = "Exception";
   public static final String BASE_EXCEPTION = "BaseException";
 
+  public static final String OBJECT_TYPE = "object";
+
   private BuiltinTypes() {
   }
 


### PR DESCRIPTION
This PR removes some FPs but also adds some FNs.

Because I think we would want to raise an issue on:
```
obj = object()
if obj is not None: pass # Remove this identity check; it will always be True.
```
Is it ok to have a bit more FNs, by assuming that the comparison between object and None is always meaningful?