### PR TITLE
DBD-691: Add support for shared checks.

### DIFF
--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonSharedCheck.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonSharedCheck.java
@@ -1,0 +1,27 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.python.api;
+
+import java.util.Set;
+import org.sonar.api.rule.RuleKey;
+
+public interface PythonSharedCheck extends PythonCheck {
+  Set<RuleKey> ruleKeys();
+}

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IPynbSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IPynbSensor.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -45,8 +46,9 @@ public final class IPynbSensor implements Sensor {
   private final NoSonarFilter noSonarFilter;
   private final PythonIndexer indexer;
 
-  public IPynbSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter, PythonIndexer indexer) {
-    this.checks = new PythonChecks(checkFactory)
+  public IPynbSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, ActiveRules activeRules,
+    NoSonarFilter noSonarFilter, PythonIndexer indexer) {
+    this.checks = new PythonChecks(checkFactory, activeRules)
       .addChecks(CheckList.IPYTHON_REPOSITORY_KEY, CheckList.getChecks());
     this.fileLinesContextFactory = fileLinesContextFactory;
     this.noSonarFilter = noSonarFilter;

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.rule.ActiveRules;
 import org.sonar.api.batch.rule.CheckFactory;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -62,31 +63,31 @@ public final class PythonSensor implements Sensor {
   private final PythonIndexer indexer;
   private final AnalysisWarningsWrapper analysisWarnings;
   private static final Logger LOG = LoggerFactory.getLogger(PythonSensor.class);
-  static final String UNSET_VERSION_WARNING =
-    "Your code is analyzed as compatible with all Python 3 versions by default." +
+  static final String UNSET_VERSION_WARNING = "Your code is analyzed as compatible with all Python 3 versions by default." +
     " You can get a more precise analysis by setting the exact Python version in your configuration via the parameter \"sonar.python.version\"";
 
   /**
    * Constructor to be used by pico if neither PythonCustomRuleRepository nor PythonIndexer are to be found and injected.
    */
-  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
-                      NoSonarFilter noSonarFilter, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, null, analysisWarnings);
+  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, ActiveRules activeRules,
+    NoSonarFilter noSonarFilter, AnalysisWarningsWrapper analysisWarnings) {
+    this(fileLinesContextFactory, checkFactory, activeRules, noSonarFilter, null, null, analysisWarnings);
   }
 
-  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                      PythonCustomRuleRepository[] customRuleRepositories, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, customRuleRepositories, null, analysisWarnings);
+  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, ActiveRules activeRules, NoSonarFilter noSonarFilter,
+    PythonCustomRuleRepository[] customRuleRepositories, AnalysisWarningsWrapper analysisWarnings) {
+    this(fileLinesContextFactory, checkFactory, activeRules, noSonarFilter, customRuleRepositories, null, analysisWarnings);
   }
 
-  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                      PythonIndexer indexer, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, indexer, analysisWarnings);
+  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, ActiveRules activeRules, NoSonarFilter noSonarFilter,
+    PythonIndexer indexer, AnalysisWarningsWrapper analysisWarnings) {
+    this(fileLinesContextFactory, checkFactory, activeRules, noSonarFilter, null, indexer, analysisWarnings);
   }
 
