### PR TITLE
SONARPY-1384 Ensure submodule imports doesn't prevent parent module import

### DIFF
--- a/python-frontend/src/test/java/org/sonar/python/semantic/SymbolTableBuilderTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/SymbolTableBuilderTest.java
@@ -309,7 +309,6 @@ public class SymbolTableBuilderTest {
 
   @Test
   public void importing_submodule_as() {
-    // SONARPY-1384
     FunctionDef functionDef = functionTreesByName.get("importing_submodule_as");
     Map<String, Symbol> symbolByName = getSymbolByName(functionDef);
 
@@ -319,7 +318,12 @@ public class SymbolTableBuilderTest {
     Map<String, Symbol> childrenSymbolByName = werkzeug.getChildrenSymbolByName();
     Collection<Symbol> values = childrenSymbolByName.values();
     assertThat(values).isNotEmpty();
-    assertThat(values).extracting(Symbol::name).doesNotContain("datastructures");
+    assertThat(values).extracting(Symbol::name).contains("Headers");
+
+    CallExpression callExpression = (CallExpression) ((ExpressionStatement) functionDef.body().statements().get(1)).expressions().get(0);
+    Symbol qualifiedExpressionSymbol = callExpression.calleeSymbol();
+    assertThat(qualifiedExpressionSymbol.is(Symbol.Kind.CLASS)).isTrue();
+    assertThat(qualifiedExpressionSymbol.fullyQualifiedName()).isEqualTo("werkzeug.datastructures.headers.Headers");
   }
 
   @Test
@@ -387,9 +391,9 @@ public class SymbolTableBuilderTest {
 
     assertThat(symbolByName).containsOnlyKeys("werkzeug");
     SymbolImpl werkzeug = (SymbolImpl) symbolByName.get("werkzeug");
-    assertThat(werkzeug.usages()).extracting(Usage::kind).containsExactly(Usage.Kind.IMPORT, Usage.Kind.IMPORT, Usage.Kind.IMPORT, Usage.Kind.OTHER);
+    assertThat(werkzeug.usages()).extracting(Usage::kind).containsExactly(Usage.Kind.IMPORT, Usage.Kind.IMPORT, Usage.Kind.IMPORT, Usage.Kind.OTHER, Usage.Kind.OTHER);
     Map<String, Symbol> childrenSymbolByName = werkzeug.getChildrenSymbolByName();
-    assertThat(childrenSymbolByName.values()).extracting(Symbol::name).contains("datastructures");
+    assertThat(childrenSymbolByName.values()).extracting(Symbol::name).contains("datastructures", "Response");
     SymbolImpl datastructures = (SymbolImpl) childrenSymbolByName.get("datastructures");
     assertThat(datastructures.getChildrenSymbolByName().values()).extracting(Symbol::name).contains("Headers", "csp");
 
@@ -397,6 +401,11 @@ public class SymbolTableBuilderTest {
     Symbol qualifiedExpressionSymbol = callExpression.calleeSymbol();
     assertThat(qualifiedExpressionSymbol.is(Symbol.Kind.CLASS)).isTrue();
     assertThat(qualifiedExpressionSymbol.fullyQualifiedName()).isEqualTo("werkzeug.datastructures.csp.ContentSecurityPolicy");
+
+    CallExpression callExpression2 = (CallExpression) ((ExpressionStatement) functionDef.body().statements().get(4)).expressions().get(0);
+    Symbol qualifiedExpressionSymbol2 = callExpression2.calleeSymbol();
+    assertThat(qualifiedExpressionSymbol2.is(Symbol.Kind.CLASS)).isTrue();
+    assertThat(qualifiedExpressionSymbol2.fullyQualifiedName()).isEqualTo("werkzeug.datastructures.headers.Headers");
   }
 
   @Test

--- a/python-frontend/src/test/resources/semantic/symbols2.py
+++ b/python-frontend/src/test/resources/semantic/symbols2.py
@@ -207,6 +207,7 @@ def importing_parent_after_submodule_2():
     import werkzeug.datastructures
     import werkzeug
     werkzeug.datastructures.csp.ContentSecurityPolicy()
+    werkzeug.datastructures.Headers()
 
 
 def importing_submodule_twice():


### PR DESCRIPTION
The missing condition of coverage is an old defensive check. To be honest, I don't remember what it's about but I'd rather just keep it as a defensive check and accept the missing piece of coverage.