### PR TITLE
SONARPY-1747 Fix incorrect type equality when classes vary in metaclass status

### DIFF
--- a/python-checks/src/test/resources/checks/tests/assertOnDissimilarTypes.py
+++ b/python-checks/src/test/resources/checks/tests/assertOnDissimilarTypes.py
@@ -157,3 +157,28 @@ class MyTest(unittest.TestCase):
     self.assertEqual(5, *a)
     self.assertEqual("5", b)  # Noncompliant
     a.assertEqual("string", True)
+
+
+class AmbiguousSymbolsNoType(unittest.TestCase):
+    def test_signature_on_class(self):
+        class ClassWithMultipleDefinitions:
+            def __init__(self, a):
+                pass
+
+        class CM(type):
+            def __call__(cls, a):
+                pass
+        class ClassWithMultipleDefinitions(metaclass=CM):
+            def __init__(self, b):
+                pass
+
+        with ...:
+            class CM(type):
+                @classmethod
+                def __call__(cls, a):
+                    return a
+            class ClassWithMultipleDefinitions(metaclass=CM):
+                def __init__(self, b):
+                    pass
+
+            self.assertEqual(ClassWithMultipleDefinitions(1), 1)  # OK, ambiguous type

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/symbols/ClassSymbol.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/symbols/ClassSymbol.java
@@ -53,4 +53,7 @@ public interface ClassSymbol extends Symbol {
 
   @Beta
   boolean hasDecorators();
+
+  @Beta
+  boolean hasMetaClass();
 }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/ClassSymbolImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ClassSymbolImpl.java
@@ -254,6 +254,7 @@ public class ClassSymbolImpl extends SymbolImpl implements ClassSymbol {
     return Optional.empty();
   }
 
+  @Override
   public boolean hasMetaClass() {
     return hasMetaClass || membersByName().get("__metaclass__") != null;
   }

