### PR TITLE
SONARPY-1582b: Independent Indexer and Cache

### DIFF
--- a/python-checks/src/test/java/org/sonar/python/checks/quickfix/PythonQuickFixVerifier.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/quickfix/PythonQuickFixVerifier.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.sonar.api.SonarProduct;
 import org.sonar.plugins.python.api.PythonCheck;
 import org.sonar.plugins.python.api.PythonCheck.PreciseIssue;
 import org.sonar.plugins.python.api.PythonFile;
@@ -154,7 +155,7 @@ public class PythonQuickFixVerifier {
 
     return new PythonVisitorContext(fileInput,
       pythonFile, null, "",
-      ProjectLevelSymbolTable.empty(), CacheContextImpl.dummyCache());
+      ProjectLevelSymbolTable.empty(), CacheContextImpl.dummyCache(), SonarProduct.SONARLINT);
   }
 
   private static String applyQuickFix(String codeWithIssue, PythonQuickFix quickFix) {

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonInputFileContext.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonInputFileContext.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.sonar.api.Beta;
+import org.sonar.api.SonarProduct;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.python.types.TypeShed;
@@ -34,10 +35,20 @@ public class PythonInputFileContext {
   private final File workingDirectory;
   private final CacheContext cacheContext;
 
+  private final SonarProduct sonarProduct;
+
+  public PythonInputFileContext(PythonFile pythonFile, @Nullable File workingDirectory, CacheContext cacheContext, SonarProduct sonarProduct) {
+    this.pythonFile = pythonFile;
+    this.workingDirectory = workingDirectory;
+    this.cacheContext = cacheContext;
+    this.sonarProduct = sonarProduct;
+  }
+
   public PythonInputFileContext(PythonFile pythonFile, @Nullable File workingDirectory, CacheContext cacheContext) {
     this.pythonFile = pythonFile;
     this.workingDirectory = workingDirectory;
     this.cacheContext = cacheContext;
+    this.sonarProduct = SonarProduct.SONARQUBE;
   }
 
   public PythonFile pythonFile() {
@@ -57,5 +68,9 @@ public class PythonInputFileContext {
   @CheckForNull
   public File workingDirectory() {
     return workingDirectory;
+  }
+
+  public SonarProduct sonarProduct() {
+    return sonarProduct;
   }
 }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.sonar.api.SonarProduct;
 import org.sonar.plugins.python.api.PythonCheck.PreciseIssue;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.api.tree.FileInput;
@@ -53,8 +54,22 @@ public class PythonVisitorContext extends PythonInputFileContext {
     new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
   }
 
+  public PythonVisitorContext(FileInput rootTree, PythonFile pythonFile, @Nullable File workingDirectory, String packageName,
+    ProjectLevelSymbolTable projectLevelSymbolTable, CacheContext cacheContext, SonarProduct sonarProduct) {
+    super(pythonFile, workingDirectory, cacheContext, sonarProduct);
+    this.rootTree = rootTree;
+    this.parsingException = null;
+    new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
+  }
+
   public PythonVisitorContext(PythonFile pythonFile, RecognitionException parsingException) {
     super(pythonFile, null, CacheContextImpl.dummyCache());
+    this.rootTree = null;
+    this.parsingException = parsingException;
+  }
+
+  public PythonVisitorContext(PythonFile pythonFile, RecognitionException parsingException, SonarProduct sonarProduct) {
+    super(pythonFile, null, CacheContextImpl.dummyCache(), sonarProduct);
     this.rootTree = null;
     this.parsingException = parsingException;
   }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/SonarLintCache.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/SonarLintCache.java
@@ -1,0 +1,77 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.python.api;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import org.sonar.api.Beta;
+import org.sonar.api.batch.sensor.cache.ReadCache;
+import org.sonar.api.batch.sensor.cache.WriteCache;
+import org.sonarsource.api.sonarlint.SonarLintSide;
+
+/**
+ * Component used in SonarLint to transfer data in memory between plugins.
+ * At the time of writing, this is used only by the DBD plugin, to consume IRs produced by DBD custom rules in SonarLint context.
+ */
+@SonarLintSide()
+@Beta
+public class SonarLintCache implements ReadCache, WriteCache {
+
+  private final Map<String, byte[]> cache = new HashMap<>();
+
+
+  @Override
+  public InputStream read(String s) {
+    if (!contains(s)) {
+      throw new IllegalArgumentException(String.format("SonarLintCache does not contain key \"%s\"", s));
+    }
+    return new ByteArrayInputStream(cache.get(s));
+  }
+
+  @Override
+  public boolean contains(String s) {
+    return cache.containsKey(s);
+  }
+
+  @Override
+  public void write(String s, InputStream inputStream) {
+    try {
+      write(s, inputStream.readAllBytes());
+    } catch (IOException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public void write(String s, byte[] bytes) {
+    if (contains(s)) {
+      throw new IllegalArgumentException(String.format("Same key cannot be written to multiple times (%s)", s));
+    }
+    cache.put(s, bytes);
+  }
+
+  @Override
+  public void copyFromPrevious(String s) {
+    throw new UnsupportedOperationException("SonarLintCache does not allow to copy from previous.");
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/caching/CacheContextImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/caching/CacheContextImpl.java
@@ -71,13 +71,13 @@ public class CacheContextImpl implements CacheContext {
       !isUsingSonarModules) {
       if (context.runtime().getProduct().equals(SonarProduct.SONARLINT)) {
         if (sonarLintCache != null) {
-          return new CacheContextImpl(context.isCacheEnabled(), new PythonWriteCacheImpl(sonarLintCache), new PythonReadCacheImpl(sonarLintCache));
+          return new CacheContextImpl(true, new PythonWriteCacheImpl(sonarLintCache), new PythonReadCacheImpl(sonarLintCache));
         }
       } else {
         return new CacheContextImpl(context.isCacheEnabled(), new PythonWriteCacheImpl(context.nextCache()), new PythonReadCacheImpl(context.previousCache()));
       }
     }
-    return new CacheContextImpl(false, new DummyCache(), new DummyCache());
+    return dummyCache();
   }
 
   public static CacheContextImpl dummyCache() {

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
@@ -19,6 +19,8 @@
  */
 package org.sonar.plugins.python.api;
 
+import com.sonar.sslr.api.RecognitionException;
+import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -27,17 +29,21 @@ import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.sonar.api.SonarProduct;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.FileInput;
 import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
+import org.sonar.python.caching.CacheContextImpl;
 import org.sonar.python.parser.PythonParser;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.SymbolImpl;
+import org.sonar.python.tree.FileInputImpl;
 import org.sonar.python.tree.PythonTreeMaker;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.mock;
 import static org.sonar.python.PythonTestUtils.pythonFile;
 
 class PythonVisitorContextTest {
@@ -78,11 +84,38 @@ class PythonVisitorContextTest {
   void globalSymbols() {
     String code = "from mod import a, b";
     FileInput fileInput = new PythonTreeMaker().fileInput(PythonParser.create().parse(code));
-    PythonFile pythonFile = Mockito.mock(PythonFile.class, "my_module.py");
+    PythonFile pythonFile = mock(PythonFile.class, "my_module.py");
     Mockito.when(pythonFile.fileName()).thenReturn("my_module.py");
     List<Symbol> modSymbols = Arrays.asList(new SymbolImpl("a", null), new SymbolImpl("b", null));
     Map<String, Set<Symbol>> globalSymbols = Collections.singletonMap("mod", new HashSet<>(modSymbols));
     new PythonVisitorContext(fileInput, pythonFile, null, "my_package", ProjectLevelSymbolTable.from(globalSymbols), null);
     assertThat(fileInput.globalVariables()).extracting(Symbol::name).containsExactlyInAnyOrder("a", "b");
+  }
+
+  @Test
+  void sonar_product() {
+    CacheContextImpl cacheContext = CacheContextImpl.dummyCache();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
+    String myPackage = "my_package";
+    File workingDirectory = null;
+    PythonFile pythonFile = mock(PythonFile.class, "my_module.py");
+    Mockito.when(pythonFile.fileName()).thenReturn("my_module.py");
+    FileInput fileInput = mock(FileInputImpl.class);
+
+    PythonVisitorContext pythonVisitorContext = new PythonVisitorContext(fileInput, pythonFile, workingDirectory, myPackage, projectLevelSymbolTable, cacheContext, SonarProduct.SONARLINT);
+    assertThat(pythonVisitorContext.sonarProduct()).isEqualTo(SonarProduct.SONARLINT);
+
+    pythonVisitorContext = new PythonVisitorContext(fileInput, pythonFile, workingDirectory, myPackage, projectLevelSymbolTable, cacheContext, SonarProduct.SONARQUBE);
+    assertThat(pythonVisitorContext.sonarProduct()).isEqualTo(SonarProduct.SONARQUBE);
+
+    pythonVisitorContext = new PythonVisitorContext(fileInput, pythonFile, workingDirectory, myPackage, projectLevelSymbolTable, cacheContext);
+    assertThat(pythonVisitorContext.sonarProduct()).isEqualTo(SonarProduct.SONARQUBE);
+
+    RecognitionException parsingException = mock(RecognitionException.class);
+    pythonVisitorContext = new PythonVisitorContext(pythonFile, parsingException);
+    assertThat(pythonVisitorContext.sonarProduct()).isEqualTo(SonarProduct.SONARQUBE);
+
+    pythonVisitorContext = new PythonVisitorContext(pythonFile, parsingException, SonarProduct.SONARLINT);
+    assertThat(pythonVisitorContext.sonarProduct()).isEqualTo(SonarProduct.SONARLINT);
   }
 }

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/SonarLintCacheTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/SonarLintCacheTest.java
@@ -1,0 +1,88 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2023 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.plugins.python.api;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+class SonarLintCacheTest {
+
+  @Test
+  void read_non_existing_key() {
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    assertThatThrownBy(() -> sonarLintCache.read("foo")).hasMessage("SonarLintCache does not contain key \"foo\"");
+  }
+
+  @Test
+  void write_and_read_existing_key() throws IOException {
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    byte[] bytes = {42};
+    sonarLintCache.write("foo", bytes);
+    try (var value = sonarLintCache.read("foo")) {
+      assertThat(value.readAllBytes()).isEqualTo(bytes);
+    }
+
+    sonarLintCache.write("bar", new ByteArrayInputStream(bytes));
+    try (var value = sonarLintCache.read("bar")) {
+      assertThat(value.readAllBytes()).isEqualTo(bytes);
+    }
+  }
+
+  @Test
+  void contains() {
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    assertThat(sonarLintCache.contains("foo")).isFalse();
+    byte[] bytes = {42};
+    sonarLintCache.write("foo", bytes);
+    assertThat(sonarLintCache.contains("foo")).isTrue();
+    assertThat(sonarLintCache.contains("bar")).isFalse();
+  }
+
+  @Test
+  void write_non_valid_input_stream() throws IOException {
+    InputStream inputStream = Mockito.mock(InputStream.class);
+    Mockito.when(inputStream.readAllBytes()).thenThrow(IOException.class);
+
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    assertThatThrownBy(() -> sonarLintCache.write("foo", inputStream)).isInstanceOf(IllegalStateException.class).hasCauseInstanceOf(IOException.class);
+  }
+
+  @Test
+  void write_same_key() {
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    byte[] bytes1 = {42};
+    byte[] bytes2 = {0, 1, 2};
+    sonarLintCache.write("foo", bytes1);
+    assertThatThrownBy(() -> sonarLintCache.write("foo", bytes2)).hasMessage("Same key cannot be written to multiple times (foo)");
+    assertThatThrownBy(() -> sonarLintCache.write("foo", new ByteArrayInputStream(bytes2))).hasMessage("Same key cannot be written to multiple times (foo)");
+  }
+
+  @Test
+  void copy_from_previous() {
+    SonarLintCache sonarLintCache = new SonarLintCache();
+    assertThatThrownBy(() -> sonarLintCache.copyFromPrevious("foo")).hasMessage("SonarLintCache does not allow to copy from previous.");
+  }
+}

--- a/python-frontend/src/test/java/org/sonar/python/caching/CacheContextImplTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/caching/CacheContextImplTest.java
@@ -66,11 +66,17 @@ class CacheContextImplTest {
   }
 
   @Test
-  void cache_context_on_sonarlint() {
-    SensorContext sensorContext = sensorContext(SonarProduct.SONARLINT, VERSION_WITH_CACHING, true);
+  void caching_is_always_enabled_if_there_is_a_sonarlint_cache() {
+    SensorContext sensorContext;
+    CacheContext cacheContext;
 
-    CacheContext cacheContext = CacheContextImpl.of(sensorContext, new SonarLintCache());
-    assertThat(cacheContext.isCacheEnabled()).isTrue();
+    sensorContext = sensorContext(SonarProduct.SONARLINT, VERSION_WITH_CACHING, true);
+    cacheContext = CacheContextImpl.of(sensorContext, new SonarLintCache());
+    Assertions.assertThat(cacheContext.isCacheEnabled()).isTrue();
+
+    sensorContext = sensorContext(SonarProduct.SONARLINT, VERSION_WITH_CACHING, false);
+    cacheContext = CacheContextImpl.of(sensorContext, new SonarLintCache());
+    Assertions.assertThat(cacheContext.isCacheEnabled()).isTrue();
   }
 
   @Test
@@ -126,17 +132,21 @@ class CacheContextImplTest {
   }
 
   @Test
-  void test_sonarlint_cache() throws IOException {
+  void use_dummy_cache_in_sonarlint_context_if_there_is_no_provided_sonarlint_cache() {
     SensorContext sensorContext = sensorContext(SonarProduct.SONARLINT, VERSION_WITH_CACHING, true);
-    CacheContext cacheContext;
 
-    cacheContext = CacheContextImpl.of(sensorContext, null);
+    var cacheContext = CacheContextImpl.of(sensorContext, null);
     Assertions.assertThat(cacheContext.isCacheEnabled()).isFalse();
     Assertions.assertThat(cacheContext.getWriteCache()).isInstanceOf(DummyCache.class);
     Assertions.assertThat(cacheContext.getReadCache()).isInstanceOf(DummyCache.class);
+  }
+
+  @Test
+  void sonarlint_cache_is_used_when_provided() throws IOException {
+    SensorContext sensorContext = sensorContext(SonarProduct.SONARLINT, VERSION_WITH_CACHING, true);
 
     var sonarLintCache = new SonarLintCache();
-    cacheContext = CacheContextImpl.of(sensorContext, sonarLintCache);
+    var cacheContext = CacheContextImpl.of(sensorContext, sonarLintCache);
     Assertions.assertThat(cacheContext.isCacheEnabled()).isTrue();
     Assertions.assertThat(cacheContext.getWriteCache()).isInstanceOf(PythonWriteCache.class);
     Assertions.assertThat(cacheContext.getReadCache()).isInstanceOf(PythonReadCache.class);

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IPynbSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IPynbSensor.java
@@ -32,6 +32,7 @@ import org.sonar.api.issue.NoSonarFilter;
 import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.plugins.python.api.ProjectPythonVersion;
 import org.sonar.plugins.python.api.PythonVersionUtils;
+import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.indexer.PythonIndexer;
 import org.sonar.python.checks.CheckList;
 import org.sonar.python.parser.PythonParser;
@@ -43,13 +44,16 @@ public final class IPynbSensor implements Sensor {
   private final PythonChecks checks;
   private final FileLinesContextFactory fileLinesContextFactory;
   private final NoSonarFilter noSonarFilter;
+  private final CacheContext cacheContext;
   private final PythonIndexer indexer;
 
-  public IPynbSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter, PythonIndexer indexer) {
+  public IPynbSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter, CacheContext cacheContext,
+    PythonIndexer indexer) {
     this.checks = new PythonChecks(checkFactory)
       .addChecks(CheckList.IPYTHON_REPOSITORY_KEY, CheckList.getChecks());
     this.fileLinesContextFactory = fileLinesContextFactory;
     this.noSonarFilter = noSonarFilter;
+    this.cacheContext = cacheContext;
     this.indexer = indexer;
   }
 
@@ -66,7 +70,7 @@ public final class IPynbSensor implements Sensor {
     context.config().get(PYTHON_VERSION_KEY)
       .map(PythonVersionUtils::fromString)
       .ifPresent(ProjectPythonVersion::setCurrentVersions);
-    PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, PythonParser.createIPythonParser(), indexer);
+    PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, PythonParser.createIPythonParser(), indexer, cacheContext);
     scanner.execute(pythonFiles, context);
   }
 

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
@@ -27,6 +27,7 @@ import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.bandit.BanditRulesDefinition;
 import org.sonar.plugins.python.bandit.BanditSensor;
 import org.sonar.plugins.python.coverage.PythonCoverageSensor;
@@ -41,7 +42,6 @@ import org.sonar.plugins.python.ruff.RuffRulesDefinition;
 import org.sonar.plugins.python.ruff.RuffSensor;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
 import org.sonar.plugins.python.xunit.PythonXUnitSensor;
-import org.sonar.plugins.python.api.SonarLintCache;
 
 public class PythonPlugin implements Plugin {
 
@@ -71,7 +71,6 @@ public class PythonPlugin implements Plugin {
         .defaultValue("py")
         .build(),
 
-
       Python.class,
 
       PythonProfile.class,
@@ -94,6 +93,7 @@ public class PythonPlugin implements Plugin {
       SonarLintPluginAPIManager sonarLintPluginAPIManager = new SonarLintPluginAPIManager();
       sonarLintPluginAPIManager.addSonarlintPythonIndexer(context, new SonarLintPluginAPIVersion());
       context.addExtensions(
+        SonarLintCache.class,
         IPynb.class,
         IPynbProfile.class,
         IPynbSensor.class,
@@ -221,7 +221,6 @@ public class PythonPlugin implements Plugin {
 
     public void addSonarlintPythonIndexer(Context context, SonarLintPluginAPIVersion sonarLintPluginAPIVersion) {
       if (sonarLintPluginAPIVersion.isDependencyAvailable()) {
-        context.addExtension(SonarLintCache.class);
         context.addExtension(SonarLintPythonIndexer.class);
       } else {
         LOG.debug("Error while trying to inject SonarLintPythonIndexer");

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonPlugin.java
@@ -19,14 +19,14 @@
  */
 package org.sonar.plugins.python;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.sonar.api.Plugin;
 import org.sonar.api.PropertyType;
 import org.sonar.api.SonarProduct;
 import org.sonar.api.SonarRuntime;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.api.resources.Qualifiers;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.sonar.plugins.python.bandit.BanditRulesDefinition;
 import org.sonar.plugins.python.bandit.BanditSensor;
 import org.sonar.plugins.python.coverage.PythonCoverageSensor;
@@ -41,6 +41,7 @@ import org.sonar.plugins.python.ruff.RuffRulesDefinition;
 import org.sonar.plugins.python.ruff.RuffSensor;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
 import org.sonar.plugins.python.xunit.PythonXUnitSensor;
+import org.sonar.plugins.python.api.SonarLintCache;
 
 public class PythonPlugin implements Plugin {
 
@@ -220,6 +221,7 @@ public class PythonPlugin implements Plugin {
 
     public void addSonarlintPythonIndexer(Context context, SonarLintPluginAPIVersion sonarLintPluginAPIVersion) {
       if (sonarLintPluginAPIVersion.isDependencyAvailable()) {
+        context.addExtension(SonarLintCache.class);
         context.addExtension(SonarLintPythonIndexer.class);
       } else {
         LOG.debug("Error while trying to inject SonarLintPythonIndexer");

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
@@ -83,7 +83,7 @@ public class PythonScanner extends Scanner {
 
   public PythonScanner(
     SensorContext context, PythonChecks checks,
-    FileLinesContextFactory fileLinesContextFactory, NoSonarFilter noSonarFilter, PythonParser parser, PythonIndexer indexer, CacheContext cacheContext) {
+    FileLinesContextFactory fileLinesContextFactory, NoSonarFilter noSonarFilter, PythonParser parser, CacheContext cacheContext, PythonIndexer indexer) {
     super(context);
     this.checks = checks;
     this.fileLinesContextFactory = fileLinesContextFactory;

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonScanner.java
@@ -107,12 +107,12 @@ public class PythonScanner extends Scanner {
       PythonTreeMaker treeMaker = getTreeMaker(inputFile);
       FileInput parse = treeMaker.fileInput(astNode);
       visitorContext = new PythonVisitorContext(
-        parse, pythonFile, getWorkingDirectory(context), indexer.packageName(inputFile), indexer.projectLevelSymbolTable(), indexer.cacheContext());
+        parse, pythonFile, getWorkingDirectory(context), indexer.packageName(inputFile), indexer.projectLevelSymbolTable(), indexer.cacheContext(), context.runtime().getProduct());
       if (fileType == InputFile.Type.MAIN) {
         saveMeasures(inputFile, visitorContext);
       }
     } catch (RecognitionException e) {
-      visitorContext = new PythonVisitorContext(pythonFile, e);
+      visitorContext = new PythonVisitorContext(pythonFile, e, context.runtime().getProduct());
       LOG.error("Unable to parse file: " + inputFile);
       LOG.error(e.getMessage());
       context.newAnalysisError()
@@ -161,7 +161,7 @@ public class PythonScanner extends Scanner {
         continue;
       }
       PythonFile pythonFile = SonarQubePythonFile.create(inputFile);
-      PythonInputFileContext inputFileContext = new PythonInputFileContext(pythonFile, context.fileSystem().workDir(), indexer.cacheContext());
+      PythonInputFileContext inputFileContext = new PythonInputFileContext(pythonFile, context.fileSystem().workDir(), indexer.cacheContext(), context.runtime().getProduct());
       if (check.scanWithoutParsing(inputFileContext)) {
         Set<PythonCheck> executedChecks = checksExecutedWithoutParsingByFiles.getOrDefault(inputFile, new HashSet<>());
         executedChecks.add(check);

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -120,7 +120,7 @@ public final class PythonSensor implements Sensor {
     pythonVersionParameter.ifPresent(value -> ProjectPythonVersion.setCurrentVersions(PythonVersionUtils.fromString(value)));
     CacheContext cacheContext = CacheContextImpl.of(context, sonarLintCache);
     PythonIndexer pythonIndexer = this.indexer != null ? this.indexer : new SonarQubePythonIndexer(pythonFiles, cacheContext, context);
-    PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, PythonParser.create(), pythonIndexer, cacheContext);
+    PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, PythonParser.create(), cacheContext, pythonIndexer);
     scanner.execute(pythonFiles, context);
     durationReport.stop();
   }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -40,6 +40,7 @@ import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.plugins.python.api.ProjectPythonVersion;
 import org.sonar.plugins.python.api.PythonCustomRuleRepository;
 import org.sonar.plugins.python.api.PythonVersionUtils;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.indexer.PythonIndexer;
 import org.sonar.plugins.python.indexer.SonarQubePythonIndexer;
@@ -62,6 +63,8 @@ public final class PythonSensor implements Sensor {
   private final FileLinesContextFactory fileLinesContextFactory;
   private final NoSonarFilter noSonarFilter;
   private final PythonIndexer indexer;
+
+  private final SonarLintCache sonarLintCache;
   private final AnalysisWarningsWrapper analysisWarnings;
   private static final Logger LOG = LoggerFactory.getLogger(PythonSensor.class);
   static final String UNSET_VERSION_WARNING =
@@ -73,27 +76,29 @@ public final class PythonSensor implements Sensor {
    */
   public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory,
                       NoSonarFilter noSonarFilter, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, null, analysisWarnings);
+    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, null, null, analysisWarnings);
   }
 
   public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
                       PythonCustomRuleRepository[] customRuleRepositories, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, customRuleRepositories, null, analysisWarnings);
+    this(fileLinesContextFactory, checkFactory, noSonarFilter, customRuleRepositories, null, null, analysisWarnings);
   }
 
   public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                      PythonIndexer indexer, AnalysisWarningsWrapper analysisWarnings) {
-    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, indexer, analysisWarnings);
+                      PythonIndexer indexer, SonarLintCache sonarLintCache, AnalysisWarningsWrapper analysisWarnings) {
+    this(fileLinesContextFactory, checkFactory, noSonarFilter, null, indexer, sonarLintCache, analysisWarnings);
   }
 
   public PythonSensor(FileLinesContextFactory fileLinesContextFactory, CheckFactory checkFactory, NoSonarFilter noSonarFilter,
-                      @Nullable PythonCustomRuleRepository[] customRuleRepositories, @Nullable PythonIndexer indexer, AnalysisWarningsWrapper analysisWarnings) {
+                      @Nullable PythonCustomRuleRepository[] customRuleRepositories, @Nullable PythonIndexer indexer,
+                      @Nullable SonarLintCache sonarLintCache, AnalysisWarningsWrapper analysisWarnings) {
     this.checks = new PythonChecks(checkFactory)
       .addChecks(CheckList.REPOSITORY_KEY, CheckList.getChecks())
       .addCustomChecks(customRuleRepositories);
     this.fileLinesContextFactory = fileLinesContextFactory;
     this.noSonarFilter = noSonarFilter;
     this.indexer = indexer;
+    this.sonarLintCache = sonarLintCache;
     this.analysisWarnings = analysisWarnings;
   }
 
@@ -116,6 +121,7 @@ public final class PythonSensor implements Sensor {
     pythonVersionParameter.ifPresent(value -> ProjectPythonVersion.setCurrentVersions(PythonVersionUtils.fromString(value)));
     CacheContext cacheContext = CacheContextImpl.of(context);
     PythonIndexer pythonIndexer = this.indexer != null ? this.indexer : new SonarQubePythonIndexer(pythonFiles, cacheContext, context);
+    pythonIndexer.setSonarLintCache(sonarLintCache);
     PythonScanner scanner = new PythonScanner(context, checks, fileLinesContextFactory, noSonarFilter, PythonParser.create(), pythonIndexer);
     scanner.execute(pythonFiles, context);
     durationReport.stop();

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/PythonSensor.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.SonarProduct;
+import org.sonar.api.batch.DependedUpon;
 import org.sonar.api.batch.fs.FilePredicates;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.rule.CheckFactory;
@@ -50,6 +51,7 @@ import org.sonarsource.performance.measure.PerformanceMeasure;
 
 import static org.sonar.plugins.python.api.PythonVersionUtils.PYTHON_VERSION_KEY;
 
+@DependedUpon(value = "org.sonar.plugins.python.PythonSensor_before_com.sonarsource.dbd.SonarLintPythonBugDetectionSensor")
 public final class PythonSensor implements Sensor {
 
   private static final String PERFORMANCE_MEASURE_PROPERTY = "sonar.python.performance.measure";

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
@@ -25,13 +25,15 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.CheckForNull;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.SensorContext;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.python.Scanner;
 import org.sonar.plugins.python.SonarQubePythonFile;
 import org.sonar.plugins.python.api.PythonFile;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.api.tree.FileInput;
 import org.sonar.python.parser.PythonParser;
@@ -79,6 +81,10 @@ public abstract class PythonIndexer {
   }
 
   public abstract void buildOnce(SensorContext context);
+
+  public void setSonarLintCache(@Nullable SonarLintCache sonarLintCache) {
+    // no op by default
+  }
 
   @CheckForNull
   public InputFile getFileWithId(String fileId) {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
@@ -33,8 +32,6 @@ import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.python.Scanner;
 import org.sonar.plugins.python.SonarQubePythonFile;
 import org.sonar.plugins.python.api.PythonFile;
-import org.sonar.plugins.python.api.SonarLintCache;
-import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.api.tree.FileInput;
 import org.sonar.python.parser.PythonParser;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
@@ -82,34 +79,30 @@ public abstract class PythonIndexer {
 
   public abstract void buildOnce(SensorContext context);
 
-  public void setSonarLintCache(@Nullable SonarLintCache sonarLintCache) {
-    // no op by default
-  }
-
   @CheckForNull
   public InputFile getFileWithId(String fileId) {
     // no op by default
     return null;
   }
 
-  /* We consider a file to be partially skippable if it is unchanged, but may depend on impacted files.
-     Regular Python rules will not run on such files.
-     Security UCFGs and DBD IRs will be regenerated for them if they do depend on impacted files.
-     In such case, these files will still need to be parsed when Security or DBD rules are enabled.
+  /*
+   * We consider a file to be partially skippable if it is unchanged, but may depend on impacted files.
+   * Regular Python rules will not run on such files.
+   * Security UCFGs and DBD IRs will be regenerated for them if they do depend on impacted files.
+   * In such case, these files will still need to be parsed when Security or DBD rules are enabled.
    */
   public boolean canBePartiallyScannedWithoutParsing(InputFile inputFile) {
     return false;
   }
 
-  /* We consider a file to be fully skippable if it is unchanged and does NOT depend on any impacted file.
-     Regular Python rules will not run on these files. Security UCFGs and DBD IRs will be retrieved from the cache.
-     These files will not be parsed.
+  /*
+   * We consider a file to be fully skippable if it is unchanged and does NOT depend on any impacted file.
+   * Regular Python rules will not run on these files. Security UCFGs and DBD IRs will be retrieved from the cache.
+   * These files will not be parsed.
    */
   public boolean canBeFullyScannedWithoutParsing(InputFile inputFile) {
     return false;
   }
-
-  public abstract CacheContext cacheContext();
 
   class GlobalSymbolsScanner extends Scanner {
 

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexer.java
@@ -25,17 +25,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.python.Python;
-import org.sonar.plugins.python.api.SonarLintCache;
-import org.sonar.plugins.python.api.caching.CacheContext;
-import org.sonar.python.caching.CacheContextImpl;
-import org.sonar.python.caching.PythonReadCacheImpl;
-import org.sonar.python.caching.PythonWriteCacheImpl;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileEvent;
 import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileListener;
@@ -46,7 +40,6 @@ public class SonarLintPythonIndexer extends PythonIndexer implements ModuleFileL
 
   private final ModuleFileSystem moduleFileSystem;
 
-  private CacheContext cacheContext;
   private final Map<String, InputFile> indexedFiles = new HashMap<>();
   private static final Logger LOG = LoggerFactory.getLogger(SonarLintPythonIndexer.class);
   private boolean shouldBuildProjectSymbolTable = true;
@@ -79,23 +72,10 @@ public class SonarLintPythonIndexer extends PythonIndexer implements ModuleFileL
     globalSymbolsStep.execute(files, context);
   }
 
-  // SonarLintCache has to be set lazily because SonarLintPythonIndex is injected in the PythonSensor
-  @Override
-  public void setSonarLintCache(@Nullable SonarLintCache sonarLintCache) {
-    if (sonarLintCache != null) {
-      this.cacheContext = new CacheContextImpl(true, new PythonWriteCacheImpl(sonarLintCache), new PythonReadCacheImpl(sonarLintCache));
-    }
-  }
-
   @Override
   public InputFile getFileWithId(String fileId) {
     String compare = fileId.replace("\\", "/");
     return indexedFiles.getOrDefault(compare, null);
-  }
-
-  @Override
-  public CacheContext cacheContext() {
-    return cacheContext != null ? cacheContext : CacheContextImpl.dummyCache();
   }
 
   private static List<InputFile> getInputFiles(ModuleFileSystem moduleFileSystem) {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexer.java
@@ -25,13 +25,17 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.python.Python;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.python.caching.CacheContextImpl;
+import org.sonar.python.caching.PythonReadCacheImpl;
+import org.sonar.python.caching.PythonWriteCacheImpl;
 import org.sonarsource.api.sonarlint.SonarLintSide;
 import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileEvent;
 import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileListener;
@@ -41,6 +45,8 @@ import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileSystem;
 public class SonarLintPythonIndexer extends PythonIndexer implements ModuleFileListener {
 
   private final ModuleFileSystem moduleFileSystem;
+
+  private CacheContext cacheContext;
   private final Map<String, InputFile> indexedFiles = new HashMap<>();
   private static final Logger LOG = LoggerFactory.getLogger(SonarLintPythonIndexer.class);
   private boolean shouldBuildProjectSymbolTable = true;
@@ -73,6 +79,14 @@ public class SonarLintPythonIndexer extends PythonIndexer implements ModuleFileL
     globalSymbolsStep.execute(files, context);
   }
 
+  // SonarLintCache has to be set lazily because SonarLintPythonIndex is injected in the PythonSensor
+  @Override
+  public void setSonarLintCache(@Nullable SonarLintCache sonarLintCache) {
+    if (sonarLintCache != null) {
+      this.cacheContext = new CacheContextImpl(true, new PythonWriteCacheImpl(sonarLintCache), new PythonReadCacheImpl(sonarLintCache));
+    }
+  }
+
   @Override
   public InputFile getFileWithId(String fileId) {
     String compare = fileId.replace("\\", "/");
@@ -81,7 +95,7 @@ public class SonarLintPythonIndexer extends PythonIndexer implements ModuleFileL
 
   @Override
   public CacheContext cacheContext() {
-    return CacheContextImpl.dummyCache();
+    return cacheContext != null ? cacheContext : CacheContextImpl.dummyCache();
   }
 
   private static List<InputFile> getInputFiles(ModuleFileSystem moduleFileSystem) {

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/SonarQubePythonIndexer.java
@@ -30,10 +30,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.sonar.api.batch.fs.InputFile;
-import org.sonar.api.batch.sensor.SensorContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.caching.Caching;
 import org.sonar.python.index.Descriptor;
@@ -115,18 +115,18 @@ public class SonarQubePythonIndexer extends PythonIndexer {
     LOG.info(
       "Cached information of global symbols will be used for {} out of {} main files. Global symbols will be recomputed for the remaining files.",
       inputFiles.size() - impactfulFiles.size(),
-      inputFiles.size()
-    );
+      inputFiles.size());
     LOG.info("Fully optimized analysis can be performed for {} out of {} files.", fullySkippableFiles.size(), inputFiles.size());
     LOG.info("Partially optimized analysis can be performed for {} out of {} files.", partiallySkippableFiles.size(), inputFiles.size());
-    // Although we need to analyze all impacted files, we only need to recompute global symbols for modified files (no cross-file dependencies in the project symbol table)
+    // Although we need to analyze all impacted files, we only need to recompute global symbols for modified files (no cross-file dependencies
+    // in the project symbol table)
     computeGlobalSymbols(impactfulFiles, context);
   }
 
   /*
-    In a full analysis, Typeshed symbols are loaded lazily depending on which module is encountered during parsing.
-    SonarSecurity needs all Typeshed symbols used in the project to be properly loaded.
-    For that reason, we load all symbols that were used in the previous analysis upfront, even if the file using them will not be parsed.
+   * In a full analysis, Typeshed symbols are loaded lazily depending on which module is encountered during parsing.
+   * SonarSecurity needs all Typeshed symbols used in the project to be properly loaded.
+   * For that reason, we load all symbols that were used in the previous analysis upfront, even if the file using them will not be parsed.
    */
   private void loadTypeshedSymbols() {
     TypeShed.builtinSymbols();
@@ -234,11 +234,6 @@ public class SonarQubePythonIndexer extends PythonIndexer {
   @Override
   public boolean canBeFullyScannedWithoutParsing(InputFile inputFile) {
     return fullySkippableFiles.contains(inputFile);
-  }
-
-  @Override
-  public CacheContext cacheContext() {
-    return caching.cacheContext();
   }
 
   private static String getCacheVersion(SensorContext context) {

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/IPynbSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/IPynbSensorTest.java
@@ -44,6 +44,7 @@ import org.sonar.api.measures.FileLinesContextFactory;
 import org.sonar.api.rule.RuleKey;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
+import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.indexer.PythonIndexer;
 import org.sonar.plugins.python.indexer.SonarLintPythonIndexer;
 import org.sonar.plugins.python.indexer.TestModuleFileSystem;
@@ -121,7 +122,7 @@ class IPynbSensorTest {
     FileLinesContext fileLinesContext = mock(FileLinesContext.class);
     when(fileLinesContextFactory.createFor(Mockito.any(InputFile.class))).thenReturn(fileLinesContext);
     CheckFactory checkFactory = new CheckFactory(activeRules);
-   return new IPynbSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer);
+    return new IPynbSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), mock(CacheContext.class), indexer);
   }
 
   private InputFile inputFile(String name) {

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonPluginTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonPluginTest.java
@@ -30,6 +30,7 @@ import org.sonar.api.SonarRuntime;
 import org.sonar.api.internal.SonarRuntimeImpl;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.api.utils.Version;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -47,7 +48,9 @@ class PythonPluginTest {
     SonarRuntime runtime = SonarRuntimeImpl.forSonarQube(v79, SonarQubeSide.SERVER, SonarEdition.DEVELOPER);
     assertThat(extensions(runtime)).hasSize(27);
     assertThat(extensions(runtime)).contains(AnalysisWarningsWrapper.class);
-    assertThat(extensions(SonarRuntimeImpl.forSonarLint(v79))).hasSize(11);
+    assertThat(extensions(SonarRuntimeImpl.forSonarLint(v79)))
+      .hasSize(12)
+      .contains(SonarLintCache.class);
   }
 
   @Test

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -36,7 +36,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import org.assertj.core.api.NotThrownAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -92,6 +91,7 @@ import org.sonar.plugins.python.caching.TestReadCache;
 import org.sonar.plugins.python.caching.TestWriteCache;
 import org.sonar.plugins.python.indexer.FileHashingUtils;
 import org.sonar.plugins.python.indexer.PythonIndexer;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.indexer.SonarLintPythonIndexer;
 import org.sonar.plugins.python.indexer.TestModuleFileSystem;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
@@ -108,7 +108,6 @@ import org.sonarsource.sonarlint.core.commons.Language;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -1243,9 +1242,9 @@ class PythonSensorTest {
       return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, analysisWarnings);
     }
     if (customRuleRepositories == null) {
-      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer, analysisWarnings);
+      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer, new SonarLintCache(), analysisWarnings);
     }
-    return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, indexer, analysisWarnings);
+    return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, indexer, new SonarLintCache(), analysisWarnings);
   }
 
   private SonarLintPythonIndexer pythonIndexer(List<InputFile> files) {

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -83,6 +83,7 @@ import org.sonar.plugins.python.api.PythonCustomRuleRepository;
 import org.sonar.plugins.python.api.PythonInputFileContext;
 import org.sonar.plugins.python.api.PythonVersionUtils;
 import org.sonar.plugins.python.api.PythonVisitorContext;
+import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.api.caching.CacheContext;
 import org.sonar.plugins.python.api.internal.EndOfAnalysis;
 import org.sonar.plugins.python.api.tree.Token;
@@ -91,7 +92,6 @@ import org.sonar.plugins.python.caching.TestReadCache;
 import org.sonar.plugins.python.caching.TestWriteCache;
 import org.sonar.plugins.python.indexer.FileHashingUtils;
 import org.sonar.plugins.python.indexer.PythonIndexer;
-import org.sonar.plugins.python.api.SonarLintCache;
 import org.sonar.plugins.python.indexer.SonarLintPythonIndexer;
 import org.sonar.plugins.python.indexer.TestModuleFileSystem;
 import org.sonar.plugins.python.warnings.AnalysisWarningsWrapper;
@@ -506,7 +506,6 @@ class PythonSensorTest {
     assertThat(context.allIssues()).hasSize(1);
   }
 
-
   @Test
   void test_issues_on_test_files() {
     activeRules = new ActiveRulesBuilder()
@@ -526,7 +525,6 @@ class PythonSensorTest {
     assertThat(issue.primaryLocation().inputComponent()).isEqualTo(inputFile);
     assertThat(issue.ruleKey().rule()).isEqualTo("S5905");
   }
-
 
   @Test
   void test_failFast_triggered_on_main_files() {
@@ -750,7 +748,6 @@ class PythonSensorTest {
     assertThat(defaultPerformanceFile).exists();
     assertThat(new String(Files.readAllBytes(defaultPerformanceFile), UTF_8)).contains("\"PythonSensor\"");
   }
-
 
   @Test
   void test_using_cache() throws IOException, NoSuchAlgorithmException {
@@ -1194,8 +1191,7 @@ class PythonSensorTest {
     context.setSettings(
       new MapSettings()
         .setProperty("sonar.python.skipUnchanged", true)
-        .setProperty("sonar.internal.analysis.failFast", true)
-    );
+        .setProperty("sonar.internal.analysis.failFast", true));
 
     sensor().execute(context);
 
@@ -1242,9 +1238,9 @@ class PythonSensorTest {
       return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, analysisWarnings);
     }
     if (customRuleRepositories == null) {
-      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer, new SonarLintCache(), analysisWarnings);
+      return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), indexer, analysisWarnings);
     }
-    return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, indexer, new SonarLintCache(), analysisWarnings);
+    return new PythonSensor(fileLinesContextFactory, checkFactory, mock(NoSonarFilter.class), customRuleRepositories, new SonarLintCache(), indexer, analysisWarnings);
   }
 
   private SonarLintPythonIndexer pythonIndexer(List<InputFile> files) {
@@ -1291,7 +1287,7 @@ class PythonSensorTest {
     return new DefaultTextRange(new DefaultTextPointer(lineStart, columnStart), new DefaultTextPointer(lineEnd, columnEnd));
   }
 
-  private void activate_rule_S2710(){
+  private void activate_rule_S2710() {
     activeRules = new ActiveRulesBuilder()
       .addRule(new NewActiveRule.Builder()
         .setRuleKey(RuleKey.of(CheckList.REPOSITORY_KEY, "S2710"))
@@ -1299,6 +1295,7 @@ class PythonSensorTest {
         .build())
       .build();
   }
+
   private void setup_quickfix_sensor() throws IOException {
     String pathToQuickFixTestFile = "src/test/resources/org/sonar/plugins/python/sensor/" + FILE_QUICKFIX;
     File file = new File(pathToQuickFixTestFile);

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexerTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/indexer/SonarLintPythonIndexerTest.java
@@ -40,12 +40,7 @@ import org.sonar.api.batch.sensor.internal.SensorContextTester;
 import org.sonar.api.testfixtures.log.LogTesterJUnit5;
 import org.sonar.plugins.python.Python;
 import org.sonar.plugins.python.TestUtils;
-import org.sonar.plugins.python.api.SonarLintCache;
-import org.sonar.plugins.python.api.caching.CacheContext;
-import org.sonar.plugins.python.api.caching.PythonReadCache;
-import org.sonar.plugins.python.api.caching.PythonWriteCache;
 import org.sonar.plugins.python.api.symbols.Symbol;
-import org.sonar.python.caching.DummyCache;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonarsource.sonarlint.plugin.api.module.file.ModuleFileEvent;
 
@@ -180,35 +175,6 @@ class SonarLintPythonIndexerTest {
   void test_indexer_non_python_file() {
     testNonPythonFile("txt");
     testNonPythonFile(null);
-  }
-
-  @Test
-  void test_sonarlint_cache() throws IOException {
-    PythonIndexer indexer = new SonarLintPythonIndexer(moduleFileSystem);
-    CacheContext cacheContext = indexer.cacheContext();
-    assertThat(cacheContext.isCacheEnabled()).isFalse();
-    assertThat(cacheContext.getWriteCache()).isInstanceOf(DummyCache.class);
-    assertThat(cacheContext.getReadCache()).isInstanceOf(DummyCache.class);
-
-    indexer.setSonarLintCache(null);
-    cacheContext = indexer.cacheContext();
-    assertThat(cacheContext.isCacheEnabled()).isFalse();
-    assertThat(cacheContext.getWriteCache()).isInstanceOf(DummyCache.class);
-    assertThat(cacheContext.getReadCache()).isInstanceOf(DummyCache.class);
-
-    SonarLintCache sonarLintCache = new SonarLintCache();
-    indexer.setSonarLintCache(sonarLintCache);
-    cacheContext = indexer.cacheContext();
-    assertThat(cacheContext.isCacheEnabled()).isTrue();
-    assertThat(cacheContext.getWriteCache()).isInstanceOf(PythonWriteCache.class);
-    assertThat(cacheContext.getReadCache()).isInstanceOf(PythonReadCache.class);
-
-    byte[] bytes = {0};
-    sonarLintCache.write("foo", bytes);
-    PythonReadCache readCache = cacheContext.getReadCache();
-    try (var inputStream = readCache.read("foo")) {
-      assertThat(inputStream.readAllBytes()).isEqualTo(bytes);
-    }
   }
 
   private void testNonPythonFile(@Nullable String language) {


### PR DESCRIPTION
This PR is meant to address [review comments](https://github.com/SonarSource/sonar-python/pull/1690#pullrequestreview-1777960787) on MMF-3482.

`SonarLintCache` and `PythonIndexer` are now more independent.
I.e. the `SonarLintCache` extension is added independently of whether `SonarLintPythonIndexer` can be added or not.
Also, Sensors can be instantiated if no `SonarLintCache` is present, but a `PythonIndexer` is available. 