### PR TITLE
SONARPY-1563 Fix FPs on S1172 when the parameter is intentionally unused

### DIFF
--- a/its/ruling/src/test/resources/expected/python-S1172.json
+++ b/its/ruling/src/test/resources/expected/python-S1172.json
@@ -1,46 +1,39 @@
 {
-'project:biopython/Bio/Alphabet/__init__.py':[
-236,
+"project:biopython/Bio/Blast/ParseBlastTable.py": [
+122
 ],
-'project:biopython/Bio/Blast/ParseBlastTable.py':[
-122,
-],
-'project:biopython/Bio/ExPASy/__init__.py':[
-66,
-],
-'project:biopython/Bio/GenBank/__init__.py':[
+"project:biopython/Bio/GenBank/__init__.py": [
 937,
 1062,
 1352,
 1604,
-1701,
+1701
 ],
-'project:biopython/Bio/Graphics/GenomeDiagram/_CircularDrawer.py':[
+"project:biopython/Bio/Graphics/GenomeDiagram/_CircularDrawer.py": [
 1093,
-1196,
+1196
 ],
-'project:biopython/Bio/MarkovModel.py':[
-542,
+"project:biopython/Bio/MarkovModel.py": [
+542
 ],
-'project:biopython/Bio/PDB/PDBIO.py':[
+"project:biopython/Bio/PDB/PDBIO.py": [
 35,
 39,
 43,
-47,
+47
 ],
-'project:biopython/Bio/PDB/SCADIO.py':[
-57,
+"project:biopython/Bio/PDB/SCADIO.py": [
+57
 ],
-'project:biopython/Bio/PDB/ic_rebuild.py':[
-350,
+"project:biopython/Bio/PDB/ic_rebuild.py": [
+350
 ],
-'project:biopython/Bio/PDB/mmtf/DefaultParser.py':[
+"project:biopython/Bio/PDB/mmtf/DefaultParser.py": [
 22,
 23,
 24,
 25,
 26,
-57,
 90,
 90,
 128,
@@ -49,37 +42,35 @@
 131,
 132,
 133,
-160,
+160
 ],
-'project:biopython/Bio/Phylo/CDAOIO.py':[
-169,
-280,
+"project:biopython/Bio/Phylo/CDAOIO.py": [
+280
 ],
-'project:biopython/Bio/Phylo/NeXMLIO.py':[
+"project:biopython/Bio/Phylo/NeXMLIO.py": [
 131,
-239,
+239
 ],
-'project:biopython/Bio/Phylo/NewickIO.py':[
+"project:biopython/Bio/Phylo/NewickIO.py": [
 333,
-351,
+351
 ],
-'project:biopython/Bio/Phylo/PAML/_parse_yn00.py':[
-98,
+"project:biopython/Bio/Phylo/PAML/_parse_yn00.py": [
+98
 ],
-'project:biopython/Bio/Phylo/_utils.py':[
+"project:biopython/Bio/Phylo/_utils.py": [
 329,
 425,
-454,
+454
 ],
-'project:biopython/Bio/PopGen/GenePop/Controller.py':[
+"project:biopython/Bio/PopGen/GenePop/Controller.py": [
 104,
-227,
+227
 ],
-'project:biopython/Bio/PopGen/GenePop/__init__.py':[
-182,
+"project:biopython/Bio/PopGen/GenePop/__init__.py": [
+182
 ],
-'project:biopython/Bio/Restriction/PrintFormat.py':[
-226,
+"project:biopython/Bio/Restriction/PrintFormat.py": [
 241,
 241,
 263,
@@ -87,29 +78,25 @@
 283,
 283,
 321,
-321,
+321
 ],
-'project:biopython/Bio/Restriction/Restriction.py':[
-2446,
+"project:biopython/Bio/Restriction/Restriction.py": [
+2446
 ],
-'project:biopython/Bio/SearchIO/HmmerIO/hmmer3_text.py':[
-329,
+"project:biopython/Bio/SearchIO/HmmerIO/hmmer3_text.py": [
+329
 ],
-'project:biopython/Bio/SearchIO/_legacy/NCBIStandalone.py':[
+"project:biopython/Bio/SearchIO/_legacy/NCBIStandalone.py": [
 964,
 967,
 970,
-1386,
+1386
 ],
-'project:biopython/Bio/SeqFeature.py':[
+"project:biopython/Bio/SeqFeature.py": [
 1659,
-1663,
+1663
 ],
-'project:biopython/Bio/SeqIO/InsdcIO.py':[
-1480,
-1488,
-],
-'project:biopython/Bio/SeqIO/QualityIO.py':[
+"project:biopython/Bio/SeqIO/QualityIO.py": [
 2036,
 2055,
 2073,
@@ -123,45 +110,39 @@
 2232,
 2285,
 2291,
-2300,
+2300
 ],
-'project:biopython/Bio/SeqIO/SnapGeneIO.py':[
+"project:biopython/Bio/SeqIO/SnapGeneIO.py": [
 102,
-102,
+102
 ],
-'project:biopython/Bio/Wise/__init__.py':[
-27,
+"project:biopython/Bio/codonalign/__init__.py": [
+37
 ],
-'project:biopython/Bio/codonalign/__init__.py':[
-37,
+"project:biopython/Bio/codonalign/codonalignment.py": [
+251
 ],
-'project:biopython/Bio/codonalign/codonalignment.py':[
-251,
-],
-'project:biopython/Bio/codonalign/codonseq.py':[
+"project:biopython/Bio/codonalign/codonseq.py": [
 213,
-841,
+841
 ],
-'project:biopython/Bio/motifs/__init__.py':[
-436,
-],
-'project:biopython/Bio/phenotype/pm_fitting.py':[
+"project:biopython/Bio/phenotype/pm_fitting.py": [
 34,
-43,
+43
 ],
-'project:biopython/BioSQL/BioSeq.py':[
-503,
+"project:biopython/BioSQL/BioSeq.py": [
+503
 ],
-'project:buildbot-0.8.6p1/buildbot/changes/hgbuildbot.py':[
+"project:buildbot-0.8.6p1/buildbot/changes/hgbuildbot.py": [
 46,
-46,
+46
 ],
-'project:buildbot-0.8.6p1/buildbot/clients/gtkPanes.py':[
+"project:buildbot-0.8.6p1/buildbot/clients/gtkPanes.py": [
 380,
 395,
-399,
+399
 ],
-'project:buildbot-0.8.6p1/buildbot/config.py':[
+"project:buildbot-0.8.6p1/buildbot/config.py": [
 297,
 311,
 333,
@@ -171,84 +152,84 @@
 418,
 440,
 456,
-474,
+474
 ],
-'project:buildbot-0.8.6p1/buildbot/db/migrate/versions/011_add_buildrequest_claims.py':[
+"project:buildbot-0.8.6p1/buildbot/db/migrate/versions/011_add_buildrequest_claims.py": [
 20,
-55,
+55
 ],
-'project:buildbot-0.8.6p1/buildbot/locks.py':[
-160,
+"project:buildbot-0.8.6p1/buildbot/locks.py": [
+160
 ],
-'project:buildbot-0.8.6p1/buildbot/manhole.py':[
-49,
+"project:buildbot-0.8.6p1/buildbot/manhole.py": [
+49
 ],
-'project:buildbot-0.8.6p1/buildbot/process/botmaster.py':[
-572,
+"project:buildbot-0.8.6p1/buildbot/process/botmaster.py": [
+572
 ],
-'project:buildbot-0.8.6p1/buildbot/process/buildstep.py':[
+"project:buildbot-0.8.6p1/buildbot/process/buildstep.py": [
 284,
 284,
 284,
-903,
+903
 ],
-'project:buildbot-0.8.6p1/buildbot/schedulers/forcesched.py':[
+"project:buildbot-0.8.6p1/buildbot/schedulers/forcesched.py": [
 48,
-48,
+48
 ],
-'project:buildbot-0.8.6p1/buildbot/scripts/startup.py':[
-89,
+"project:buildbot-0.8.6p1/buildbot/scripts/startup.py": [
+89
 ],
-'project:buildbot-0.8.6p1/buildbot/status/logfile.py':[
+"project:buildbot-0.8.6p1/buildbot/status/logfile.py": [
 166,
 166,
-166,
+166
 ],
-'project:buildbot-0.8.6p1/buildbot/status/web/authz.py':[
-131,
+"project:buildbot-0.8.6p1/buildbot/status/web/authz.py": [
+131
 ],
-'project:buildbot-0.8.6p1/buildbot/status/web/base.py':[
+"project:buildbot-0.8.6p1/buildbot/status/web/base.py": [
 184,
-555,
+555
 ],
-'project:buildbot-0.8.6p1/buildbot/status/web/hooks/base.py':[
-23,
+"project:buildbot-0.8.6p1/buildbot/status/web/hooks/base.py": [
+23
 ],
-'project:buildbot-0.8.6p1/buildbot/status/web/hooks/github.py':[
+"project:buildbot-0.8.6p1/buildbot/status/web/hooks/github.py": [
 77,
 100,
-100,
+100
 ],
-'project:buildbot-0.8.6p1/buildbot/test/fake/fakedb.py':[
+"project:buildbot-0.8.6p1/buildbot/test/fake/fakedb.py": [
 354,
-957,
+957
 ],
-'project:buildbot-0.8.6p1/buildbot/test/fake/remotecommand.py':[
-38,
+"project:buildbot-0.8.6p1/buildbot/test/fake/remotecommand.py": [
+38
 ],
-'project:buildbot-0.8.6p1/contrib/buildbot_cvs_mail.py':[
+"project:buildbot-0.8.6p1/contrib/buildbot_cvs_mail.py": [
 64,
-64,
+64
 ],
-'project:buildbot-0.8.6p1/contrib/git_buildbot.py':[
-200,
+"project:buildbot-0.8.6p1/contrib/git_buildbot.py": [
+200
 ],
-'project:buildbot-slave-0.8.6p1/buildslave/commands/base.py':[
-192,
+"project:buildbot-slave-0.8.6p1/buildslave/commands/base.py": [
+192
 ],
-'project:buildbot-slave-0.8.6p1/buildslave/scripts/startup.py':[
-101,
+"project:buildbot-slave-0.8.6p1/buildslave/scripts/startup.py": [
+101
 ],
-'project:buildbot-slave-0.8.6p1/buildslave/test/fake/runprocess.py':[
-180,
+"project:buildbot-slave-0.8.6p1/buildslave/test/fake/runprocess.py": [
+180
 ],
-'project:django-2.2.3/django/contrib/admin/checks.py':[
+"project:django-2.2.3/django/contrib/admin/checks.py": [
 52,
 60,
 134,
-673,
+673
 ],
-'project:django-2.2.3/django/contrib/admin/options.py':[
+"project:django-2.2.3/django/contrib/admin/options.py": [
 190,
 279,
 308,
@@ -261,73 +242,72 @@
 420,
 474,
 489,
-504,
+504
 ],
-'project:django-2.2.3/django/contrib/admin/widgets.py':[
-422,
+"project:django-2.2.3/django/contrib/admin/widgets.py": [
+422
 ],
-'project:django-2.2.3/django/contrib/admindocs/middleware.py':[
+"project:django-2.2.3/django/contrib/admindocs/middleware.py": [
 12,
-12,
+12
 ],
-'project:django-2.2.3/django/contrib/auth/backends.py':[
-16,
+"project:django-2.2.3/django/contrib/auth/backends.py": [
+16
 ],
-'project:django-2.2.3/django/contrib/auth/checks.py':[
+"project:django-2.2.3/django/contrib/auth/checks.py": [
 11,
-97,
+97
 ],
-'project:django-2.2.3/django/contrib/auth/handlers/modwsgi.py':[
+"project:django-2.2.3/django/contrib/auth/handlers/modwsgi.py": [
 7,
-29,
+29
 ],
-'project:django-2.2.3/django/contrib/auth/hashers.py':[
+"project:django-2.2.3/django/contrib/auth/hashers.py": [
 213,
-216,
-216,
+216
 ],
-'project:django-2.2.3/django/contrib/auth/models.py':[
+"project:django-2.2.3/django/contrib/auth/models.py": [
 14,
 14,
-410,
+410
 ],
-'project:django-2.2.3/django/contrib/auth/password_validation.py':[
+"project:django-2.2.3/django/contrib/auth/password_validation.py": [
 98,
 182,
-197,
+197
 ],
-'project:django-2.2.3/django/contrib/contenttypes/checks.py':[
+"project:django-2.2.3/django/contrib/contenttypes/checks.py": [
 7,
-24,
+24
 ],
-'project:django-2.2.3/django/contrib/contenttypes/fields.py':[
+"project:django-2.2.3/django/contrib/contenttypes/fields.py": [
 49,
-74,
+74
 ],
-'project:django-2.2.3/django/contrib/contenttypes/management/__init__.py':[
+"project:django-2.2.3/django/contrib/contenttypes/management/__init__.py": [
 45,
 104,
-104,
+104
 ],
-'project:django-2.2.3/django/contrib/gis/db/backends/base/operations.py':[
-79,
+"project:django-2.2.3/django/contrib/gis/db/backends/base/operations.py": [
+79
 ],
-'project:django-2.2.3/django/contrib/gis/db/backends/spatialite/operations.py':[
+"project:django-2.2.3/django/contrib/gis/db/backends/spatialite/operations.py": [
 205,
 205,
 213,
-213,
+213
 ],
-'project:django-2.2.3/django/contrib/gis/db/backends/utils.py':[
-24,
+"project:django-2.2.3/django/contrib/gis/db/backends/utils.py": [
+24
 ],
-'project:django-2.2.3/django/contrib/gis/db/models/lookups.py':[
-70,
+"project:django-2.2.3/django/contrib/gis/db/models/lookups.py": [
+70
 ],
-'project:django-2.2.3/django/contrib/gis/gdal/libgdal.py':[
-109,
+"project:django-2.2.3/django/contrib/gis/gdal/libgdal.py": [
+109
 ],
-'project:django-2.2.3/django/contrib/gis/gdal/prototypes/errcheck.py':[
+"project:django-2.2.3/django/contrib/gis/gdal/prototypes/errcheck.py": [
 26,
 38,
 70,
@@ -338,71 +318,65 @@
 114,
 114,
 121,
-131,
+131
 ],
-'project:django-2.2.3/django/contrib/gis/geos/prototypes/errcheck.py':[
+"project:django-2.2.3/django/contrib/gis/geos/prototypes/errcheck.py": [
 20,
 29,
 36,
 44,
-71,
+71
 ],
-'project:django-2.2.3/django/contrib/gis/sitemaps/views.py':[
-10,
+"project:django-2.2.3/django/contrib/gis/sitemaps/views.py": [
+10
 ],
-'project:django-2.2.3/django/contrib/postgres/fields/citext.py':[
+"project:django-2.2.3/django/contrib/postgres/fields/citext.py": [
+11
+],
+"project:django-2.2.3/django/contrib/postgres/signals.py": [
+37
+],
+"project:django-2.2.3/django/contrib/sites/management.py": [
 11,
-],
-'project:django-2.2.3/django/contrib/postgres/signals.py':[
-37,
-],
-'project:django-2.2.3/django/contrib/sites/management.py':[
 11,
-11,
-11,
+11
 ],
-'project:django-2.2.3/django/contrib/staticfiles/checks.py':[
+"project:django-2.2.3/django/contrib/staticfiles/checks.py": [
 4,
-4,
+4
 ],
-'project:django-2.2.3/django/contrib/staticfiles/storage.py':[
-73,
-209,
+"project:django-2.2.3/django/contrib/staticfiles/storage.py": [
+209
 ],
-'project:django-2.2.3/django/contrib/syndication/views.py':[
+"project:django-2.2.3/django/contrib/syndication/views.py": [
 95,
 102,
 109,
 109,
-109,
+109
 ],
-'project:django-2.2.3/django/core/files/locks.py':[
+"project:django-2.2.3/django/core/files/locks.py": [
 99,
 99,
-103,
+103
 ],
-'project:django-2.2.3/django/core/management/commands/inspectdb.py':[
-229,
+"project:django-2.2.3/django/core/management/commands/inspectdb.py": [
+229
 ],
-'project:django-2.2.3/django/core/management/commands/runserver.py':[
+"project:django-2.2.3/django/core/management/commands/runserver.py": [
 62,
-62,
+62
 ],
-'project:django-2.2.3/django/core/management/commands/showmigrations.py':[
-50,
+"project:django-2.2.3/django/core/management/commands/showmigrations.py": [
+50
 ],
-'project:django-2.2.3/django/db/backends/base/creation.py':[
+"project:django-2.2.3/django/db/backends/base/creation.py": [
 155,
 199,
-266,
+266
 ],
-'project:django-2.2.3/django/db/backends/base/introspection.py':[
-17,
-],
-'project:django-2.2.3/django/db/backends/base/operations.py':[
+"project:django-2.2.3/django/db/backends/base/operations.py": [
 56,
-56,
-65,
 83,
 165,
 184,
@@ -412,7 +386,6 @@
 248,
 257,
 257,
-406,
 406,
 416,
 416,
@@ -424,11 +397,10 @@
 594,
 601,
 669,
-672,
+672
 ],
-'project:django-2.2.3/django/db/backends/base/schema.py':[
+"project:django-2.2.3/django/db/backends/base/schema.py": [
 192,
-401,
 781,
 781,
 803,
@@ -438,42 +410,41 @@
 855,
 855,
 951,
-982,
+982
 ],
-'project:django-2.2.3/django/db/backends/base/validation.py':[
+"project:django-2.2.3/django/db/backends/base/validation.py": [
 6,
-9,
+9
 ],
-'project:django-2.2.3/django/db/backends/ddl_references.py':[
+"project:django-2.2.3/django/db/backends/ddl_references.py": [
 10,
 16,
-16,
+16
 ],
-'project:django-2.2.3/django/db/backends/mysql/operations.py':[
-218,
+"project:django-2.2.3/django/db/backends/mysql/operations.py": [
+218
 ],
-'project:django-2.2.3/django/db/backends/mysql/validation.py':[
-12,
+"project:django-2.2.3/django/db/backends/mysql/validation.py": [
+12
 ],
-'project:django-2.2.3/django/db/backends/oracle/base.py':[
-372,
+"project:django-2.2.3/django/db/backends/oracle/base.py": [
+372
 ],
-'project:django-2.2.3/django/db/backends/postgresql/operations.py':[
-234,
+"project:django-2.2.3/django/db/backends/postgresql/operations.py": [
+234
 ],
-'project:django-2.2.3/django/db/backends/sqlite3/operations.py':[
+"project:django-2.2.3/django/db/backends/sqlite3/operations.py": [
 283,
 287,
 287,
-300,
+300
 ],
-'project:django-2.2.3/django/db/migrations/operations/base.py':[
-83,
+"project:django-2.2.3/django/db/migrations/operations/base.py": [
 83,
 95,
-116,
+116
 ],
-'project:django-2.2.3/django/db/migrations/questioner.py':[
+"project:django-2.2.3/django/db/migrations/questioner.py": [
 56,
 56,
 61,
@@ -486,27 +457,27 @@
 70,
 74,
 78,
-78,
+78
 ],
-'project:django-2.2.3/django/db/models/base.py':[
-875,
+"project:django-2.2.3/django/db/models/base.py": [
+875
 ],
-'project:django-2.2.3/django/db/models/deletion.py':[
+"project:django-2.2.3/django/db/models/deletion.py": [
 33,
 36,
 42,
 46,
-170,
+170
 ],
-'project:django-2.2.3/django/db/models/expressions.py':[
+"project:django-2.2.3/django/db/models/expressions.py": [
 223,
 247,
 510,
 539,
 542,
-553,
+553
 ],
-'project:django-2.2.3/django/db/models/fields/__init__.py':[
+"project:django-2.2.3/django/db/models/fields/__init__.py": [
 390,
 549,
 592,
@@ -517,9 +488,9 @@
 1516,
 1678,
 1910,
-2276,
+2276
 ],
-'project:django-2.2.3/django/db/models/fields/related.py':[
+"project:django-2.2.3/django/db/models/fields/related.py": [
 386,
 684,
 684,
@@ -528,78 +499,65 @@
 1149,
 1160,
 1193,
-1392,
+1392
 ],
-'project:django-2.2.3/django/db/models/lookups.py':[
+"project:django-2.2.3/django/db/models/lookups.py": [
 73,
-76,
+76
 ],
-'project:django-2.2.3/django/db/models/manager.py':[
-75,
+"project:django-2.2.3/django/db/models/manager.py": [
+75
 ],
-'project:django-2.2.3/django/db/models/query_utils.py':[
+"project:django-2.2.3/django/db/models/query_utils.py": [
 43,
 43,
-332,
+332
 ],
-'project:django-2.2.3/django/db/models/sql/datastructures.py':[
+"project:django-2.2.3/django/db/models/sql/datastructures.py": [
 157,
-165,
+165
 ],
-'project:django-2.2.3/django/db/models/sql/query.py':[
+"project:django-2.2.3/django/db/models/sql/query.py": [
 281,
 1004,
 1004,
-1017,
+1017
 ],
-'project:django-2.2.3/django/db/models/sql/where.py':[
+"project:django-2.2.3/django/db/models/sql/where.py": [
 208,
-208,
+208
 ],
-'project:django-2.2.3/django/forms/fields.py':[
-166,
+"project:django-2.2.3/django/forms/fields.py": [
+166
 ],
-'project:django-2.2.3/django/forms/formsets.py':[
-139,
-],
-'project:django-2.2.3/django/forms/models.py':[
-648,
-],
-'project:django-2.2.3/django/forms/widgets.py':[
+"project:django-2.2.3/django/forms/widgets.py": [
 253,
 260,
-275,
+275
 ],
-'project:django-2.2.3/django/middleware/cache.py':[
-71,
+"project:django-2.2.3/django/middleware/cache.py": [
+71
 ],
-'project:django-2.2.3/django/middleware/clickjacking.py':[
-37,
-37,
+"project:django-2.2.3/django/middleware/clickjacking.py": [
+37
 ],
-'project:django-2.2.3/django/middleware/common.py':[
-148,
-],
-'project:django-2.2.3/django/middleware/csrf.py':[
+"project:django-2.2.3/django/middleware/csrf.py": [
 206,
-206,
+206
 ],
-'project:django-2.2.3/django/template/context_processors.py':[
+"project:django-2.2.3/django/template/context_processors.py": [
 52,
 61,
 66,
-73,
+73
 ],
-'project:django-2.2.3/django/template/engine.py':[
-121,
+"project:django-2.2.3/django/template/engine.py": [
+121
 ],
-'project:django-2.2.3/django/template/library.py':[
-136,
+"project:django-2.2.3/django/template/library.py": [
+136
 ],
-'project:django-2.2.3/django/template/smartif.py':[
-133,
-],
-'project:django-2.2.3/django/test/runner.py':[
+"project:django-2.2.3/django/test/runner.py": [
 189,
 193,
 217,
@@ -610,66 +568,56 @@
 586,
 590,
 590,
-614,
+614
 ],
-'project:django-2.2.3/django/test/utils.py':[
-155,
+"project:django-2.2.3/django/test/utils.py": [
+155
 ],
-'project:django-2.2.3/django/utils/cache.py':[
-116,
+"project:django-2.2.3/django/utils/cache.py": [
+116
 ],
-'project:django-2.2.3/django/utils/decorators.py':[
-117,
+"project:django-2.2.3/django/utils/decorators.py": [
+117
 ],
-'project:django-2.2.3/django/utils/feedgenerator.py':[
-133,
-],
-'project:django-2.2.3/django/utils/six.py':[
+"project:django-2.2.3/django/utils/six.py": [
 182,
-539,
+539
 ],
-'project:django-2.2.3/django/utils/translation/reloader.py':[
+"project:django-2.2.3/django/utils/translation/reloader.py": [
 7,
 20,
-20,
+20
 ],
-'project:django-2.2.3/django/utils/translation/trans_null.py':[
-24,
-28,
+"project:django-2.2.3/django/utils/translation/trans_null.py": [
 32,
 51,
 55,
 55,
 59,
-63,
+63
 ],
-'project:django-2.2.3/django/views/csrf.py':[
-104,
-],
-'project:django-2.2.3/django/views/debug.py':[
+"project:django-2.2.3/django/views/debug.py": [
 121,
-131,
-512,
+512
 ],
-'project:django-2.2.3/django/views/generic/base.py':[
+"project:django-2.2.3/django/views/generic/base.py": [
 106,
 106,
 106,
 157,
-157,
+157
 ],
-'project:django-2.2.3/django/views/generic/dates.py':[
+"project:django-2.2.3/django/views/generic/dates.py": [
 298,
 298,
-298,
+298
 ],
-'project:django-2.2.3/django/views/generic/detail.py':[
+"project:django-2.2.3/django/views/generic/detail.py": [
 105,
 105,
-105,
+105
 ],
-'project:django-2.2.3/django/views/generic/edit.py':[
-55,
+"project:django-2.2.3/django/views/generic/edit.py": [
 131,
 131,
 131,
@@ -678,46 +626,41 @@
 135,
 206,
 206,
-206,
+206
 ],
-'project:django-2.2.3/django/views/generic/list.py':[
+"project:django-2.2.3/django/views/generic/list.py": [
 77,
 141,
 141,
-141,
+141
 ],
-'project:django-2.2.3/scripts/manage_translations.py':[
-83,
+"project:django-2.2.3/scripts/manage_translations.py": [
+83
 ],
-'project:django-cms-3.7.1/cms/app_base.py':[
+"project:django-cms-3.7.1/cms/app_base.py": [
 55,
-55,
-55,
-81,
-81,
-81,
+81
 ],
-'project:django-cms-3.7.1/cms/cache/choices.py':[
+"project:django-cms-3.7.1/cms/cache/choices.py": [
 26,
 26,
 30,
-30,
+30
 ],
-'project:django-cms-3.7.1/cms/page_rendering.py':[
-16,
+"project:django-cms-3.7.1/cms/page_rendering.py": [
+16
 ],
-'project:django-cms-3.7.1/cms/plugin_processors.py':[
+"project:django-cms-3.7.1/cms/plugin_processors.py": [
 4,
-4,
 19,
 19,
-19,
+19
 ],
-'project:django-cms-3.7.1/cms/signals/apphook.py':[
+"project:django-cms-3.7.1/cms/signals/apphook.py": [
 17,
-35,
+35
 ],
-'project:django-cms-3.7.1/cms/signals/permissions.py':[
+"project:django-cms-3.7.1/cms/signals/permissions.py": [
 8,
 8,
 26,
@@ -733,99 +676,95 @@
 78,
 82,
 82,
-87,
+87
 ],
-'project:django-cms-3.7.1/cms/test_utils/project/objectpermissionsapp/backends.py':[
-39,
+"project:django-cms-3.7.1/cms/test_utils/project/objectpermissionsapp/backends.py": [
+39
 ],
-'project:django-cms-3.7.1/cms/test_utils/project/sampleapp/views.py':[
+"project:django-cms-3.7.1/cms/test_utils/project/sampleapp/views.py": [
 71,
-76,
+76
 ],
-'project:django-cms-3.7.1/cms/utils/helpers.py':[
-8,
+"project:django-cms-3.7.1/cms/utils/helpers.py": [
+8
 ],
-'project:django-cms-3.7.1/cms/utils/moderator.py':[
+"project:django-cms-3.7.1/cms/utils/moderator.py": [
 18,
-24,
+24
 ],
-'project:django-cms-3.7.1/cms/utils/page_permissions.py':[
-47,
+"project:django-cms-3.7.1/cms/utils/page_permissions.py": [
+47
 ],
-'project:django-cms-3.7.1/cms/utils/placeholder.py':[
+"project:django-cms-3.7.1/cms/utils/placeholder.py": [
 130,
-133,
+133
 ],
-'project:django-cms-3.7.1/cms/utils/urlutils.py':[
-95,
+"project:django-cms-3.7.1/cms/utils/urlutils.py": [
+95
 ],
-'project:django-cms-3.7.1/cms/wizards/wizard_base.py':[
+"project:django-cms-3.7.1/cms/wizards/wizard_base.py": [
 66,
 72,
 78,
-104,
+104
 ],
-'project:docker-compose-1.24.1/compose/cli/command.py':[
+"project:docker-compose-1.24.1/compose/cli/command.py": [
 74,
-90,
+90
 ],
-'project:docker-compose-1.24.1/compose/cli/main.py':[
+"project:docker-compose-1.24.1/compose/cli/main.py": [
 1162,
 1162,
-1342,
+1342
 ],
-'project:docker-compose-1.24.1/compose/config/config.py':[
+"project:docker-compose-1.24.1/compose/config/config.py": [
 1129,
 1129,
 1146,
-1354,
+1354
 ],
-'project:docker-compose-1.24.1/contrib/migration/migrate-compose-file-v1-to-v2.py':[
-144,
+"project:docker-compose-1.24.1/contrib/migration/migrate-compose-file-v1-to-v2.py": [
+144
 ],
-'project:mypy-0.782/misc/actions_stubs.py':[
-16,
+"project:mypy-0.782/misc/actions_stubs.py": [
+16
 ],
-'project:mypy-0.782/misc/proper_plugin.py':[
-136,
+"project:mypy-0.782/misc/proper_plugin.py": [
+136
 ],
-'project:mypy-0.782/misc/variadics.py':[
-9,
+"project:mypy-0.782/misc/variadics.py": [
+9
 ],
-'project:mypy-0.782/mypy/build.py':[
-2505,
-],
-'project:mypy-0.782/mypy/checkmember.py':[
+"project:mypy-0.782/mypy/checkmember.py": [
 534,
-620,
+620
 ],
-'project:mypy-0.782/mypy/checkstrformat.py':[
-372,
+"project:mypy-0.782/mypy/checkstrformat.py": [
+372
 ],
-'project:mypy-0.782/mypy/config_parser.py':[
-296,
+"project:mypy-0.782/mypy/config_parser.py": [
+296
 ],
-'project:mypy-0.782/mypy/dmypy_server.py':[
-133,
+"project:mypy-0.782/mypy/dmypy_server.py": [
+133
 ],
-'project:mypy-0.782/mypy/fastparse.py':[
+"project:mypy-0.782/mypy/fastparse.py": [
 648,
-1560,
+1560
 ],
-'project:mypy-0.782/mypy/fastparse2.py':[
-999,
+"project:mypy-0.782/mypy/fastparse2.py": [
+999
 ],
-'project:mypy-0.782/mypy/main.py':[
-43,
+"project:mypy-0.782/mypy/main.py": [
+43
 ],
-'project:mypy-0.782/mypy/messages.py':[
+"project:mypy-0.782/mypy/messages.py": [
 749,
 836,
-1772,
+1772
 ],
-'project:mypy-0.782/mypy/plugin.py':[
+"project:mypy-0.782/mypy/plugin.py": [
 477,
-500,
 517,
 536,
 553,
@@ -835,122 +774,115 @@
 635,
 647,
 657,
-666,
+666
 ],
-'project:mypy-0.782/mypy/semanal_namedtuple.py':[
-312,
-],
-'project:mypy-0.782/mypy/semanal_typeddict.py':[
-269,
-],
-'project:mypy-0.782/mypy/server/update.py':[
+"project:mypy-0.782/mypy/server/update.py": [
 686,
-695,
+695
 ],
-'project:mypy-0.782/mypy/suggestions.py':[
-349,
-637,
+"project:mypy-0.782/mypy/suggestions.py": [
+349
 ],
-'project:mypy-0.782/mypy/test/typefixture.py':[
-200,
+"project:mypy-0.782/mypy/test/typefixture.py": [
+200
 ],
-'project:mypy-0.782/mypy/types.py':[
-1473,
+"project:mypy-0.782/mypy/types.py": [
+1473
 ],
-'project:mypy-0.782/mypyc/codegen/emit.py':[
+"project:mypy-0.782/mypyc/codegen/emit.py": [
 502,
 529,
-529,
+529
 ],
-'project:mypy-0.782/mypyc/codegen/emitclass.py':[
+"project:mypy-0.782/mypyc/codegen/emitclass.py": [
 107,
 470,
-528,
+528
 ],
-'project:mypy-0.782/mypyc/ir/class_ir.py':[
-217,
+"project:mypy-0.782/mypyc/ir/class_ir.py": [
+217
 ],
-'project:mypy-0.782/mypyc/irbuild/prepare.py':[
+"project:mypy-0.782/mypyc/irbuild/prepare.py": [
 41,
-42,
+42
 ],
-'project:mypy-0.782/mypyc/transform/refcount.py':[
-99,
+"project:mypy-0.782/mypyc/transform/refcount.py": [
+99
 ],
-'project:mypy-0.782/test-data/stdlib-samples/3.2/shutil.py':[
+"project:mypy-0.782/test-data/stdlib-samples/3.2/shutil.py": [
 569,
-637,
+637
 ],
-'project:mypy-0.782/test-data/unit/plugins/arg_kinds.py':[
-33,
+"project:mypy-0.782/test-data/unit/plugins/arg_kinds.py": [
+33
 ],
-'project:mypy-0.782/test-data/unit/plugins/arg_names.py':[
-34,
+"project:mypy-0.782/test-data/unit/plugins/arg_names.py": [
+34
 ],
-'project:mypy-0.782/test-data/unit/plugins/attrhook.py':[
-20,
+"project:mypy-0.782/test-data/unit/plugins/attrhook.py": [
+20
 ],
-'project:mypy-0.782/test-data/unit/plugins/attrhook2.py':[
-25,
+"project:mypy-0.782/test-data/unit/plugins/attrhook2.py": [
+25
 ],
-'project:mypy-0.782/test-data/unit/plugins/badreturn2.py':[
-4,
+"project:mypy-0.782/test-data/unit/plugins/badreturn2.py": [
+4
 ],
-'project:mypy-0.782/test-data/unit/plugins/callable_instance.py':[
-22,
+"project:mypy-0.782/test-data/unit/plugins/callable_instance.py": [
+22
 ],
-'project:mypy-0.782/test-data/unit/plugins/class_callable.py':[
-31,
+"project:mypy-0.782/test-data/unit/plugins/class_callable.py": [
+31
 ],
-'project:mypy-0.782/test-data/unit/plugins/common_api_incremental.py':[
-43,
+"project:mypy-0.782/test-data/unit/plugins/common_api_incremental.py": [
+43
 ],
-'project:mypy-0.782/test-data/unit/plugins/config_data.py':[
-17,
+"project:mypy-0.782/test-data/unit/plugins/config_data.py": [
+17
 ],
-'project:mypy-0.782/test-data/unit/plugins/customentry.py':[
-13,
+"project:mypy-0.782/test-data/unit/plugins/customentry.py": [
+13
 ],
-'project:mypy-0.782/test-data/unit/plugins/customize_mro.py':[
-9,
+"project:mypy-0.782/test-data/unit/plugins/customize_mro.py": [
+9
 ],
-'project:mypy-0.782/test-data/unit/plugins/depshook.py':[
-14,
+"project:mypy-0.782/test-data/unit/plugins/depshook.py": [
+14
 ],
-'project:mypy-0.782/test-data/unit/plugins/descriptor.py':[
-33,
+"project:mypy-0.782/test-data/unit/plugins/descriptor.py": [
+33
 ],
-'project:mypy-0.782/test-data/unit/plugins/dyn_class.py':[
-46,
+"project:mypy-0.782/test-data/unit/plugins/dyn_class.py": [
+46
 ],
-'project:mypy-0.782/test-data/unit/plugins/dyn_class_from_method.py':[
-27,
+"project:mypy-0.782/test-data/unit/plugins/dyn_class_from_method.py": [
+27
 ],
-'project:mypy-0.782/test-data/unit/plugins/fnplugin.py':[
-13,
+"project:mypy-0.782/test-data/unit/plugins/fnplugin.py": [
+13
 ],
-'project:mypy-0.782/test-data/unit/plugins/fully_qualified_test_hook.py':[
-15,
+"project:mypy-0.782/test-data/unit/plugins/fully_qualified_test_hook.py": [
+15
 ],
-'project:mypy-0.782/test-data/unit/plugins/method_sig_hook.py':[
-29,
+"project:mypy-0.782/test-data/unit/plugins/method_sig_hook.py": [
+29
 ],
-'project:mypy-0.782/test-data/unit/plugins/named_callable.py':[
-27,
+"project:mypy-0.782/test-data/unit/plugins/named_callable.py": [
+27
 ],
-'project:mypy-0.782/test-data/unit/plugins/plugin2.py':[
-12,
+"project:mypy-0.782/test-data/unit/plugins/plugin2.py": [
+12
 ],
-'project:mypy-0.782/test-data/unit/plugins/type_anal_hook.py':[
-38,
+"project:mypy-0.782/test-data/unit/plugins/type_anal_hook.py": [
+38
 ],
-'project:mypy-0.782/test-data/unit/plugins/union_method.py':[
-48,
+"project:mypy-0.782/test-data/unit/plugins/union_method.py": [
+48
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_app.py':[
-52,
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_app.py": [
+52
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_core.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_core.py": [
 105,
 109,
 109,
@@ -967,14 +899,14 @@
 134,
 147,
 150,
-153,
+153
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_indexing.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_indexing.py": [
 37,
 37,
-37,
+37
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_io.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_io.py": [
 21,
 28,
 31,
@@ -986,18 +918,18 @@
 183,
 189,
 202,
-238,
+238
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_lib.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_lib.py": [
 21,
 21,
-27,
+27
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_linalg.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_linalg.py": [
 99,
-99,
+99
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_ma.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_ma.py": [
 40,
 40,
 40,
@@ -1020,23 +952,23 @@
 77,
 77,
 114,
-114,
+114
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_overrides.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_overrides.py": [
 9,
-9,
+9
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_random.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_random.py": [
 20,
-55,
+55
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_reduce.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_reduce.py": [
 23,
 26,
 57,
-60,
+60
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_shape_base.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_shape_base.py": [
 40,
 43,
 46,
@@ -1044,132 +976,118 @@
 86,
 86,
 86,
-102,
+102
 ],
-'project:numpy-1.16.4/benchmarks/benchmarks/bench_ufunc.py':[
+"project:numpy-1.16.4/benchmarks/benchmarks/bench_ufunc.py": [
 59,
 126,
 129,
 132,
-135,
+135
 ],
-'project:numpy-1.16.4/numpy/compat/py3k.py':[
-126,
-],
-'project:numpy-1.16.4/numpy/core/_internal.py':[
+"project:numpy-1.16.4/numpy/core/_internal.py": [
 240,
-821,
+821
 ],
-'project:numpy-1.16.4/numpy/core/code_generators/generate_ufunc_api.py':[
-155,
+"project:numpy-1.16.4/numpy/core/code_generators/generate_ufunc_api.py": [
+155
 ],
-'project:numpy-1.16.4/numpy/core/defchararray.py':[
+"project:numpy-1.16.4/numpy/core/defchararray.py": [
 1050,
-1366,
+1366
 ],
-'project:numpy-1.16.4/numpy/core/setup.py':[
+"project:numpy-1.16.4/numpy/core/setup.py": [
 261,
-261,
+261
 ],
-'project:numpy-1.16.4/numpy/distutils/ccompiler.py':[
-730,
+"project:numpy-1.16.4/numpy/distutils/ccompiler.py": [
+730
 ],
-'project:numpy-1.16.4/numpy/distutils/command/build_ext.py':[
-479,
+"project:numpy-1.16.4/numpy/distutils/command/build_ext.py": [
+479
 ],
-'project:numpy-1.16.4/numpy/distutils/command/config.py':[
+"project:numpy-1.16.4/numpy/distutils/command/config.py": [
 204,
 232,
-432,
+432
 ],
-'project:numpy-1.16.4/numpy/distutils/fcompiler/__init__.py':[
-796,
+"project:numpy-1.16.4/numpy/distutils/fcompiler/__init__.py": [
+796
 ],
-'project:numpy-1.16.4/numpy/distutils/misc_util.py':[
+"project:numpy-1.16.4/numpy/distutils/misc_util.py": [
 368,
 368,
-1565,
+1565
 ],
-'project:numpy-1.16.4/numpy/distutils/npy_pkg_config.py':[
-248,
+"project:numpy-1.16.4/numpy/distutils/npy_pkg_config.py": [
+248
 ],
-'project:numpy-1.16.4/numpy/distutils/system_info.py':[
+"project:numpy-1.16.4/numpy/distutils/system_info.py": [
 1758,
-2461,
+2461
 ],
-'project:numpy-1.16.4/numpy/f2py/auxfuncs.py':[
+"project:numpy-1.16.4/numpy/f2py/auxfuncs.py": [
 69,
 543,
 547,
-581,
+581
 ],
-'project:numpy-1.16.4/numpy/f2py/capi_maps.py':[
-719,
+"project:numpy-1.16.4/numpy/f2py/capi_maps.py": [
+719
 ],
-'project:numpy-1.16.4/numpy/f2py/crackfortran.py':[
-2167,
+"project:numpy-1.16.4/numpy/f2py/crackfortran.py": [
+2167
 ],
-'project:numpy-1.16.4/numpy/lib/utils.py':[
-1034,
+"project:numpy-1.16.4/numpy/lib/utils.py": [
+1034
 ],
-'project:numpy-1.16.4/numpy/linalg/linalg.py':[
-140,
-],
-'project:numpy-1.16.4/numpy/ma/extras.py':[
+"project:numpy-1.16.4/numpy/ma/extras.py": [
 918,
-963,
+963
 ],
-'project:numpy-1.16.4/numpy/testing/_private/decorators.py':[
-276,
+"project:numpy-1.16.4/numpy/testing/_private/decorators.py": [
+276
 ],
-'project:numpy-1.16.4/numpy/testing/_private/noseclasses.py':[
-286,
+"project:numpy-1.16.4/numpy/testing/_private/noseclasses.py": [
+286
 ],
-'project:numpy-1.16.4/numpy/testing/_private/parameterized.py':[
-60,
+"project:numpy-1.16.4/numpy/testing/_private/parameterized.py": [
+60
 ],
-'project:numpy-1.16.4/runtests.py':[
-473,
+"project:numpy-1.16.4/tools/npy_tempita/__init__.py": [
+1099
 ],
-'project:numpy-1.16.4/tools/npy_tempita/__init__.py':[
-1077,
-1099,
-1099,
+"project:pecos/examples/MACLR/model.py": [
+40
 ],
-'project:pecos/examples/MACLR/model.py':[
-40,
+"project:pecos/pecos/core/base.py": [
+993
 ],
-'project:pecos/pecos/core/base.py':[
-992,
-993,
+"project:tensorflow/python/compiler/tensorrt/test/conv2d_test.py": [
+67
 ],
-'project:tensorflow/python/compiler/tensorrt/test/conv2d_test.py':[
-67,
-],
-'project:tensorflow/python/debug/lib/debug_service_pb2_grpc.py':[
+"project:tensorflow/python/debug/lib/debug_service_pb2_grpc.py": [
 63,
 76,
-83,
+83
 ],
-'project:tensorflow/python/framework/ops.py':[
-3178,
+"project:tensorflow/python/framework/ops.py": [
+3178
 ],
-'project:tensorflow/python/keras/engine/base_layer_utils.py':[
-67,
+"project:tensorflow/python/keras/engine/base_layer_utils.py": [
+67
 ],
-'project:tensorflow/python/keras/layers/legacy_rnn/rnn_cell_wrapper_impl.py':[
-206,
+"project:tensorflow/python/keras/layers/legacy_rnn/rnn_cell_wrapper_impl.py": [
+206
 ],
-'project:tensorflow/python/keras/saving/saved_model_experimental.py':[
+"project:tensorflow/python/keras/saving/saved_model_experimental.py": [
 367,
-367,
-367,
-367,
+367
 ],
-'project:tensorflow/python/keras/wrappers/scikit_learn.py':[
-108,
+"project:tensorflow/python/keras/wrappers/scikit_learn.py": [
+108
 ],
-'project:tensorflow/python/kernel_tests/distributions/util_test.py':[
+"project:tensorflow/python/kernel_tests/distributions/util_test.py": [
 1031,
 1031,
 1031,
@@ -1183,145 +1101,132 @@
 1068,
 1068,
 1068,
-1068,
+1068
 ],
-'project:tensorflow/python/kernel_tests/signal/mel_ops_test.py':[
-62,
+"project:tensorflow/python/kernel_tests/signal/mel_ops_test.py": [
+62
 ],
-'project:tensorflow/python/ops/data_flow_ops.py':[
-1935,
+"project:tensorflow/python/ops/data_flow_ops.py": [
+1935
 ],
-'project:tensorflow/python/ops/rnn.py':[
-158,
+"project:tensorflow/python/ops/rnn.py": [
+158
 ],
-'project:tensorflow/python/ops/variables.py':[
+"project:tensorflow/python/ops/variables.py": [
 182,
-223,
+223
 ],
-'project:tensorflow/python/platform/tf_logging.py':[
-64,
+"project:tensorflow/python/platform/tf_logging.py": [
+64
 ],
-'project:tensorflow/python/summary/writer/fake_summary_writer.py':[
-127,
+"project:tensorflow/python/summary/writer/fake_summary_writer.py": [
+127
 ],
-'project:tensorflow/python/tools/freeze_graph.py':[
-364,
+"project:tensorflow/python/tools/freeze_graph.py": [
+364
 ],
-'project:tensorflow/python/tpu/profiler/profiler_analysis_pb2_grpc.py':[
+"project:tensorflow/python/tpu/profiler/profiler_analysis_pb2_grpc.py": [
 73,
 83,
-89,
+89
 ],
-'project:tensorflow/python/tpu/tensor_tracer.py':[
-980,
+"project:tensorflow/python/training/basic_loops_test.py": [
+88
 ],
-'project:tensorflow/python/training/basic_loops_test.py':[
-88,
+"project:tensorflow/python/training/saver.py": [
+157
 ],
-'project:tensorflow/python/training/saver.py':[
-157,
+"project:tensorflow/python/training/session_run_hook.py": [
+129
 ],
-'project:tensorflow/python/training/session_run_hook.py':[
-129,
-],
-'project:tensorflow/python/util/dispatch.py':[
+"project:tensorflow/python/util/dispatch.py": [
 59,
-59,
+59
 ],
-'project:tensorflow/tools/api/lib/python_object_to_proto_visitor.py':[
+"project:tensorflow/tools/api/lib/python_object_to_proto_visitor.py": [
 94,
-94,
+94
 ],
-'project:tensorflow/tools/compatibility/tf_upgrade_v2.py':[
-2100,
+"project:tensorflow/tools/compatibility/tf_upgrade_v2.py": [
+2100
 ],
-'project:tensorflow/tools/docs/parser.py':[
-449,
+"project:tensorflow/tools/docs/parser.py": [
+449
 ],
-'project:tensorflow/tools/docs/tf_doctest.py':[
+"project:tensorflow/tools/docs/tf_doctest.py": [
 140,
-140,
+140
 ],
-'project:tensorflow/tools/test/system_info.py':[
-25,
+"project:tensorflow/tools/test/system_info.py": [
+25
 ],
-'project:tornado-2.3/tornado/auth.py':[
-394,
+"project:tornado-2.3/tornado/auth.py": [
+394
 ],
-'project:tornado-2.3/tornado/simple_httpclient.py':[
-65,
-],
-'project:tornado-2.3/tornado/test/twisted_test.py':[
+"project:tornado-2.3/tornado/test/twisted_test.py": [
 205,
-228,
+228
 ],
-'project:tornado-2.3/tornado/web.py':[
-335,
+"project:tornado-2.3/tornado/web.py": [
 1593,
 1593,
 1593,
 1695,
-1698,
+1698
 ],
-'project:tornado-2.3/tornado/websocket.py':[
-146,
+"project:twisted-12.1.0/doc/conch/examples/sshsimpleserver.py": [
+31
 ],
-'project:twisted-12.1.0/doc/conch/examples/sshsimpleserver.py':[
-31,
+"project:twisted-12.1.0/doc/core/benchmarks/failure.py": [
+48
 ],
-'project:twisted-12.1.0/doc/core/benchmarks/failure.py':[
-48,
+"project:twisted-12.1.0/doc/core/examples/cred.py": [
+133
 ],
-'project:twisted-12.1.0/doc/core/examples/cred.py':[
-133,
-],
-'project:twisted-12.1.0/doc/core/examples/pb_exceptions.py':[
+"project:twisted-12.1.0/doc/core/examples/pb_exceptions.py": [
 11,
-11,
+11
 ],
-'project:twisted-12.1.0/doc/core/examples/pbbenchserver.py':[
+"project:twisted-12.1.0/doc/core/examples/pbbenchserver.py": [
 34,
-34,
+34
 ],
-'project:twisted-12.1.0/doc/core/examples/pbecho.py':[
+"project:twisted-12.1.0/doc/core/examples/pbecho.py": [
 34,
-34,
+34
 ],
-'project:twisted-12.1.0/doc/core/examples/pbgtk2.py':[
+"project:twisted-12.1.0/doc/core/examples/pbgtk2.py": [
 41,
 48,
-48,
+48
 ],
-'project:twisted-12.1.0/doc/core/howto/listings/pb/pb5server.py':[
-20,
+"project:twisted-12.1.0/doc/core/howto/listings/pb/pb5server.py": [
+20
 ],
-'project:twisted-12.1.0/doc/core/howto/listings/pb/pb6server.py':[
-20,
+"project:twisted-12.1.0/doc/core/howto/listings/pb/pb6server.py": [
+20
 ],
-'project:twisted-12.1.0/doc/core/howto/listings/pb/pbAnonServer.py':[
-61,
+"project:twisted-12.1.0/doc/core/howto/listings/pb/pbAnonServer.py": [
+61
 ],
-'project:twisted-12.1.0/doc/web/examples/webguard.py':[
+"project:twisted-12.1.0/doc/web/examples/webguard.py": [
 46,
-46,
+46
 ],
-'project:twisted-12.1.0/doc/words/examples/cursesclient.py':[
-113,
+"project:twisted-12.1.0/doc/words/examples/cursesclient.py": [
+113
 ],
-'project:twisted-12.1.0/setup.py':[
-38,
+"project:twisted-12.1.0/setup.py": [
+38
 ],
-'project:twisted-12.1.0/twisted/conch/checkers.py':[
-298,
+"project:twisted-12.1.0/twisted/conch/checkers.py": [
+298
 ],
-'project:twisted-12.1.0/twisted/conch/client/default.py':[
-30,
-],
-'project:twisted-12.1.0/twisted/conch/client/knownhosts.py':[
+"project:twisted-12.1.0/twisted/conch/client/knownhosts.py": [
 183,
-190,
+190
 ],
-'project:twisted-12.1.0/twisted/conch/insults/insults.py':[
+"project:twisted-12.1.0/twisted/conch/insults/insults.py": [
 944,
 953,
 962,
@@ -1332,9 +1237,9 @@
 1006,
 1017,
 1028,
-1046,
+1046
 ],
-'project:twisted-12.1.0/twisted/conch/insults/window.py':[
+"project:twisted-12.1.0/twisted/conch/insults/window.py": [
 517,
 522,
 684,
@@ -1348,266 +1253,258 @@
 810,
 817,
 825,
-833,
+833
 ],
-'project:twisted-12.1.0/twisted/conch/manhole_ssh.py':[
-112,
+"project:twisted-12.1.0/twisted/conch/manhole_ssh.py": [
+112
 ],
-'project:twisted-12.1.0/twisted/conch/manhole_tap.py':[
-46,
+"project:twisted-12.1.0/twisted/conch/manhole_tap.py": [
+46
 ],
-'project:twisted-12.1.0/twisted/conch/ssh/keys.py':[
-346,
+"project:twisted-12.1.0/twisted/conch/ssh/keys.py": [
+346
 ],
-'project:twisted-12.1.0/twisted/conch/unix.py':[
+"project:twisted-12.1.0/twisted/conch/unix.py": [
 30,
 327,
-327,
+327
 ],
-'project:twisted-12.1.0/twisted/cred/checkers.py':[
-56,
+"project:twisted-12.1.0/twisted/cred/checkers.py": [
+56
 ],
-'project:twisted-12.1.0/twisted/internet/_glibbase.py':[
-151,
+"project:twisted-12.1.0/twisted/internet/_glibbase.py": [
+151
 ],
-'project:twisted-12.1.0/twisted/internet/_posixstdio.py':[
-76,
+"project:twisted-12.1.0/twisted/internet/_posixstdio.py": [
+76
 ],
-'project:twisted-12.1.0/twisted/internet/abstract.py':[
-169,
+"project:twisted-12.1.0/twisted/internet/abstract.py": [
+169
 ],
-'project:twisted-12.1.0/twisted/internet/base.py':[
+"project:twisted-12.1.0/twisted/internet/base.py": [
 280,
 596,
 602,
-608,
+608
 ],
-'project:twisted-12.1.0/twisted/internet/iocpreactor/abstract.py':[
+"project:twisted-12.1.0/twisted/internet/iocpreactor/abstract.py": [
 98,
 197,
-317,
+317
 ],
-'project:twisted-12.1.0/twisted/internet/process.py':[
-896,
+"project:twisted-12.1.0/twisted/internet/process.py": [
+896
 ],
-'project:twisted-12.1.0/twisted/internet/protocol.py':[
-93,
+"project:twisted-12.1.0/twisted/internet/protocol.py": [
+93
 ],
-'project:twisted-12.1.0/twisted/internet/test/connectionmixins.py':[
-159,
+"project:twisted-12.1.0/twisted/internet/test/connectionmixins.py": [
+159
 ],
-'project:twisted-12.1.0/twisted/internet/tksupport.py':[
-42,
+"project:twisted-12.1.0/twisted/internet/tksupport.py": [
+42
 ],
-'project:twisted-12.1.0/twisted/internet/win32eventreactor.py':[
-65,
-65,
+"project:twisted-12.1.0/twisted/internet/win32eventreactor.py": [
+65
 ],
-'project:twisted-12.1.0/twisted/lore/default.py':[
+"project:twisted-12.1.0/twisted/lore/default.py": [
 41,
 52,
-52,
+52
 ],
-'project:twisted-12.1.0/twisted/lore/htmlbook.py':[
+"project:twisted-12.1.0/twisted/lore/htmlbook.py": [
 5,
-8,
+8
 ],
-'project:twisted-12.1.0/twisted/lore/man2lore.py':[
+"project:twisted-12.1.0/twisted/lore/man2lore.py": [
 186,
 206,
 220,
 225,
-283,
+283
 ],
-'project:twisted-12.1.0/twisted/lore/process.py':[
-99,
+"project:twisted-12.1.0/twisted/lore/process.py": [
+99
 ],
-'project:twisted-12.1.0/twisted/lore/slides.py':[
+"project:twisted-12.1.0/twisted/lore/slides.py": [
 109,
 241,
-241,
+241
 ],
-'project:twisted-12.1.0/twisted/lore/tree.py':[
-976,
+"project:twisted-12.1.0/twisted/lore/tree.py": [
+976
 ],
-'project:twisted-12.1.0/twisted/mail/alias.py':[
-105,
+"project:twisted-12.1.0/twisted/mail/alias.py": [
+105
 ],
-'project:twisted-12.1.0/twisted/mail/imap4.py':[
+"project:twisted-12.1.0/twisted/mail/imap4.py": [
 4435,
 4692,
-5570,
+5570
 ],
-'project:twisted-12.1.0/twisted/mail/mail.py':[
+"project:twisted-12.1.0/twisted/mail/mail.py": [
 36,
 192,
-192,
+192
 ],
-'project:twisted-12.1.0/twisted/mail/maildir.py':[
-113,
+"project:twisted-12.1.0/twisted/mail/maildir.py": [
 161,
 161,
-489,
+489
 ],
-'project:twisted-12.1.0/twisted/mail/pop3.py':[
-946,
+"project:twisted-12.1.0/twisted/mail/pop3.py": [
+946
 ],
-'project:twisted-12.1.0/twisted/mail/protocols.py':[
-38,
+"project:twisted-12.1.0/twisted/mail/protocols.py": [
+38
 ],
-'project:twisted-12.1.0/twisted/mail/relay.py':[
+"project:twisted-12.1.0/twisted/mail/relay.py": [
 39,
 94,
 94,
 94,
-94,
+94
 ],
-'project:twisted-12.1.0/twisted/mail/relaymanager.py':[
+"project:twisted-12.1.0/twisted/mail/relaymanager.py": [
 52,
 52,
 52,
 52,
-65,
+65
 ],
-'project:twisted-12.1.0/twisted/mail/scripts/mailmail.py':[
-297,
+"project:twisted-12.1.0/twisted/mail/scripts/mailmail.py": [
+297
 ],
-'project:twisted-12.1.0/twisted/manhole/_inspectro.py':[
+"project:twisted-12.1.0/twisted/manhole/_inspectro.py": [
 246,
 249,
 252,
 252,
-355,
+355
 ],
-'project:twisted-12.1.0/twisted/manhole/gladereactor.py':[
+"project:twisted-12.1.0/twisted/manhole/gladereactor.py": [
 60,
 64,
 71,
 77,
-113,
+113
 ],
-'project:twisted-12.1.0/twisted/manhole/ui/gtk2manhole.py':[
+"project:twisted-12.1.0/twisted/manhole/ui/gtk2manhole.py": [
 249,
-249,
-297,
-297,
+297
 ],
-'project:twisted-12.1.0/twisted/names/client.py':[
-474,
+"project:twisted-12.1.0/twisted/names/client.py": [
+474
 ],
-'project:twisted-12.1.0/twisted/names/common.py':[
+"project:twisted-12.1.0/twisted/names/common.py": [
 61,
 61,
 61,
-61,
+61
 ],
-'project:twisted-12.1.0/twisted/names/dns.py':[
+"project:twisted-12.1.0/twisted/names/dns.py": [
 237,
 251,
 322,
 410,
-1605,
+1605
 ],
-'project:twisted-12.1.0/twisted/names/srvconnect.py':[
+"project:twisted-12.1.0/twisted/names/srvconnect.py": [
 20,
 23,
-26,
+26
 ],
-'project:twisted-12.1.0/twisted/news/database.py':[
-923,
+"project:twisted-12.1.0/twisted/news/database.py": [
+923
 ],
-'project:twisted-12.1.0/twisted/plugins/cred_anonymous.py':[
-34,
+"project:twisted-12.1.0/twisted/plugins/cred_anonymous.py": [
+34
 ],
-'project:twisted-12.1.0/twisted/plugins/cred_sshkeys.py':[
-37,
+"project:twisted-12.1.0/twisted/plugins/cred_sshkeys.py": [
+37
 ],
-'project:twisted-12.1.0/twisted/plugins/cred_unix.py':[
-127,
+"project:twisted-12.1.0/twisted/plugins/cred_unix.py": [
+127
 ],
-'project:twisted-12.1.0/twisted/plugins/twisted_words.py':[
+"project:twisted-12.1.0/twisted/plugins/twisted_words.py": [
 29,
 39,
-39,
+39
 ],
-'project:twisted-12.1.0/twisted/protocols/amp.py':[
+"project:twisted-12.1.0/twisted/protocols/amp.py": [
 1165,
 1242,
 1256,
 1975,
-1975,
+1975
 ],
-'project:twisted-12.1.0/twisted/protocols/ftp.py':[
+"project:twisted-12.1.0/twisted/protocols/ftp.py": [
 1621,
 1625,
 1629,
 1633,
 1633,
 1668,
-1940,
+1940
 ],
-'project:twisted-12.1.0/twisted/protocols/htb.py':[
-149,
-149,
+"project:twisted-12.1.0/twisted/protocols/htb.py": [
+149
 ],
-'project:twisted-12.1.0/twisted/protocols/loopback.py':[
-304,
+"project:twisted-12.1.0/twisted/protocols/loopback.py": [
+304
 ],
-'project:twisted-12.1.0/twisted/protocols/policies.py':[
-442,
+"project:twisted-12.1.0/twisted/protocols/policies.py": [
+442
 ],
-'project:twisted-12.1.0/twisted/protocols/sip.py':[
+"project:twisted-12.1.0/twisted/protocols/sip.py": [
 1027,
 1112,
 1333,
-1333,
+1333
 ],
-'project:twisted-12.1.0/twisted/python/constants.py':[
-52,
+"project:twisted-12.1.0/twisted/python/constants.py": [
 143,
 143,
-143,
-365,
+365
 ],
-'project:twisted-12.1.0/twisted/python/htmlizer.py':[
-20,
+"project:twisted-12.1.0/twisted/python/htmlizer.py": [
+20
 ],
-'project:twisted-12.1.0/twisted/python/lockfile.py':[
-40,
+"project:twisted-12.1.0/twisted/python/lockfile.py": [
+40
 ],
-'project:twisted-12.1.0/twisted/python/modules.py':[
+"project:twisted-12.1.0/twisted/python/modules.py": [
 278,
-726,
+726
 ],
-'project:twisted-12.1.0/twisted/python/roots.py':[
+"project:twisted-12.1.0/twisted/python/roots.py": [
 137,
 167,
-183,
-191,
+183
 ],
-'project:twisted-12.1.0/twisted/python/util.py':[
+"project:twisted-12.1.0/twisted/python/util.py": [
 359,
-359,
+359
 ],
-'project:twisted-12.1.0/twisted/spread/jelly.py':[
+"project:twisted-12.1.0/twisted/spread/jelly.py": [
 325,
 348,
 689,
 989,
 997,
-1006,
+1006
 ],
-'project:twisted-12.1.0/twisted/spread/pb.py':[
-1322,
+"project:twisted-12.1.0/twisted/spread/pb.py": [
+1322
 ],
-'project:twisted-12.1.0/twisted/spread/ui/gtk2util.py':[
+"project:twisted-12.1.0/twisted/spread/ui/gtk2util.py": [
 126,
 126,
 129,
 129,
-209,
+209
 ],
-'project:twisted-12.1.0/twisted/trial/reporter.py':[
+"project:twisted-12.1.0/twisted/trial/reporter.py": [
 822,
 880,
 880,
@@ -1615,38 +1512,36 @@
 913,
 917,
 1057,
-1072,
+1072
 ],
-'project:twisted-12.1.0/twisted/trial/unittest.py':[
-1247,
+"project:twisted-12.1.0/twisted/trial/unittest.py": [
+1247
 ],
-'project:twisted-12.1.0/twisted/web/_auth/basic.py':[
+"project:twisted-12.1.0/twisted/web/_auth/basic.py": [
 37,
-45,
+45
 ],
-'project:twisted-12.1.0/twisted/web/_auth/wrapper.py':[
+"project:twisted-12.1.0/twisted/web/_auth/wrapper.py": [
 62,
 62,
-133,
+133
 ],
-'project:twisted-12.1.0/twisted/web/_element.py':[
-170,
+"project:twisted-12.1.0/twisted/web/_element.py": [
+170
 ],
-'project:twisted-12.1.0/twisted/web/_newclient.py':[
+"project:twisted-12.1.0/twisted/web/_newclient.py": [
 1430,
 1438,
 1461,
-1479,
+1479
 ],
-'project:twisted-12.1.0/twisted/web/client.py':[
-1319,
+"project:twisted-12.1.0/twisted/web/client.py": [
+1319
 ],
-'project:twisted-12.1.0/twisted/web/resource.py':[
-109,
-129,
-129,
+"project:twisted-12.1.0/twisted/web/resource.py": [
+109
 ],
-'project:twisted-12.1.0/twisted/web/sux.py':[
+"project:twisted-12.1.0/twisted/web/sux.py": [
 213,
 222,
 410,
@@ -1654,47 +1549,43 @@
 492,
 515,
 560,
-587,
+587
 ],
-'project:twisted-12.1.0/twisted/web/xmlrpc.py':[
-85,
+"project:twisted-12.1.0/twisted/web/xmlrpc.py": [
+85
 ],
-'project:twisted-12.1.0/twisted/words/im/basechat.py':[
-165,
+"project:twisted-12.1.0/twisted/words/im/basesupport.py": [
+36
 ],
-'project:twisted-12.1.0/twisted/words/im/basesupport.py':[
-36,
-],
-'project:twisted-12.1.0/twisted/words/protocols/irc.py':[
+"project:twisted-12.1.0/twisted/words/protocols/irc.py": [
 648,
 681,
 724,
 809,
-939,
+939
 ],
-'project:twisted-12.1.0/twisted/words/protocols/jabber/xmlstream.py':[
+"project:twisted-12.1.0/twisted/words/protocols/jabber/xmlstream.py": [
 886,
-913,
+913
 ],
-'project:twisted-12.1.0/twisted/words/protocols/msn.py':[
+"project:twisted-12.1.0/twisted/words/protocols/msn.py": [
 302,
 748,
 752,
 829,
 833,
 1088,
-1088,
 1148,
 1160,
 1788,
 1803,
 2334,
-2338,
+2338
 ],
-'project:twisted-12.1.0/twisted/words/xish/xmlstream.py':[
-229,
+"project:twisted-12.1.0/twisted/words/xish/xmlstream.py": [
+229
 ],
-'project:twisted-12.1.0/twisted/words/xish/xpath.py':[
-20,
-],
+"project:twisted-12.1.0/twisted/words/xish/xpath.py": [
+20
+]
 }

--- a/its/ruling/src/test/resources/expected/python-S1172.json
+++ b/its/ruling/src/test/resources/expected/python-S1172.json
@@ -493,8 +493,6 @@
 "project:django-2.2.3/django/db/models/fields/related.py": [
 386,
 684,
-684,
-684,
 845,
 1149,
 1160,
@@ -1474,7 +1472,6 @@
 40
 ],
 "project:twisted-12.1.0/twisted/python/modules.py": [
-278,
 726
 ],
 "project:twisted-12.1.0/twisted/python/roots.py": [

--- a/python-checks/src/main/java/org/sonar/python/checks/UnusedFunctionParameterCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/UnusedFunctionParameterCheck.java
@@ -84,7 +84,7 @@ public class UnusedFunctionParameterCheck extends PythonSubscriptionCheck {
     StringLiteralValuesCollector stringLiteralValuesCollector = new StringLiteralValuesCollector();
     stringLiteralValuesCollector.collect(functionDef);
     List<String> comments = collectComments(functionDef);
-    Pattern p = Pattern.compile("(^|\\s+|@)" + symbolName + "($|\\s+)");
+    Pattern p = Pattern.compile("(^|\\s+|\"|'|@)" + symbolName + "($|\\s+|\"|')");
     return stringLiteralValuesCollector.anyMatches(str -> p.matcher(str).find()) ||
       comments.stream().anyMatch(str -> p.matcher(str).find());
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/UnusedFunctionParameterCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/UnusedFunctionParameterCheck.java
@@ -19,8 +19,13 @@
  */
 package org.sonar.python.checks;
 
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.PythonSubscriptionCheck;
@@ -35,9 +40,12 @@ import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Parameter;
 import org.sonar.plugins.python.api.tree.ReturnStatement;
 import org.sonar.plugins.python.api.tree.Statement;
+import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.plugins.python.api.tree.Tree.Kind;
+import org.sonar.plugins.python.api.tree.Trivia;
 import org.sonar.python.checks.utils.CheckUtils;
+import org.sonar.python.checks.utils.StringLiteralValuesCollector;
 import org.sonar.python.semantic.SymbolUtils;
 import org.sonar.python.tree.FunctionDefImpl;
 import org.sonar.python.tree.TreeUtils;
@@ -46,6 +54,8 @@ import org.sonar.python.tree.TreeUtils;
 public class UnusedFunctionParameterCheck extends PythonSubscriptionCheck {
 
   private static final String MESSAGE = "Remove the unused function parameter \"%s\".";
+
+  private static final Set<String> AWS_LAMBDA_PARAMETERS = Set.of("event", "context");
 
   @Override
   public void initialize(Context context) {
@@ -56,14 +66,31 @@ public class UnusedFunctionParameterCheck extends PythonSubscriptionCheck {
     if (isException(ctx, functionDef)) return;
     functionDef.localVariables().stream()
       .filter(symbol -> !isIgnoredSymbolName(symbol.name()))
-      .map(Symbol::usages)
-      .filter(usages -> usages.size() == 1 && usages.get(0).tree().parent().is(Kind.PARAMETER))
-      .map(usages -> (Parameter) usages.get(0).tree().parent())
+      .filter(UnusedFunctionParameterCheck::isUnused)
+      .filter(symbol -> !isUsedInStringLiteralOrComment(symbol.name(), functionDef))
+      .map(symbol -> (Parameter) symbol.usages().get(0).tree().parent())
       .forEach(param -> ctx.addIssue(param, String.format(MESSAGE, param.name().name())));
   }
 
+  private static boolean isUnused(Symbol s) {
+    return s.usages().size() == 1 && s.usages().get(0).tree().parent().is(Kind.PARAMETER);
+  }
+
+  /* If the parameter is used within a string literal or comment, this might indicate either:
+   * A docstring or a comment explains why this parameter is unused (e.g the method is method to be overridden)
+   * The parameter is used through a DSL (e.g pandas.DataFrame.query)
+   */
+  private static boolean isUsedInStringLiteralOrComment(String symbolName, FunctionDef functionDef) {
+    StringLiteralValuesCollector stringLiteralValuesCollector = new StringLiteralValuesCollector();
+    stringLiteralValuesCollector.collect(functionDef);
+    List<String> comments = collectComments(functionDef);
+    Pattern p = Pattern.compile("(^|\\s+|@)" + symbolName + "($|\\s+)");
+    return stringLiteralValuesCollector.anyMatches(str -> p.matcher(str).find()) ||
+      comments.stream().anyMatch(str -> p.matcher(str).find());
+  }
+
   private static boolean isIgnoredSymbolName(String symbolName) {
-    return "self".equals(symbolName) || symbolName.startsWith("_");
+    return "self".equals(symbolName) || symbolName.startsWith("_") || AWS_LAMBDA_PARAMETERS.contains(symbolName);
   }
 
   private static boolean isException(SubscriptionContext ctx, FunctionDef functionDef) {
@@ -124,5 +151,21 @@ public class UnusedFunctionParameterCheck extends PythonSubscriptionCheck {
     if (callExpression == null) return false;
     Expression callee = callExpression.callee();
     return callee == tree || TreeUtils.hasDescendant(callee, t -> t == tree);
+  }
+
+  private static List<String> collectComments(Tree element) {
+    List<String> comments = new ArrayList<>();
+    Deque<Tree> stack = new ArrayDeque<>();
+    stack.push(element);
+    while (!stack.isEmpty()) {
+      Tree currentElement = stack.pop();
+      if (currentElement.is(Kind.TOKEN)) {
+        ((Token) currentElement).trivia().stream().map(Trivia::value).forEach(comments::add);
+      }
+      for (int i = currentElement.children().size() - 1; i >= 0; i--) {
+        Optional.ofNullable(currentElement.children().get(i)).ifPresent(stack::push);
+      }
+    }
+    return comments;
   }
 }

--- a/python-checks/src/test/resources/checks/unusedFunctionParameter/unusedFunctionParameter.py
+++ b/python-checks/src/test/resources/checks/unusedFunctionParameter/unusedFunctionParameter.py
@@ -1,4 +1,6 @@
-def f1(a):  # Noncompliant {{Remove the unused function parameter "a".}}
+# Noncompliant@+2 {{Remove the unused function parameter "a".}}
+'Issues are not raised when the variable is mentioned in a comment related to the function'
+def f1(a):
 #      ^
     print("foo")
 
@@ -25,7 +27,9 @@ class MyInterface:
         raise NotImplementedError("This object should be subclassed")
 
 class Parent:
-    def do_something(self, a, b):  # Noncompliant {{Remove the unused function parameter "a".}}
+    # Noncompliant@+2 {{Remove the unused function parameter "a".}}
+    'Issues are not raised when the variable is mentioned in a comment related to the function'
+    def do_something(self, a, b):
         #                  ^
         return compute(b)
 
@@ -130,3 +134,22 @@ def test_using_fixture(my_fixture):
 def lambda_handler(_event, _context):
     print("foo")
 
+
+def no_issue_aws_lambda_parameters(event, context):  # OK, may be required in AWS Lambda context
+    print("foo")
+
+
+class MyClass:
+    def param_referenced_in_docstring_no_issue(unused_param):  # OK
+       '''
+       Overrides may use unused_param to do something
+       '''
+       print("hello")
+
+    def param_referenced_in_comment_no_issue(unused_param_2):
+        # Overrides may use unused_param_2 to do something
+        print("hello")
+
+    def param_accessed_through_pandas_no_issue(sample_df, area_of_interest): # OK
+        sample_df.query('area == @area_of_interest').population
+        print("hello")

--- a/python-checks/src/test/resources/checks/unusedFunctionParameter/unusedFunctionParameter.py
+++ b/python-checks/src/test/resources/checks/unusedFunctionParameter/unusedFunctionParameter.py
@@ -150,6 +150,14 @@ class MyClass:
         # Overrides may use unused_param_2 to do something
         print("hello")
 
+    def param_referenced_in_comment_no_issue_2(unused_param_2):
+        # Overrides may use 'unused_param_2' to do something
+        print("hello")
+
+    def param_referenced_in_comment_no_issue_3(unused_param_2):
+        # Overrides may use "unused_param_2" to do something
+        print("hello")
+
     def param_accessed_through_pandas_no_issue(sample_df, area_of_interest): # OK
         sample_df.query('area == @area_of_interest').population
         print("hello")


### PR DESCRIPTION
I decided to go for a less aggressive approach than initially  discussed (excluding all methods from this rule). Instead, I decided to:
* Exclude parameter names `event` and `context` that may be required by AWS Lambda.
* Exclude any parameter that is referenced in a string literal or a comment (thus excluding any case of documented unused parameter for overriding purpose as well as anything that may be used through a DSL).

Seeing the results on ruling, this will make us lose some legitimate issues, although I believe the benefit of raising fewer FPs is worth the cost. Despite this change, this rule might still prove problematic and we might want to consider a more aggressive approach later.