### PR TITLE
SONARPY-1803 Store type definition location in the new type model

### DIFF
--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/LocationInFile.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/LocationInFile.java
@@ -19,38 +19,5 @@
  */
 package org.sonar.plugins.python.api;
 
-public class LocationInFile {
-  private final String fileId;
-  private final int startLine;
-  private final int startLineOffset;
-  private final int endLine;
-  private final int endLineOffset;
-
-  public LocationInFile(String fileId, int startLine, int startLineOffset, int endLine, int endLineOffset) {
-    this.fileId = fileId;
-    this.startLine = startLine;
-    this.startLineOffset = startLineOffset;
-    this.endLine = endLine;
-    this.endLineOffset = endLineOffset;
-  }
-
-  public String fileId() {
-    return fileId;
-  }
-
-  public int startLine() {
-    return startLine;
-  }
-
-  public int startLineOffset() {
-    return startLineOffset;
-  }
-
-  public int endLine() {
-    return endLine;
-  }
-
-  public int endLineOffset() {
-    return endLineOffset;
-  }
+public record LocationInFile(String fileId, int startLine, int startLineOffset, int endLine, int endLineOffset) {
 }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
@@ -49,7 +49,7 @@ public class PythonVisitorContext extends PythonInputFileContext {
     symbolTableBuilder.visitFileInput(rootTree);
     SymbolTableBuilderV2 symbolTableBuilderV2 = new SymbolTableBuilderV2();
     symbolTableBuilderV2.visitFileInput(rootTree);
-    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty())));
+    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty()), pythonFile));
   }
 
   public PythonVisitorContext(FileInput rootTree, PythonFile pythonFile, @Nullable File workingDirectory, String packageName,
@@ -60,7 +60,7 @@ public class PythonVisitorContext extends PythonInputFileContext {
     new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
     SymbolTableBuilderV2 symbolTableBuilderV2 = new SymbolTableBuilderV2();
     symbolTableBuilderV2.visitFileInput(rootTree);
-    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(projectLevelSymbolTable)));
+    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(projectLevelSymbolTable), pythonFile));
   }
 
   public PythonVisitorContext(FileInput rootTree, PythonFile pythonFile, @Nullable File workingDirectory, String packageName,
@@ -71,7 +71,7 @@ public class PythonVisitorContext extends PythonInputFileContext {
     new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
     SymbolTableBuilderV2 symbolTableBuilderV2 = new SymbolTableBuilderV2();
     symbolTableBuilderV2.visitFileInput(rootTree);
-    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(projectLevelSymbolTable)));
+    rootTree.accept(new TypeInferenceV2(new ProjectLevelTypeTable(projectLevelSymbolTable), pythonFile));
   }
 
   public PythonVisitorContext(PythonFile pythonFile, RecognitionException parsingException) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.types.v2.ClassType;
 import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.PythonType;
@@ -35,14 +36,21 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
   List<PythonType> attributes = new ArrayList<>();
   List<PythonType> superClasses = new ArrayList<>();
   List<PythonType> metaClasses = new ArrayList<>();
+  LocationInFile definitionLocation;
 
   @Override
   public ClassType build() {
-    return new ClassType(name, members, attributes, superClasses, metaClasses);
+    return new ClassType(name, members, attributes, superClasses, metaClasses, definitionLocation);
   }
 
   public ClassTypeBuilder setName(String name) {
     this.name = name;
+    return this;
+  }
+
+  @Override
+  public ClassTypeBuilder withDefinitionLocation(LocationInFile definitionLocation) {
+    this.definitionLocation = definitionLocation;
     return this;
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -44,7 +44,7 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
     return new ClassType(name, members, attributes, superClasses, metaClasses, definitionLocation);
   }
 
