### PR TITLE
SONARPY-1825 Return Python.UNKNOWN instead of ObjectType[PythonType.U…

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/tree/CallExpressionImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/CallExpressionImpl.java
@@ -189,9 +189,6 @@ public class CallExpressionImpl extends PyTree implements CallExpression, HasTyp
     if (callee().typeV2() instanceof ClassType classType) {
       return new ObjectType(classType);
     }
-    if (callee().typeV2() instanceof FunctionType functionType) {
-      return new ObjectType(functionType.returnType());
-    }
     return PythonType.UNKNOWN;
   }
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -573,7 +573,6 @@ class TypeInferenceV2Test {
   }
 
   @Test
-  @Disabled("ObjectType[PythonType.UNKNOWN] should just be PythonType.UNKNOWN")
   void call_expression() {
     assertThat(lastExpression(
       "f()").typeV2()).isEqualTo(PythonType.UNKNOWN);
@@ -606,14 +605,13 @@ class TypeInferenceV2Test {
   }
 
   @Test
-  @Disabled("Flow insensitive type inference scope issue")
   void variable_outside_function_3() {
     assertThat(lastExpression(
       """
       def foo():
         a = 42
       a
-      """).type()).isEqualTo(PythonType.UNKNOWN);
+      """).typeV2()).isEqualTo(PythonType.UNKNOWN);
   }
 
   @Test


### PR DESCRIPTION
…NKNOWN] for unknown call expressions