### PR TITLE
SONARPY-1523 Configure an extended ruling project as a Python 3.12 project

### DIFF
--- a/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
@@ -133,6 +133,8 @@ class PythonExtendedRulingTest {
   @Test
   void test_salt() throws IOException {
     SonarScanner build = buildWithCommonProperties("salt");
+    // salt is not actually a Python 3.12 project. This is to ensure analysis is performed correctly when the parameter is set.
+    build.setProperty("sonar.python.version", "3.12");
     build.setProperty("sonar.sources", "salt");
     build.setProperty("sonar.tests", "tests");
     executeBuild(build);


### PR DESCRIPTION
The initial goal of this ticket was to add an actual Python 3.12 project, or a project for which our new rules could raise issues (such as `mypy`).

However, this is not practical for various reasons:
* Extended ruling currently only raises issues on hardcoded bug rules, which is something that should be revisited (SONARPY-984) (our new rules are code smells)
* Reusing `mypy` would require changing the actual ruling as well, for which there is still an open ticket (SONARPY-1366)
* There are not yet many projects that use the Python 3.12 syntax to be integrated in our ruling tests.

Simply setting one of our existing project as a Python 3.12 project allows us to guarantee analysis performs correctly on such project for a fraction of the cost that would be involved should we want an actual Python 3.12 project there.