### PR TITLE
S1192 Implemented RuleProperty exclusionRegex to enable custom exclusion patterns

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/StringLiteralDuplicationCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/StringLiteralDuplicationCheck.java
@@ -43,7 +43,7 @@ public class StringLiteralDuplicationCheck extends PythonVisitorCheck {
 
   private static final Integer MINIMUM_LITERAL_LENGTH = 5;
   private static final int DEFAULT_THRESHOLD = 3;
-  private static final Pattern BASIC_EXCLUSION_PATTERN = Pattern.compile("[_\\-a-zA-Z0-9]+");
+  private static final String DEFAULT_EXCLUSION_REGEX = "[_\\-a-zA-Z0-9]+"
   private static final Pattern FORMATTING_PATTERN = Pattern.compile("[0-9{} .-_%:dfrsymhYMHS]+");
   private static final Pattern COLOR_PATTERN = Pattern.compile("#[0-9a-fA-F]{6}");
 
@@ -52,6 +52,12 @@ public class StringLiteralDuplicationCheck extends PythonVisitorCheck {
     description = "Number of times a literal must be duplicated to trigger an issue",
     defaultValue = "" + DEFAULT_THRESHOLD)
   public int threshold = DEFAULT_THRESHOLD;
+
+  @RuleProperty(
+    key = "exclusionRegex",
+    description = "RegEx matching literals to exclude from triggering an issue",
+    defaultValue = DEFAULT_EXCLUSION_REGEX)
+  public String exclusionRegex = DEFAULT_EXCLUSION_REGEX;
 
   private Map<String, List<StringLiteral>> literalsByValue = new HashMap<>();
 
@@ -90,9 +96,10 @@ public class StringLiteralDuplicationCheck extends PythonVisitorCheck {
   public void visitStringLiteral(StringLiteral literal) {
     String value = Expressions.unescape(literal);
     boolean hasInterpolation = literal.stringElements().stream().anyMatch(StringElement::isInterpolated);
+    Pattern exclusionPattern = Pattern.compile(exclusionRegex);
     boolean isExcluded = hasInterpolation
       || value.length() < MINIMUM_LITERAL_LENGTH
-      || BASIC_EXCLUSION_PATTERN.matcher(value).matches()
+      || exclusionPattern.matcher(value).matches()
       || FORMATTING_PATTERN.matcher(value).matches()
       || COLOR_PATTERN.matcher(value).matches();
     if (!isExcluded) {

--- a/python-checks/src/main/java/org/sonar/python/checks/StringLiteralDuplicationCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/StringLiteralDuplicationCheck.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 import org.sonar.check.Rule;
 import org.sonar.check.RuleProperty;
@@ -96,7 +97,11 @@ public class StringLiteralDuplicationCheck extends PythonVisitorCheck {
   public void visitStringLiteral(StringLiteral literal) {
     String value = Expressions.unescape(literal);
     boolean hasInterpolation = literal.stringElements().stream().anyMatch(StringElement::isInterpolated);
-    Pattern exclusionPattern = Pattern.compile(exclusionRegex);
+    try  {
+      Pattern exclusionPattern = Pattern.compile(exclusionRegex);
+    } catch (PatternSyntaxException e){
+      throw new IllegalStateException("Unable to compile regular expression: " + exclusionRegex, e);
+    }
     boolean isExcluded = hasInterpolation
       || value.length() < MINIMUM_LITERAL_LENGTH
       || exclusionPattern.matcher(value).matches()


### PR DESCRIPTION
The ability for users to define custom exclusion patterns has not yet explicitly been requested but issues like https://sonarsource.atlassian.net/browse/SONARPY-750 and https://sonarsource.atlassian.net/browse/SONARPHP-1294 relate to it.

This PR aims to enable users to define their own regular expressions and thus resolve issues like the ones mentioned above as well as giving users more control over what this rule enforces.

Since I couldn't find a test case for the only other RuleProperty 'threshold', I refrained from adding one to this property as well. Base case behaviour remains unchanged.