### PR TITLE
SONARPY-1374 Fix FN on S5607: list and tuple are not duck-type compatible

### DIFF
--- a/python-checks/src/test/resources/checks/incompatibleOperands/comparison.py
+++ b/python-checks/src/test/resources/checks/incompatibleOperands/comparison.py
@@ -2,7 +2,7 @@ def builtin_noncompliant(p):
   1 < "1"  # Noncompliant {{Fix this invalid "<" operation between incompatible types (int and str).}}
 #   ^
   complex(1) < complex(1)  # Noncompliant
-  [1] < (1,)  # FN Noncompliant
+  [1] < (1,)  # Noncompliant
 
   "1" > 1 # Noncompliant {{Fix this invalid ">" operation between incompatible types (str and int).}}
 

--- a/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
@@ -91,6 +91,7 @@ public class InferredTypes {
   private static final String BYTES = "bytes";
   // https://github.com/python/mypy/blob/e97377c454a1d5c019e9c56871d5f229db6b47b2/mypy/semanal_classprop.py#L16-L46
   private static final Map<String, Set<String>> HARDCODED_COMPATIBLE_TYPES = new HashMap<>();
+  private static final Set<String> HARDCODED_INCOMPATIBLE_TYPES = Set.of("tuple", "list");
 
   static {
     HARDCODED_COMPATIBLE_TYPES.put(BuiltinTypes.INT, new HashSet<>(Arrays.asList(BuiltinTypes.FLOAT, BuiltinTypes.COMPLEX)));
@@ -364,12 +365,24 @@ public class InferredTypes {
     boolean isDuckTypeCompatible = !"NoneType".equals(otherFullyQualifiedName) &&
       expectedTypeClass.declaredMembers().stream().allMatch(m -> actualTypeClass.resolveMember(m.name()).isPresent());
     boolean canBeOrExtend = otherFullyQualifiedName == null || actualTypeClass.canBeOrExtend(otherFullyQualifiedName);
-    return areHardcodedCompatible || isDuckTypeCompatible || canBeOrExtend;
+    boolean areHardcodedIncompatible = areHardCodedIncompatible(actualTypeClass, expectedTypeClass);
+    return (areHardcodedCompatible || isDuckTypeCompatible || canBeOrExtend) && !areHardcodedIncompatible;
   }
 
   private static boolean areHardcodedCompatible(ClassSymbol actual, ClassSymbol expected) {
     Set<String> compatibleTypes = HARDCODED_COMPATIBLE_TYPES.getOrDefault(actual.fullyQualifiedName(), Collections.emptySet());
     return compatibleTypes.stream().anyMatch(expected::canBeOrExtend);
+  }
+
+  private static boolean areHardCodedIncompatible(ClassSymbol actual, ClassSymbol expected) {
+    String expectedFqn = expected.fullyQualifiedName();
+    String actualFqn = actual.fullyQualifiedName();
+    if (expectedFqn == null || actualFqn == null) {
+      return false;
+    }
+    return HARDCODED_INCOMPATIBLE_TYPES.contains(actualFqn)
+      && HARDCODED_INCOMPATIBLE_TYPES.contains(expectedFqn)
+      && !expectedFqn.equals(actualFqn);
   }
 
   public static boolean containsDeclaredType(InferredType type) {

--- a/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
@@ -91,7 +91,8 @@ public class InferredTypes {
   private static final String BYTES = "bytes";
   // https://github.com/python/mypy/blob/e97377c454a1d5c019e9c56871d5f229db6b47b2/mypy/semanal_classprop.py#L16-L46
   private static final Map<String, Set<String>> HARDCODED_COMPATIBLE_TYPES = new HashMap<>();
-  private static final Set<String> HARDCODED_INCOMPATIBLE_TYPES = Set.of("tuple", "list");
+
+  private static final Set<Set<String>> HARDCODED_INCOMPATIBLE_TYPES = Set.of(Set.of("tuple", "list"));
 
   static {
     HARDCODED_COMPATIBLE_TYPES.put(BuiltinTypes.INT, new HashSet<>(Arrays.asList(BuiltinTypes.FLOAT, BuiltinTypes.COMPLEX)));
@@ -375,14 +376,12 @@ public class InferredTypes {
   }
 
   private static boolean areHardCodedIncompatible(ClassSymbol actual, ClassSymbol expected) {
-    String expectedFqn = expected.fullyQualifiedName();
-    String actualFqn = actual.fullyQualifiedName();
-    if (expectedFqn == null || actualFqn == null) {
-      return false;
-    }
-    return HARDCODED_INCOMPATIBLE_TYPES.contains(actualFqn)
-      && HARDCODED_INCOMPATIBLE_TYPES.contains(expectedFqn)
-      && !expectedFqn.equals(actualFqn);
+    return HARDCODED_INCOMPATIBLE_TYPES.contains(
+      Stream.of(actual, expected)
+        .map(ClassSymbol::fullyQualifiedName)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet())
+    );
   }
 
   public static boolean containsDeclaredType(InferredType type) {

--- a/python-frontend/src/test/java/org/sonar/python/types/RuntimeTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/RuntimeTypeTest.java
@@ -280,6 +280,14 @@ class RuntimeTypeTest {
   }
 
   @Test
+  void test_list_and_tuple_are_not_compatible() {
+    ClassSymbolImpl listType = new ClassSymbolImpl("list", "list");
+    ClassSymbolImpl tupleType = new ClassSymbolImpl("tuple", "tuple");
+    assertThat(new RuntimeType(listType).isCompatibleWith(new RuntimeType(tupleType))).isFalse();
+    assertThat(new RuntimeType(tupleType).isCompatibleWith(new RuntimeType(listType))).isFalse();
+  }
+
+  @Test
   void test_mustBeOrExtend() {
     ClassSymbolImpl x1 = new ClassSymbolImpl("x1", "x1");
     ClassSymbolImpl x2 = new ClassSymbolImpl("x2", "x2");


### PR DESCRIPTION
I did not see a clean and easy way to represent this other than by hardcoding it.
By our definition, a list can be used as a substitute for a tuple and they are therefore compatible types in that regard, as they define the same members.
We know it's actually not the case and I therefore hardcoded that information.