-  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                      @Nullable PythonCustomRuleRepository[] customRuleRepositories, @Nullable PythonIndexer indexer, AnalysisWarningsWrapper analysisWarnings) {
-    this.checks = new PythonChecks(checkFactory)
+  public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, ActiveRules activeRules,
+    NoSonarFilter noSonarFilter, @Nullable PythonCustomRuleRepository[] customRuleRepositories, @Nullable PythonIndexer indexer,
+    AnalysisWarningsWrapper analysisWarnings) {
+    this.checks = new PythonChecks(checkFactory, activeRules)
       .addChecks(CheckList.REPOSITORY_KEY, CheckList.getChecks())
       .addCustomChecks(customRuleRepositories);
     this.fileLinesContextFactory = fileLinesContextFactory;

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/IPynbSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/IPynbSensorTest.java
@@ -121,7 +121,7 @@ class IPynbSensorTest {
     FileLinesContext fileLinesContext = mock(FileLinesContext.class);
     when(fileLinesContextFactory.createFor(Mockito.any(InputFile.class))).thenReturn(fileLinesContext);
     CheckFactory checkFactory = new CheckFactory(activeRules);
-   return new IPynbSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer);
+    return new IPynbSensor(fileLinesContextFactory, checkFactory, activeRules, mock(NoSonarFilter.class), indexer);
   }
 
   private InputFile inputFile(String name) {

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.assertj.core.api.NotThrownAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -108,7 +107,6 @@ import org.sonarsource.sonarlint.core.commons.Language;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -507,7 +505,6 @@ class PythonSensorTest {
     assertThat(context.allIssues()).hasSize(1);
   }
 
-
   @Test
   void test_issues_on_test_files() {
     activeRules = new ActiveRulesBuilder()
@@ -527,7 +524,6 @@ class PythonSensorTest {
     assertThat(issue.primaryLocation().inputComponent()).isEqualTo(inputFile);
     assertThat(issue.ruleKey().rule()).isEqualTo("S5905");
   }
-
 
   @Test
   void test_failFast_triggered_on_main_files() {
@@ -751,7 +747,6 @@ class PythonSensorTest {
     assertThat(defaultPerformanceFile).exists();
     assertThat(new String(Files.readAllBytes(defaultPerformanceFile), UTF_8)).contains("\"PythonSensor\"");
   }
-
 
   @Test
   void test_using_cache() throws IOException, NoSuchAlgorithmException {
@@ -1195,8 +1190,7 @@ class PythonSensorTest {
     context.setSettings(
       new MapSettings()
         .setProperty("sonar.python.skipUnchanged", true)
-        .setProperty("sonar.internal.analysis.failFast", true)
-    );
+        .setProperty("sonar.internal.analysis.failFast", true));
 
     sensor().execute(context);
 
@@ -1237,15 +1231,15 @@ class PythonSensorTest {
     when(fileLinesContextFactory.createFor(Mockito.any(InputFile.class))).thenReturn(fileLinesContext);
     CheckFactory checkFactory = new CheckFactory(activeRules);
     if (indexer == null && customRuleRepositories == null) {
-      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), analysisWarnings);
+      return new PythonSensor(fileLinesContextFactory, checkFactory, activeRules, mock(NoSonarFilter.class), analysisWarnings);
     }
     if (indexer == null) {
-      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, analysisWarnings);
+      return new PythonSensor(fileLinesContextFactory, checkFactory, activeRules, mock(NoSonarFilter.class), customRuleRepositories, analysisWarnings);
     }
     if (customRuleRepositories == null) {
-      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer, analysisWarnings);
+      return new PythonSensor(fileLinesContextFactory, checkFactory, activeRules, mock(NoSonarFilter.class), indexer, analysisWarnings);
     }
-    return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, indexer, analysisWarnings);
+    return new PythonSensor(fileLinesContextFactory, checkFactory, activeRules, mock(NoSonarFilter.class), customRuleRepositories, indexer, analysisWarnings);
   }
 
   private SonarLintPythonIndexer pythonIndexer(List<InputFile> files) {
@@ -1292,7 +1286,7 @@ class PythonSensorTest {
     return new DefaultTextRange(new DefaultTextPointer(lineStart, columnStart), new DefaultTextPointer(lineEnd, columnEnd));
   }
 
-  private void activate_rule_S2710(){
+  private void activate_rule_S2710() {
     activeRules = new ActiveRulesBuilder()
       .addRule(new NewActiveRule.Builder()
         .setRuleKey(RuleKey.of(CheckList.REPOSITORY_KEY, "S2710"))
@@ -1300,6 +1294,7 @@ class PythonSensorTest {
         .build())
       .build();
   }
+
   private void setup_quickfix_sensor() throws IOException {
     String pathToQuickFixTestFile = "src/test/resources/org/sonar/plugins/python/sensor/" + FILE_QUICKFIX;
     File file = new File(pathToQuickFixTestFile);


### PR DESCRIPTION
Shared checks are responsible for multiple rule keys at the same time. They are executed if at least one of the rules registered for them is active.
A similar concept has for example also been implemented for sonar-java. See org.sonar.plugins.java.api.CheckRegistrar::registerMainSharedCheck.

In practice, this feature is needed by DBD.
DBD needs to supply a custom check to sonar-python for generating IR.

Previously, this was achieved by supplying a check for every DBD rule and only the first one that is executed would actually generate the IR. This approach required static fields that keep track whether IR has already been generated or not.
Since static fields like this don't work well with SonarLint we now need proper support for checks that cover multiple rules.