--- a/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/InferredTypes.java
@@ -474,9 +474,10 @@ public class InferredTypes {
   }
 
   public static String getBuiltinCategory(InferredType inferredType) {
-    return BUILTINS_TYPE_CATEGORY.keySet().stream()
+    List<String> list = BUILTINS_TYPE_CATEGORY.keySet().stream()
       .filter(inferredType::canOnlyBe)
-      .map(BUILTINS_TYPE_CATEGORY::get).findFirst().orElse(null);
+      .map(BUILTINS_TYPE_CATEGORY::get).toList();
+    return list.size() == 1 ? list.get(0) : null;
   }
 
   public static Map<String, String> getBuiltinsTypeCategory() {

--- a/python-frontend/src/main/java/org/sonar/python/types/RuntimeType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/RuntimeType.java
@@ -112,6 +112,9 @@ class RuntimeType implements InferredType {
     RuntimeType that = (RuntimeType) o;
     return Objects.equals(getTypeClass().name(), that.getTypeClass().name()) &&
       Objects.equals(getTypeClass().fullyQualifiedName(), that.getTypeClass().fullyQualifiedName())
+      && Objects.equals(getTypeClass().hasUnresolvedTypeHierarchy(), that.getTypeClass().hasUnresolvedTypeHierarchy())
+      && Objects.equals(getTypeClass().hasDecorators(), that.getTypeClass().hasDecorators())
+      && Objects.equals(getTypeClass().hasMetaClass(), that.getTypeClass().hasMetaClass())
       && Objects.equals(typeClassSuperClassesFQN(), that.typeClassSuperClassesFQN())
       && Objects.equals(typeClassMembersFQN(), that.typeClassMembersFQN());
   }
@@ -136,7 +139,14 @@ class RuntimeType implements InferredType {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getTypeClass().name(), getTypeClass().fullyQualifiedName(), typeClassSuperClassesFQN(), typeClassMembersFQN());
+    return Objects.hash(
+      getTypeClass().name(),
+      getTypeClass().fullyQualifiedName(),
+      getTypeClass().hasDecorators(),
+      getTypeClass().hasUnresolvedTypeHierarchy(),
+      getTypeClass().hasMetaClass(),
+      typeClassSuperClassesFQN(),
+      typeClassMembersFQN());
   }
 
   @Override

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ClassSymbolTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ClassSymbolTest.java
@@ -53,6 +53,7 @@ class ClassSymbolTest {
     ClassSymbol classSymbol = (ClassSymbol) symbol;
     assertThat(classSymbol.superClasses()).hasSize(0);
     assertThat(classSymbol.hasUnresolvedTypeHierarchy()).isFalse();
+    assertThat(classSymbol.hasMetaClass()).isFalse();
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/types/InferredTypesTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/InferredTypesTest.java
@@ -23,7 +23,6 @@ import com.google.protobuf.TextFormat;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.plugins.python.api.symbols.ClassSymbol;
@@ -35,14 +34,12 @@ import org.sonar.plugins.python.api.types.InferredType;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.AmbiguousSymbolImpl;
 import org.sonar.python.semantic.ClassSymbolImpl;
-import org.sonar.python.semantic.FunctionSymbolImpl;
 import org.sonar.python.semantic.SymbolImpl;
 import org.sonar.python.types.protobuf.SymbolsProtos;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.python.PythonTestUtils.lastExpression;
 import static org.sonar.python.PythonTestUtils.lastExpressionInFunction;
-import static org.sonar.python.PythonTestUtils.pythonFile;
 import static org.sonar.python.types.InferredTypes.COMPLEX;
 import static org.sonar.python.types.InferredTypes.DECL_INT;
 import static org.sonar.python.types.InferredTypes.DECL_STR;
@@ -501,6 +498,7 @@ class InferredTypesTest {
     assertThat(getBuiltinCategory(LIST)).isEqualTo(BuiltinTypes.LIST);
     assertThat(getBuiltinCategory(SET)).isEqualTo(BuiltinTypes.SET);
     assertThat(getBuiltinCategory(TUPLE)).isEqualTo(BuiltinTypes.TUPLE);
+    assertThat(getBuiltinCategory(anyType())).isNull();
     assertThat(getBuiltinsTypeCategory()).isNotNull();
     assertThat(getBuiltinsTypeCategory()).isNotEmpty();
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/RuntimeTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/RuntimeTypeTest.java
@@ -20,6 +20,7 @@
 package org.sonar.python.types;
 
 import java.util.Collections;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.symbols.ClassSymbol;
 import org.sonar.plugins.python.api.tree.ClassDef;
@@ -27,6 +28,7 @@ import org.sonar.plugins.python.api.tree.FileInput;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.plugins.python.api.types.InferredType;
 import org.sonar.python.PythonTestUtils;
+import org.sonar.python.index.ClassDescriptor;
 import org.sonar.python.semantic.ClassSymbolImpl;
 import org.sonar.python.semantic.SymbolImpl;
 import org.sonar.python.semantic.SymbolTableBuilder;
@@ -204,6 +206,18 @@ class RuntimeTypeTest {
     RuntimeType x = new RuntimeType(new ClassSymbolImpl("X", null));
     RuntimeType y = new RuntimeType(new ClassSymbolImpl("Y", null));
     assertThat(x).isNotEqualTo(y);
+
+    RuntimeType fff1 = new RuntimeType(new ClassSymbolImpl(generateDescriptor(false, false, false), "a"));
+    RuntimeType fff2 = new RuntimeType(new ClassSymbolImpl(generateDescriptor(false, false, false), "a"));
+    RuntimeType tff = new RuntimeType(new ClassSymbolImpl(generateDescriptor(true, false, false), "a"));
+    RuntimeType ftf = new RuntimeType(new ClassSymbolImpl(generateDescriptor(false, true, false), "a"));
+    RuntimeType fft = new RuntimeType(new ClassSymbolImpl(generateDescriptor(false, false, true), "a"));
+
+    assertThat(fff1)
+      .isEqualTo(fff2)
+      .isNotEqualTo(tff)
+      .isNotEqualTo(ftf)
+      .isNotEqualTo(fft);
   }
 
   @Test
@@ -346,6 +360,19 @@ class RuntimeTypeTest {
 
     assertThat(typeX2.mustBeOrExtend("x1")).isTrue();
     assertThat(typeX2.mustBeOrExtend("x2")).isTrue();
+  }
+
+  ClassDescriptor generateDescriptor(boolean hasDecorators, boolean hasMetaClass, boolean hasUnresolvedHierarchy) {
+    return new ClassDescriptor("a",
+      "a",
+      Set.of(),
+      Set.of(),
+      hasDecorators,
+      null,
+      hasUnresolvedHierarchy,
+      hasMetaClass,
+      null,
+      false);
   }
 
   @Test


### PR DESCRIPTION
It seems `RuntimeType#equals` relies on a somewhat loose mechanism to determine that classes are equal, while `equals` is not implemented on `Symbol` level.

I made sure that `metaclass`, `decorator` and type hierarchy resolution status are accounted for when performing this check. 
I think it would be better to have proper `equals` implemented on `ClassSymbol`. However, it seems we actually rely on the loose comparison to implicitly merge almost-identical symbols.  Given we are in the process of refactoring our type inference model and engine, I think the quick-fix makes sense.