### PR TITLE
SONARPY-1796 Infer types for set, dict and tuple literals

### DIFF
--- a/python-checks/src/test/resources/checks/nonCallableCalled.py
+++ b/python-checks/src/test/resources/checks/nonCallableCalled.py
@@ -22,10 +22,13 @@ def call_noncallable(p):
     list_var()  # Noncompliant
 
     tuple_var = ()
-    tuple_var()  # FN
+    tuple_var()  # Noncompliant
 
     dict_var = {}
-    dict_var()  # FN
+    dict_var()  # Noncompliant
+
+    set_literal = {1, 2}
+    set_literal()  # Noncompliant
 
     set_var = set()
     set_var()  # FN

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -88,20 +88,20 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     ModuleType builtins = this.projectLevelTypeTable.getModule(BUILTINS);
     // TODO: multiple object types to represent str instance?
     PythonType strType = builtins.resolveMember("str").orElse(PythonType.UNKNOWN);
-    ((StringLiteralImpl) stringLiteral).typeV2(new ObjectType(strType, List.of(), List.of()));
+    ((StringLiteralImpl) stringLiteral).typeV2(new ObjectType(strType, new ArrayList<>(), new ArrayList<>()));
   }
 
   @Override
   public void visitTuple(Tuple tuple) {
     super.visitTuple(tuple);
     List<PythonType> contentTypes = tuple.elements().stream().map(Expression::typeV2).distinct().toList();
-    List<PythonType> attributes = List.of();
+    List<PythonType> attributes = new ArrayList<>();
     if (contentTypes.size() == 1 && !contentTypes.get(0).equals(PythonType.UNKNOWN)) {
       attributes = contentTypes;
     }
     ModuleType builtins = this.projectLevelTypeTable.getModule(BUILTINS);
     PythonType tupleType = builtins.resolveMember("tuple").orElse(PythonType.UNKNOWN);
-    ((TupleImpl) tuple).typeV2(new ObjectType(tupleType,  attributes, List.of()));
+    ((TupleImpl) tuple).typeV2(new ObjectType(tupleType,  attributes, new ArrayList<>()));
   }
 
   @Override
@@ -109,7 +109,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     super.visitDictionaryLiteral(dictionaryLiteral);
     ModuleType builtins = this.projectLevelTypeTable.getModule(BUILTINS);
     PythonType dictType = builtins.resolveMember("dict").orElse(PythonType.UNKNOWN);
-    ((DictionaryLiteralImpl) dictionaryLiteral).typeV2(new ObjectType(dictType,  List.of(), List.of()));
+    ((DictionaryLiteralImpl) dictionaryLiteral).typeV2(new ObjectType(dictType,  new ArrayList<>(), new ArrayList<>()));
   }
 
   @Override
@@ -117,7 +117,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     super.visitSetLiteral(setLiteral);
     ModuleType builtins = this.projectLevelTypeTable.getModule(BUILTINS);
     PythonType setType = builtins.resolveMember("set").orElse(PythonType.UNKNOWN);
-    ((SetLiteralImpl) setLiteral).typeV2(new ObjectType(setType,  List.of(), List.of()));
+    ((SetLiteralImpl) setLiteral).typeV2(new ObjectType(setType,  new ArrayList<>(), new ArrayList<>()));
   }
 
   @Override
@@ -127,7 +127,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     String memberName = ((RuntimeType) type).getTypeClass().fullyQualifiedName();
     if (memberName != null) {
       PythonType pythonType = builtins.resolveMember(memberName).orElse(PythonType.UNKNOWN);
-      ((NumericLiteralImpl) numericLiteral).typeV2(new ObjectType(pythonType, List.of(), List.of()));
+      ((NumericLiteralImpl) numericLiteral).typeV2(new ObjectType(pythonType, new ArrayList<>(), new ArrayList<>()));
     }
   }
 
@@ -136,7 +136,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     ModuleType builtins = this.projectLevelTypeTable.getModule(BUILTINS);
     // TODO: multiple object types to represent str instance?
     PythonType noneType = builtins.resolveMember("NoneType").orElse(PythonType.UNKNOWN);
-    ((NoneExpressionImpl) noneExpression).typeV2(new ObjectType(noneType, List.of(), List.of()));
+    ((NoneExpressionImpl) noneExpression).typeV2(new ObjectType(noneType, new ArrayList<>(), new ArrayList<>()));
   }
 
   @Override
