### PR TITLE
SONARPY-1426: Failling Typeshed tests should fail the maven build

### DIFF
--- a/python-frontend/pom.xml
+++ b/python-frontend/pom.xml
@@ -157,6 +157,7 @@
                   <arguments>
                       <argument>runners/tox_runner.py</argument>
                   </arguments>
+                  <useMavenLogger>true</useMavenLogger>
                 </configuration>
                 <goals>
                   <goal>exec</goal>

--- a/python-frontend/typeshed_serializer/runners/tox_runner.py
+++ b/python-frontend/typeshed_serializer/runners/tox_runner.py
@@ -127,7 +127,7 @@ def main():
     logger.info(f"Checksum is computed over {len(source_files)} files")
     if previous_sources_checksum != current_sources_checksum:
         logger.info("STARTING TYPESHED SERIALIZATION")
-        subprocess.run(["tox"])
+        subprocess.run(["tox"], check=True)
     else:
         binary_file_names = fetch_binary_file_names()
         current_binaries_checksum = compute_checksum(binary_file_names, read_file)
@@ -140,7 +140,7 @@ def main():
         logger.info("SKIPPING TYPESHED SERIALIZATION")
         # At the moment we need to run the tests in order to not break the quality gate.
         # If the tests are skipped this could potentially result in missing coverage.
-        subprocess.run(['tox', '-e', 'py39'])
+        subprocess.run(['tox', '-e', 'py39'], check=True)
 
 
 if __name__ == '__main__':

--- a/python-frontend/typeshed_serializer/tests/runners/test_tox_runner.py
+++ b/python-frontend/typeshed_serializer/tests/runners/test_tox_runner.py
@@ -197,7 +197,7 @@ class ToxRunnerTest(unittest.TestCase):
             mocked_previous_checksum.assert_any_call(tox_runner.CHECKSUM_FILE)
             mocked_checksum.assert_any_call(self.FILE_NAMES, tox_runner.normalize_text_files)
             mocked_checksum.assert_any_call(self.FILE_NAMES, tox_runner.read_file)
-            mocked_subprocess.run.assert_called_with(['tox', '-e', 'py39'])
+            mocked_subprocess.run.assert_called_with(['tox', '-e', 'py39'], check=True)
 
     def test_tox_runner_different_binary_checksums(self):
         previous_checksum = '123'
@@ -234,4 +234,4 @@ class ToxRunnerTest(unittest.TestCase):
             tox_runner.main()
             mocked_previous_checksum.assert_called_with(tox_runner.CHECKSUM_FILE)
             mocked_checksum.assert_called_with(self.FILE_NAMES, tox_runner.normalize_text_files)
-            mocked_subprocess.run.assert_called_with(['tox'])
+            mocked_subprocess.run.assert_called_with(['tox'], check=True)


### PR DESCRIPTION
This PR depends on SONARPY-1427