### PR TITLE
SONARPY-1402 Rule S6658: Fix - Raise only for methods

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/SpecialMethodReturnTypeCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/SpecialMethodReturnTypeCheck.java
@@ -71,6 +71,10 @@ public class SpecialMethodReturnTypeCheck extends PythonSubscriptionCheck {
   }
 
   private static void checkFunctionDefinition(SubscriptionContext ctx, FunctionDef funDef) {
+    if (!funDef.isMethodDefinition()) {
+      return;
+    }
+
     String funNameString = funDef.name().name();
     String expectedReturnType = METHOD_TO_RETURN_TYPE.get(funNameString);
     if (expectedReturnType == null) {

--- a/python-checks/src/test/resources/checks/specialMethodReturnTypeCheck.py
+++ b/python-checks/src/test/resources/checks/specialMethodReturnTypeCheck.py
@@ -364,4 +364,5 @@ class AbstractSpecialMethod01(ABC):
     def __format__(self, format_spec): # Compliant
         pass
 
-
+def __bool__():
+    return 42 # Compliant: This function is not part of a class definition


### PR DESCRIPTION
This is a minor change to not raise any issues for functions whose name matches one of the special methods but which are not actual methods.

Example:

```python
class C:
    def __bool__(self):
        return "Hello" # Noncompliant

def __bool__():
    return "Hello" # Compliant: This function is not part of a class definition
```

Hence, this fixes potential (albeit very unlikely) FPs 