@@ -146,7 +146,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     List<PythonType> pythonTypes = listLiteral.elements().expressions().stream().map(Expression::typeV2).distinct().toList();
     // TODO: cleanly reduce attributes
     PythonType listType = builtins.resolveMember("list").orElse(PythonType.UNKNOWN);
-    ((ListLiteralImpl) listLiteral).typeV2(new ObjectType(listType, pythonTypes, List.of()));
+    ((ListLiteralImpl) listLiteral).typeV2(new ObjectType(listType, pythonTypes, new ArrayList<>()));
   }
 
   @Override

--- a/python-frontend/src/main/java/org/sonar/python/tree/DictionaryLiteralImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/DictionaryLiteralImpl.java
@@ -26,8 +26,11 @@ import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.TreeVisitor;
 import org.sonar.plugins.python.api.types.InferredType;
 import org.sonar.python.types.InferredTypes;
+import org.sonar.python.types.v2.PythonType;
 
 public class DictionaryLiteralImpl extends DictOrSetLiteralImpl<DictionaryLiteralElement> implements DictionaryLiteral {
+
+  private PythonType pythonType = PythonType.UNKNOWN;
 
   public DictionaryLiteralImpl(Token lCurlyBrace, List<Token> commas, List<DictionaryLiteralElement> elements, Token rCurlyBrace) {
     super(lCurlyBrace, commas, elements, rCurlyBrace);
@@ -45,5 +48,15 @@ public class DictionaryLiteralImpl extends DictOrSetLiteralImpl<DictionaryLitera
   @Override
   public InferredType type() {
     return InferredTypes.DICT;
+  }
+
+  @Override
+  public PythonType typeV2() {
+    return pythonType;
+  }
+
+  public DictionaryLiteral typeV2(PythonType pythonType) {
+    this.pythonType = pythonType;
+    return this;
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/tree/SetLiteralImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/SetLiteralImpl.java
@@ -26,8 +26,11 @@ import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.TreeVisitor;
 import org.sonar.plugins.python.api.types.InferredType;
 import org.sonar.python.types.InferredTypes;
+import org.sonar.python.types.v2.PythonType;
 
 public class SetLiteralImpl extends DictOrSetLiteralImpl<Expression> implements SetLiteral {
+
+  private PythonType pythonType = PythonType.UNKNOWN;
 
   public SetLiteralImpl(Token lCurlyBrace, List<Expression> elements, List<Token> commas, Token rCurlyBrace) {
     super(lCurlyBrace, commas, elements, rCurlyBrace);
@@ -45,5 +48,15 @@ public class SetLiteralImpl extends DictOrSetLiteralImpl<Expression> implements 
   @Override
   public InferredType type() {
     return InferredTypes.SET;
+  }
+
+  @Override
+  public PythonType typeV2() {
+    return pythonType;
+  }
+
+  public SetLiteralImpl typeV2(PythonType pythonType) {
+    this.pythonType = pythonType;
+    return this;
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/tree/TupleImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TupleImpl.java
@@ -30,6 +30,7 @@ import org.sonar.plugins.python.api.tree.TreeVisitor;
 import org.sonar.plugins.python.api.tree.Tuple;
 import org.sonar.plugins.python.api.types.InferredType;
 import org.sonar.python.types.InferredTypes;
+import org.sonar.python.types.v2.PythonType;
 
 public class TupleImpl extends PyTree implements Tuple {
 
@@ -37,6 +38,7 @@ public class TupleImpl extends PyTree implements Tuple {
   private final List<Expression> elements;
   private final List<Token> commas;
   private final Token rightParenthesis;
+  private PythonType pythonType = PythonType.UNKNOWN;
 
   public TupleImpl(@Nullable Token leftParenthesis, List<Expression> elements, List<Token> commas, @Nullable Token rightParenthesis) {
     this.leftParenthesis = leftParenthesis;
@@ -100,5 +102,15 @@ public class TupleImpl extends PyTree implements Tuple {
   @Override
   public InferredType type() {
     return InferredTypes.TUPLE;
+  }
+
+  @Override
+  public PythonType typeV2() {
+    return pythonType;
+  }
+
+  public TupleImpl typeV2(PythonType pythonType) {
+    this.pythonType = pythonType;
+    return this;
   }
 }


### PR DESCRIPTION
Tuple content type is inferred immediately if (and unique) available as tuple are immutables.
This should be seen as a baby step/low-hanging fruit. I'd expect a dedicated effort to tackle any more complex case.

Also, this PR does not deal with display name/representation of those generic types.

Not 100% related to the ticket, but I also took the opportunity to add some missing test for some already covered literal types (str, numeric literals and None).