-  public ClassTypeBuilder setName(String name) {
+  public ClassTypeBuilder withName(String name) {
     this.name = name;
     return this;
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.types.v2.ClassType;
 import org.sonar.python.types.v2.Member;
@@ -49,7 +50,7 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
   }
 
   @Override
-  public ClassTypeBuilder withDefinitionLocation(LocationInFile definitionLocation) {
+  public ClassTypeBuilder withDefinitionLocation(@Nullable LocationInFile definitionLocation) {
     this.definitionLocation = definitionLocation;
     return this;
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.plugins.python.api.tree.AnyParameter;
 import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Name;
@@ -48,6 +49,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
   private boolean isInstanceMethod;
   private PythonType owner;
   private PythonType returnType = PythonType.UNKNOWN;
+  private LocationInFile definitionLocation;
 
   private static final String CLASS_METHOD_DECORATOR = "classmethod";
   private static final String STATIC_METHOD_DECORATOR = "staticmethod";
@@ -108,8 +110,16 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     return this;
   }
 
+  @Override
+  public FunctionTypeBuilder withDefinitionLocation(@Nullable LocationInFile definitionLocation) {
+    this.definitionLocation = definitionLocation;
+    return this;
+  }
+
   public FunctionType build() {
-    return new FunctionType(name, attributes, parameters, returnType, isAsynchronous, hasDecorators, isInstanceMethod, hasVariadicParameter, owner);
+    return new FunctionType(
+      name, attributes, parameters, returnType, isAsynchronous, hasDecorators, isInstanceMethod, hasVariadicParameter, owner, definitionLocation
+    );
   }
 
   private static boolean isInstanceMethod(FunctionDef functionDef) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
@@ -121,7 +121,8 @@ public class SymbolsModuleTypeProvider {
         .withAsynchronous(symbol.isAsynchronous())
         .withHasDecorators(symbol.hasDecorators())
         .withInstanceMethod(symbol.isInstanceMethod())
-        .withHasVariadicParameter(symbol.hasVariadicParameter());
+        .withHasVariadicParameter(symbol.hasVariadicParameter())
+        .withDefinitionLocation(symbol.definitionLocation());
     FunctionType functionType = functionTypeBuilder.build();
     createdTypesBySymbol.put(symbol, functionType);
     return functionType;
@@ -142,7 +143,7 @@ public class SymbolsModuleTypeProvider {
     if (createdTypesBySymbol.containsKey(symbol)) {
       return createdTypesBySymbol.get(symbol);
     }
-    ClassType classType = new ClassType(symbol.name());
+    ClassType classType = new ClassType(symbol.name(), symbol.definitionLocation());
     createdTypesBySymbol.put(symbol, classType);
     Set<Member> members =
       symbol.declaredMembers().stream().map(m -> new Member(m.name(), convertToType(m, createdTypesBySymbol))).collect(Collectors.toSet());

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeBuilder.java
@@ -19,9 +19,12 @@
  */
 package org.sonar.python.semantic.v2;
 
+import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.types.v2.PythonType;
 
 public interface TypeBuilder<T extends PythonType> {
 
   T build();
+
+  TypeBuilder<T> withDefinitionLocation(LocationInFile definitionLocation);
 }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -73,14 +73,12 @@ import static org.sonar.python.tree.TreeUtils.locationInFile;
 public class TypeInferenceV2 extends BaseTreeVisitor {
 
   private final ProjectLevelTypeTable projectLevelTypeTable;
-  private final PythonFile pythonFile;
   private final String fileId;
 
   private final Deque<PythonType> typeStack = new ArrayDeque<>();
 
   public TypeInferenceV2(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile) {
     this.projectLevelTypeTable = projectLevelTypeTable;
-    this.pythonFile = pythonFile;
     Path path = pathOf(pythonFile);
     this.fileId = path != null ? path.toString() : pythonFile.toString();
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -160,7 +160,7 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
     scan(classDef.args());
     Name name = classDef.name();
     ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder()
-      .setName(name.name())
+      .withName(name.name())
       .withDefinitionLocation(locationInFile(classDef.name(), fileId));
     resolveTypeHierarchy(classDef, classTypeBuilder);
     ClassType type = classTypeBuilder.build();

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.semantic.v2;
 
+import java.nio.file.Path;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -26,6 +27,7 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.tree.ArgList;
 import org.sonar.plugins.python.api.tree.AssignmentStatement;
 import org.sonar.plugins.python.api.tree.BaseTreeVisitor;
@@ -65,14 +67,22 @@ import org.sonar.python.types.v2.ModuleType;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.PythonType;
 
+import static org.sonar.python.semantic.SymbolUtils.pathOf;
+import static org.sonar.python.tree.TreeUtils.locationInFile;
+
 public class TypeInferenceV2 extends BaseTreeVisitor {
 
   private final ProjectLevelTypeTable projectLevelTypeTable;
+  private final PythonFile pythonFile;
+  private final String fileId;
 
   private final Deque<PythonType> typeStack = new ArrayDeque<>();
 
-  public TypeInferenceV2(ProjectLevelTypeTable projectLevelTypeTable) {
+  public TypeInferenceV2(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile) {
     this.projectLevelTypeTable = projectLevelTypeTable;
+    this.pythonFile = pythonFile;
+    Path path = pathOf(pythonFile);
+    this.fileId = path != null ? path.toString() : pythonFile.toString();
   }
 
   @Override
@@ -151,7 +161,9 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
   public void visitClassDef(ClassDef classDef) {
     scan(classDef.args());
     Name name = classDef.name();
-    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder().setName(name.name());
+    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder()
+      .setName(name.name())
+      .withDefinitionLocation(locationInFile(classDef.name(), fileId));
     resolveTypeHierarchy(classDef, classTypeBuilder);
     ClassType type = classTypeBuilder.build();
     ((NameImpl) name).typeV2(type);
@@ -212,7 +224,9 @@ public class TypeInferenceV2 extends BaseTreeVisitor {
   }
 
   private FunctionType buildFunctionType(FunctionDef functionDef) {
-    FunctionTypeBuilder functionTypeBuilder = new FunctionTypeBuilder().fromFunctionDef(functionDef);
+    FunctionTypeBuilder functionTypeBuilder = new FunctionTypeBuilder()
+      .fromFunctionDef(functionDef)
+      .withDefinitionLocation(locationInFile(functionDef.name(), fileId));
     ClassType owner = null;
     if (currentType() instanceof ClassType classType) {
       owner = classType;

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.sonar.plugins.python.api.LocationInFile;
 
 /**
  * ClassType
@@ -36,14 +38,15 @@ public record ClassType(
   Set<Member> members,
   List<PythonType> attributes,
   List<PythonType> superClasses,
-  List<PythonType> metaClasses) implements PythonType {
+  List<PythonType> metaClasses,
+  @Nullable LocationInFile locationInFile) implements PythonType {
 
   public ClassType(String name) {
-    this(name, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    this(name, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), null);
   }
 
-  public ClassType(String name, List<PythonType> attributes) {
-    this(name, new HashSet<>(), attributes, new ArrayList<>(), new ArrayList<>());
+  public ClassType(String name, @Nullable LocationInFile locationInFile) {
+    this(name, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), locationInFile);
   }
 
   @Override
@@ -157,6 +160,11 @@ public record ClassType(
       return TriBool.TRUE;
     }
     return resolveMember(memberName).isPresent() ? TriBool.TRUE : TriBool.FALSE;
+  }
+
+  @Override
+  public Optional<LocationInFile> definitionLocation() {
+    return Optional.ofNullable(this.locationInFile);
   }
 
   @Override

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/FunctionType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/FunctionType.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.sonar.plugins.python.api.LocationInFile;
 
 /**
  * FunctionType
@@ -36,7 +37,8 @@ public record FunctionType(
   boolean hasDecorators,
   boolean isInstanceMethod,
   boolean hasVariadicParameter,
-  @Nullable PythonType owner
+  @Nullable PythonType owner,
+  @Nullable LocationInFile locationInFile
 ) implements PythonType {
 
   @Override
@@ -57,6 +59,11 @@ public record FunctionType(
   @Override
   public Optional<String> displayName() {
     return Optional.of("Callable");
+  }
+
+  @Override
+  public Optional<LocationInFile> definitionLocation() {
+    return Optional.ofNullable(this.locationInFile);
   }
 
   @Override

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ObjectType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ObjectType.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import org.sonar.plugins.python.api.LocationInFile;
 
 public record ObjectType(PythonType type, List<PythonType> attributes, List<Member> members) implements PythonType {
 
@@ -58,5 +59,10 @@ public record ObjectType(PythonType type, List<PythonType> attributes, List<Memb
       return classType.instancesHaveMember(memberName);
     }
     return TriBool.UNKNOWN;
+  }
+
+  @Override
+  public Optional<LocationInFile> definitionLocation() {
+    return type.definitionLocation();
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/PythonType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/PythonType.java
@@ -20,6 +20,7 @@
 package org.sonar.python.types.v2;
 
 import java.util.Optional;
+import org.sonar.plugins.python.api.LocationInFile;
 
 /**
  * PythonType
@@ -53,5 +54,9 @@ public interface PythonType {
 
   default TriBool hasMember(String memberName) {
     return TriBool.UNKNOWN;
+  }
+
+  default Optional<LocationInFile> definitionLocation() {
+    return Optional.empty();
   }
 }

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
@@ -84,8 +84,7 @@ class PythonVisitorContextTest {
   void globalSymbols() {
     String code = "from mod import a, b";
     FileInput fileInput = new PythonTreeMaker().fileInput(PythonParser.create().parse(code));
-    PythonFile pythonFile = mock(PythonFile.class, "my_module.py");
-    Mockito.when(pythonFile.fileName()).thenReturn("my_module.py");
+    PythonFile pythonFile = pythonFile("my_module.py");
     List<Symbol> modSymbols = Arrays.asList(new SymbolImpl("a", null), new SymbolImpl("b", null));
     Map<String, Set<Symbol>> globalSymbols = Collections.singletonMap("mod", new HashSet<>(modSymbols));
     new PythonVisitorContext(fileInput, pythonFile, null, "my_package", ProjectLevelSymbolTable.from(globalSymbols), null);
@@ -98,8 +97,7 @@ class PythonVisitorContextTest {
     ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     String myPackage = "my_package";
     File workingDirectory = null;
-    PythonFile pythonFile = mock(PythonFile.class, "my_module.py");
-    Mockito.when(pythonFile.fileName()).thenReturn("my_module.py");
+    PythonFile pythonFile = pythonFile("my_module.py");
     FileInput fileInput = mock(FileInputImpl.class);
 
     PythonVisitorContext pythonVisitorContext = new PythonVisitorContext(fileInput, pythonFile, workingDirectory, myPackage, projectLevelSymbolTable, cacheContext, SonarProduct.SONARLINT);

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.AssignmentStatement;
 import org.sonar.plugins.python.api.tree.CallExpression;
@@ -53,6 +55,8 @@ import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
 class TypeInferenceV2Test {
   private static FileInput fileInput;
 
+  static PythonFile pythonFile = PythonTestUtils.pythonFile("");
+
   @BeforeAll
   static void init() {
     var context = TestPythonVisitorRunner.createContext(new File("src/test/resources/semantic/v2/script.py"));
@@ -64,7 +68,7 @@ class TypeInferenceV2Test {
     var pythonFile = PythonTestUtils.pythonFile("script.py");
     var builder = new SymbolTableBuilderV2();
     builder.visitFileInput(fileInput);
-    var typeInferenceV2 = new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty()));
+    var typeInferenceV2 = new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty()), pythonFile);
     fileInput.accept(typeInferenceV2);
 
     System.out.println("hello");
@@ -272,7 +276,7 @@ class TypeInferenceV2Test {
     FileInput root = parseWithoutSymbols(lines);
     var symbolTableBuilderV2 = new SymbolTableBuilderV2();
     root.accept(symbolTableBuilderV2);
-    var typeInferenceV2 = new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.from(globalSymbols)));
+    var typeInferenceV2 = new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.from(globalSymbols)), pythonFile);
     root.accept(typeInferenceV2);
     return root;
   }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -27,7 +27,6 @@ import java.util.Set;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.symbols.Symbol;
 import org.sonar.plugins.python.api.tree.AssignmentStatement;

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -586,7 +586,7 @@ public class ClassTypeTest {
   @Test
   void builder() {
     ClassType classType = classType("class A: ...");
-    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder().setName("A");
+    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder().withName("A");
     assertThat(classTypeBuilder.build()).isEqualTo(classType);
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -22,7 +22,6 @@ package org.sonar.python.types.v2;
 import java.util.List;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.tree.AnnotatedAssignment;

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -32,6 +32,7 @@ import org.sonar.plugins.python.api.tree.Name;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
+import org.sonar.python.semantic.SymbolUtils;
 import org.sonar.python.semantic.v2.ClassTypeBuilder;
 import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
 import org.sonar.python.semantic.v2.SymbolTableBuilderV2;
@@ -42,7 +43,6 @@ import org.sonar.python.semantic.v2.UsageV2;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.python.PythonTestUtils.parse;
 import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
-import static org.sonar.python.semantic.SymbolUtils.pathOf;
 
 public class ClassTypeTest {
 
@@ -66,7 +66,7 @@ public class ClassTypeTest {
     assertThat(classType.displayName()).contains("type");
     assertThat(classType.instanceDisplayName()).contains("C");
 
-    String fileId = pathOf(pythonFile).toString();
+    String fileId = SymbolUtils.pathOf(pythonFile).toString();
     assertThat(classType.definitionLocation()).contains(new LocationInFile(fileId, 1, 6, 1, 7));
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -28,13 +28,13 @@ import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
+import org.sonar.python.semantic.SymbolUtils;
 import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
 import org.sonar.python.semantic.v2.SymbolTableBuilderV2;
 import org.sonar.python.semantic.v2.TypeInferenceV2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
-import static org.sonar.python.semantic.SymbolUtils.pathOf;
 
 class FunctionTypeTest {
 
@@ -47,7 +47,7 @@ class FunctionTypeTest {
     assertThat(functionType.parameters()).isEmpty();
     assertThat(functionType.displayName()).contains("Callable");
     assertThat(functionType.instanceDisplayName()).isEmpty();
-    String fileId = pathOf(pythonFile).toString();
+    String fileId = SymbolUtils.pathOf(pythonFile).toString();
     assertThat(functionType.definitionLocation()).contains(new LocationInFile(fileId, 1, 4, 1, 6));
 
     functionType = functionType("async def fn(p1, p2, p3): pass");

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
@@ -37,9 +37,9 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.plugins.python.api.tree.Tuple;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.tree.TreeUtils;
+import org.sonar.python.semantic.SymbolUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.python.semantic.SymbolUtils.pathOf;
 import static org.sonar.python.types.v2.TypesTestUtils.parseAndInferTypes;
 
 
@@ -60,7 +60,7 @@ class ObjectTypeTest {
     assertThat(objectType.displayName()).contains("A");
     assertThat(objectType.isCompatibleWith(classType)).isTrue();
     assertThat(objectType.hasMember("foo")).isEqualTo(TriBool.FALSE);
-    String fileId = pathOf(pythonFile).toString();
+    String fileId = SymbolUtils.pathOf(pythonFile).toString();
     assertThat(objectType.definitionLocation()).contains(new LocationInFile(fileId, 1, 6, 1, 7));
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
@@ -22,6 +22,8 @@ package org.sonar.python.types.v2;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.sonar.plugins.python.api.LocationInFile;
+import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.tree.ClassDef;
 import org.sonar.plugins.python.api.tree.DictionaryLiteral;
 import org.sonar.plugins.python.api.tree.ExpressionStatement;
@@ -33,17 +35,20 @@ import org.sonar.plugins.python.api.tree.SetLiteral;
 import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.plugins.python.api.tree.Tuple;
+import org.sonar.python.PythonTestUtils;
 import org.sonar.python.tree.TreeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.sonar.python.semantic.SymbolUtils.pathOf;
 import static org.sonar.python.types.v2.TypesTestUtils.parseAndInferTypes;
 
 
-public class ObjectTypeTest {
+class ObjectTypeTest {
 
   @Test
   void simpleObject() {
-    FileInput fileInput = parseAndInferTypes("""
+    PythonFile pythonFile = PythonTestUtils.pythonFile("");
+    FileInput fileInput = parseAndInferTypes(pythonFile, """
       class A: ...
       a = A()
       a
@@ -55,6 +60,8 @@ public class ObjectTypeTest {
     assertThat(objectType.displayName()).contains("A");
     assertThat(objectType.isCompatibleWith(classType)).isTrue();
     assertThat(objectType.hasMember("foo")).isEqualTo(TriBool.FALSE);
+    String fileId = pathOf(pythonFile).toString();
+    assertThat(objectType.definitionLocation()).contains(new LocationInFile(fileId, 1, 6, 1, 7));
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -21,22 +21,20 @@ package org.sonar.python.types.v2;
 
 import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.tree.FileInput;
+import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
 import org.sonar.python.semantic.v2.SymbolTableBuilderV2;
 import org.sonar.python.semantic.v2.TypeInferenceV2;
 
-import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
-import static org.sonar.python.PythonTestUtils.pythonFile;
-
 public class TypesTestUtils {
 
   public static FileInput parseAndInferTypes(String... code) {
-    return parseAndInferTypes(pythonFile(""), code);
+    return parseAndInferTypes(PythonTestUtils.pythonFile(""), code);
   }
 
   public static FileInput parseAndInferTypes(PythonFile pythonFile, String... code) {
-    FileInput fileInput = parseWithoutSymbols(code);
+    FileInput fileInput = PythonTestUtils.parseWithoutSymbols(code);
     fileInput.accept(new SymbolTableBuilderV2());
     fileInput.accept(new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty()), pythonFile));
     return fileInput;

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.types.v2;
 
+import org.sonar.plugins.python.api.PythonFile;
 import org.sonar.plugins.python.api.tree.FileInput;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
@@ -26,14 +27,18 @@ import org.sonar.python.semantic.v2.SymbolTableBuilderV2;
 import org.sonar.python.semantic.v2.TypeInferenceV2;
 
 import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
+import static org.sonar.python.PythonTestUtils.pythonFile;
 
 public class TypesTestUtils {
 
-
   public static FileInput parseAndInferTypes(String... code) {
+    return parseAndInferTypes(pythonFile(""), code);
+  }
+
+  public static FileInput parseAndInferTypes(PythonFile pythonFile, String... code) {
     FileInput fileInput = parseWithoutSymbols(code);
     fileInput.accept(new SymbolTableBuilderV2());
-    fileInput.accept(new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty())));
+    fileInput.accept(new TypeInferenceV2(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty()), pythonFile));
     return fileInput;
   }
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/UnionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/UnionTypeTest.java
@@ -43,6 +43,7 @@ class UnionTypeTest {
 
     assertThat(unionType.displayName()).contains("Union[int, str]");
     assertThat(unionType.instanceDisplayName()).isEmpty();
+    assertThat(unionType.definitionLocation()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
To be honest I'm not entirely convinced of the proposed solution and I think you made good points in our discussion, so my goal here is to make sure we have a first baby step that can be used in the `NonCallableCalledCheck` and can be revisited later.

One thing to note is that both `ObjectType` and `ClassType` will point to the definition of the class. To be consistent with the `displayName` implementation, `ClassType#definitionLocation` should probably refer to the definition of `type`, however, I didn't think that makes sense (no such definition could be found anyway) so they both return the location of the class definition instead.