### PR TITLE
DBD-673b: PythonSensor is depended upon by SonarLintPythonBugDetectionSensor

### DIFF
--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.SonarProduct;
+import org.sonar.api.batch.DependedUpon;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.CheckFactory;
@@ -50,6 +51,7 @@ import org.sonarsource.performance.measure.PerformanceMeasure;
 
 import static org.sonar.plugins.python.api.PythonVersionUtils.PYTHON_VERSION_KEY;
 
+@DependedUpon(value = "org.sonar.plugins.python.PythonSensor_before_com.sonarsource.dbd.SonarLintPythonBugDetectionSensor")
 public final class PythonSensor implements Sensor {
 
   private static final String PERFORMANCE_MEASURE_PROPERTY = "sonar.python.performance.measure";


### PR DESCRIPTION
DBD is working on support for SonarLint in VSCode. For this purpose, a ProjectSensor needs to be used on the DBD side that depends on the PythonSensor.

PythonSensor is a non-global, non-ProjectSensor.
SonarLintPythonBugDetectionSensor is a ProjectSensor. Based on this
[documentation](https://github.com/SonarSource/sonar-plugin-api/blob/master/docs/influencing-extensions-execution-order.md), they already should be running in order:

> In the Plugin API, there are 3 special extension points:
> * `org.sonar.api.batch.sensor.Sensor`
> * `org.sonar.api.scanner.sensor.ProjectSensor`
> * `org.sonar.api.batch.postjob.PostJob`
> [...]
> In Sonar products, extensions coming from those 3 extension points are executed one after another.

Except perhaps for the `root` module:
> Note that `org.sonar.api.batch.sensor.Sensor` extends `org.sonar.api.scanner.sensor.ProjectSensor` therefore, ordering can be defined by the classes which implement them. Ordering will be effective only when scanning the 'root' module.

Hence, for safety, and for self-documenting purposes, we add a @DependedUpon annotation to PythonSensor.
Note, that a @DependsUpon annotation with the same unique key is added to SonarLintPythonBugDetectionSensor within DBD for this to take effect.