### PR TITLE
S935: Fix ruleSpecification value in metadata

### DIFF
--- a/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S935.json
+++ b/python-checks/src/main/resources/org/sonar/l10n/py/rules/python/S935.json
@@ -1,6 +1,12 @@
 {
   "title": "Functions and methods should only return expected values",
   "type": "BUG",
+  "code": {
+    "impacts": {
+      "RELIABILITY": "HIGH"
+    },
+    "attribute": "LOGICAL"
+  },
   "status": "ready",
   "remediation": {
     "func": "Constant\/Issue",
@@ -8,7 +14,7 @@
   },
   "tags": [],
   "defaultSeverity": "Blocker",
-  "ruleSpecification": "RSPEC-S935",
+  "ruleSpecification": "RSPEC-935",
   "sqKey": "S935",
   "scope": "All",
   "securityStandards": {


### PR DESCRIPTION
There was an "S" in front of the rule number in the "ruleSpecification" value for the python version of the rule. I.e. "RSPEC-S935" -> "RSPEC-935".

This caused problems with the deployment of the rules marketing website: http://rules.sonarsource.com/

The corresponding change in the rspec repository have already been made, see the following PR: https://github.com/SonarSource/rspec/pull/2895
The changes of this commit have been generated using the rule API.