### PR TITLE
Refactor TreeUtils#fullyQualifiedNameFromExpression to return Optional

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/UseOfAnyAsTypeHintCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/UseOfAnyAsTypeHintCheck.java
@@ -65,7 +65,8 @@ public class UseOfAnyAsTypeHintCheck extends PythonSubscriptionCheck {
 
   private static boolean isTypeAny(@Nullable TypeAnnotation typeAnnotation) {
     return Optional.ofNullable(typeAnnotation)
-      .map(annotation -> "typing.Any".equals(TreeUtils.fullyQualifiedNameFromExpression(annotation.expression())))
+      .flatMap(a -> TreeUtils.fullyQualifiedNameFromExpression(a.expression()))
+      .map("typing.Any"::equals)
       .orElse(false);
   }
 
@@ -73,7 +74,7 @@ public class UseOfAnyAsTypeHintCheck extends PythonSubscriptionCheck {
     return currentFunctionDef.decorators().stream()
       .map(Decorator::expression)
       .map(TreeUtils::fullyQualifiedNameFromExpression)
-      .filter(Objects::nonNull)
+      .flatMap(Optional::stream)
       .anyMatch(OVERRIDE_FQNS::contains);
   }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/UseOfAnyAsTypeHintCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/UseOfAnyAsTypeHintCheck.java
@@ -19,7 +19,6 @@
  */
 package org.sonar.python.checks;
 
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -65,7 +64,8 @@ public class UseOfAnyAsTypeHintCheck extends PythonSubscriptionCheck {
 
   private static boolean isTypeAny(@Nullable TypeAnnotation typeAnnotation) {
     return Optional.ofNullable(typeAnnotation)
-      .flatMap(a -> TreeUtils.fullyQualifiedNameFromExpression(a.expression()))
+      .map(TypeAnnotation::expression)
+      .flatMap(TreeUtils:: fullyQualifiedNameFromExpression)
       .map("typing.Any"::equals)
       .orElse(false);
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/CdkPredicate.java
@@ -66,7 +66,7 @@ public class CdkPredicate {
    * @return Predicate which tests if expression is a fully qualified name (FQN) and is equal the expected FQN
    */
   public static Predicate<Expression> isFqn(String fqnValue) {
-    return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
+    return expression ->  TreeUtils.fullyQualifiedNameFromExpression(expression)
       .filter(fqnValue::equals)
       .isPresent();
   }
@@ -75,7 +75,7 @@ public class CdkPredicate {
    * @return Predicate which tests if expression is a fully qualified name (FQN) and part of the FQN list
    */
   public static Predicate<Expression> isFqnOf(Collection<String> fqnValues) {
-    return expression ->  Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
+    return expression ->  TreeUtils.fullyQualifiedNameFromExpression(expression)
       .filter(fqnValues::contains)
       .isPresent();
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/cdk/ClearTextProtocolsCheckPart.java
@@ -217,7 +217,7 @@ public class ClearTextProtocolsCheckPart extends AbstractCdkResourceCheck {
    * @return Predicate which tests if expression is a FQN and is listed in sensitive transport protocol FQN list
    */
   private static Predicate<Expression> isSensitiveTransportProtocolFqn(Collection<String> transportProtocolFqns) {
-    return expression -> Optional.ofNullable(TreeUtils.fullyQualifiedNameFromExpression(expression))
+    return expression -> TreeUtils.fullyQualifiedNameFromExpression(expression)
       .filter(transportProtocolFqns::contains).isPresent();
   }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/django/DjangoReceiverDecoratorCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/django/DjangoReceiverDecoratorCheck.java
@@ -57,7 +57,7 @@ public class DjangoReceiverDecoratorCheck extends PythonSubscriptionCheck {
   private static boolean isReceiverDecorator(Decorator decorator) {
     return Optional.of(decorator)
       .map(Decorator::expression)
-      .map(TreeUtils::fullyQualifiedNameFromExpression)
+      .flatMap(TreeUtils::fullyQualifiedNameFromExpression)
       .filter(RECEIVER_DECORATOR_FQN::equals)
       .isPresent();
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/regex/UnusedGroupNamesCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/regex/UnusedGroupNamesCheck.java
@@ -86,7 +86,7 @@ public class UnusedGroupNamesCheck extends AbstractRegexCheck {
 
   private static Optional<List<Usage>> getCallExpressionResultUsages(CallExpression regexFunctionCall, Set<String> expressionFQNs) {
     return Optional.of(regexFunctionCall)
-      .filter(c -> expressionFQNs.contains(TreeUtils.fullyQualifiedNameFromExpression(c)))
+      .filter(c -> TreeUtils.fullyQualifiedNameFromExpression(c).filter(expressionFQNs::contains).isPresent())
       .map(call -> TreeUtils.firstAncestorOfKind(call, Tree.Kind.ASSIGNMENT_STMT))
       .map(AssignmentStatement.class::cast)
       .map(UnusedGroupNamesCheck::getAssignmentResultUsages)

--- a/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
@@ -375,23 +375,16 @@ public class TreeUtils {
     return null;
   }
 
-  public static String fullyQualifiedNameFromQualifiedExpression(QualifiedExpression qualifiedExpression) {
+  public static Optional<String> fullyQualifiedNameFromQualifiedExpression(QualifiedExpression qualifiedExpression) {
     String exprName = qualifiedExpression.name().name();
     Expression qualifier = qualifiedExpression.qualifier();
-    String nameOfQualifier = fullyQualifiedNameFromExpression(qualifier);
-    if (nameOfQualifier != null) {
-      exprName = nameOfQualifier + "." + exprName;
-    } else {
-      exprName = null;
-    }
-    return exprName;
+    return fullyQualifiedNameFromExpression(qualifier).map(nameOfQualifier -> nameOfQualifier + "." + exprName);
   }
 
-  @CheckForNull
-  public static String fullyQualifiedNameFromExpression(Expression expression) {
+  public static Optional<String> fullyQualifiedNameFromExpression(Expression expression) {
     if (expression.is(Kind.NAME)) {
       Symbol symbol = ((Name) expression).symbol();
-      return symbol != null ? symbol.fullyQualifiedName() : ((Name) expression).name();
+      return Optional.of(Optional.ofNullable(symbol).map(Symbol::fullyQualifiedName).orElse(((Name) expression).name()));
     }
     if (expression.is(Kind.QUALIFIED_EXPR)) {
       return fullyQualifiedNameFromQualifiedExpression((QualifiedExpression) expression);
@@ -399,7 +392,7 @@ public class TreeUtils {
     if (expression.is(Kind.CALL_EXPR)) {
       return fullyQualifiedNameFromExpression(((CallExpression) expression).callee());
     }
-    return null;
+    return Optional.empty();
   }
 
   @CheckForNull

--- a/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerMatchStatementTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerMatchStatementTest.java
@@ -206,13 +206,13 @@ class PythonTreeMakerMatchStatementTest extends RuleTest {
     assertThat(((LiteralPattern) firstKeyValuePattern.value()).valueAsString()).isEqualTo("'foo'");
     QualifiedExpression firstKeyQualExpr = ((ValuePattern) firstKeyValuePattern.key()).qualifiedExpression();
     assertThat(TreeUtils.nameFromQualifiedExpression(firstKeyQualExpr)).isEqualTo("a.b");
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(firstKeyQualExpr)).isEqualTo("a.b");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(firstKeyQualExpr)).contains("a.b");
 
     KeyValuePattern secondKeyValuePattern = (KeyValuePattern) mappingPattern.elements().get(1);
     assertThat(((LiteralPattern) secondKeyValuePattern.value()).valueAsString()).isEqualTo("'bar'");
     QualifiedExpression secondKeyQualExpr = ((ValuePattern) secondKeyValuePattern.key()).qualifiedExpression();
     assertThat(TreeUtils.nameFromQualifiedExpression(secondKeyQualExpr)).isEqualTo("c.d.e");
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(secondKeyQualExpr)).isEqualTo("c.d.e");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(secondKeyQualExpr)).contains("c.d.e");
   }
 
   @Test
@@ -230,13 +230,13 @@ class PythonTreeMakerMatchStatementTest extends RuleTest {
     QualifiedExpression qualifiedExpression = valuePattern.qualifiedExpression();
     assertThat(((Name) qualifiedExpression.qualifier()).isVariable()).isTrue();
     assertThat(TreeUtils.nameFromQualifiedExpression(qualifiedExpression)).isEqualTo("a.b");
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("a.b");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("a.b");
     assertThat(valuePattern.children()).containsExactly(valuePattern.qualifiedExpression());
 
     valuePattern = pattern("case a.b.c: ...");
     qualifiedExpression = valuePattern.qualifiedExpression();
     assertThat(TreeUtils.nameFromQualifiedExpression(qualifiedExpression)).isEqualTo("a.b.c");
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("a.b.c");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("a.b.c");
   }
 
   @Test
@@ -319,7 +319,7 @@ class PythonTreeMakerMatchStatementTest extends RuleTest {
     Name qualifierA = (Name) ((QualifiedExpression) qualifiedExpression.qualifier()).qualifier();
     assertThat(qualifierA.isVariable()).isTrue();
     assertThat(TreeUtils.nameFromQualifiedExpression(qualifiedExpression)).isEqualTo("A.B.C");
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("A.B.C");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("A.B.C");
 
     classPattern = pattern("case A(foo='bar'): ...");
     KeywordPattern arg = ((KeywordPattern) classPattern.arguments().get(0));

--- a/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/PythonTreeMakerTest.java
@@ -940,7 +940,7 @@ class PythonTreeMakerTest extends RuleTest {
     assertThat(decorators).hasSize(2);
     Decorator decorator = decorators.get(0);
     assertThat(TreeUtils.decoratorNameFromExpression(decorator.expression())).isEqualTo("foo");
-    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).isEqualTo("foo");
+    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).contains("foo");
     assertThat(decorator.expression().is(Kind.CALL_EXPR)).isTrue();
 
     functionDef = funcDef("@foo.bar(1)\ndef func(x): pass");
@@ -948,7 +948,7 @@ class PythonTreeMakerTest extends RuleTest {
     assertThat(decorators).hasSize(1);
     decorator = decorators.get(0);
     assertThat(TreeUtils.decoratorNameFromExpression(decorator.expression())).isEqualTo("foo.bar");
-    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).isEqualTo("foo.bar");
+    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).contains("foo.bar");
     assertThat(decorator.expression().is(Kind.CALL_EXPR)).isTrue();
 
     functionDef = funcDef("@buttons[\"hello\"].clicked.connect\ndef func(x): pass");
@@ -956,7 +956,7 @@ class PythonTreeMakerTest extends RuleTest {
     assertThat(decorators).hasSize(1);
     decorator = decorators.get(0);
     assertThat(TreeUtils.decoratorNameFromExpression(decorator.expression())).isNull();
-    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).isNull();
+    assertThat(TreeUtils.fullyQualifiedNameFromExpression(decorator.expression())).isNotPresent();
     assertThat(decorator.expression().is(Kind.QUALIFIED_EXPR)).isTrue();
 
     functionDef = funcDef("@hello() or bye()\ndef func(x): pass");

--- a/python-frontend/src/test/java/org/sonar/python/tree/TreeUtilsTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/TreeUtilsTest.java
@@ -380,21 +380,21 @@ class TreeUtilsTest {
       "a = alias.attribute"
     );
     QualifiedExpression qualifiedExpression = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Kind.QUALIFIED_EXPR));
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("third_party_lib.element.attribute");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("third_party_lib.element.attribute");
 
     fileInput = PythonTestUtils.parse(
       "from third_party_lib import (element as alias)",
       "a = alias().attribute"
     );
     qualifiedExpression = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Kind.QUALIFIED_EXPR));
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("third_party_lib.element.attribute");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("third_party_lib.element.attribute");
 
     fileInput = PythonTestUtils.parse(
       "from third_party_lib import (element as alias)",
       "a = alias.attr"
     );
     qualifiedExpression = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Kind.QUALIFIED_EXPR));
-    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).isEqualTo("third_party_lib.element.attr");
+    assertThat(TreeUtils.fullyQualifiedNameFromQualifiedExpression(qualifiedExpression)).contains("third_party_lib.element.attr");
   }
 
   @Test


### PR DESCRIPTION
Due to the fact this API is often used within stream and can be error prone due to the fact it's nullable, I believe it makes sense to have it return an optional instead.