### PR TITLE
SONARPY-1550: Google cloud function for promotion migration

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -215,8 +215,7 @@ promote_task:
     memory: 1G
   env:
     #promotion cloud function
-    GCF_ACCESS_TOKEN: VAULT[development/kv/data/promote data.token]
-    PROMOTE_URL: VAULT[development/kv/data/promote data.url]
+    ARTIFACTORY_PROMOTE_ACCESS_TOKEN: VAULT[development/artifactory/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promoter access_token]    
     GITHUB_TOKEN: VAULT[development/github/token/${CIRRUS_REPO_OWNER}-${CIRRUS_REPO_NAME}-promotion token]
     #artifacts that will have downloadable links in burgr
     ARTIFACTS: org.sonarsource.python:sonar-python-plugin:jar


### PR DESCRIPTION
This PR follows the required changes depicted on [this page](https://xtranet-sonarsource.atlassian.net/wiki/spaces/RE/pages/2931064959/Cirrus+CI+-+How+to+migrate+away+of+GCP+promote+function)