### PR TITLE
SONARPY 1950

### DIFF
--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/BanditReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/BanditReportTest.java
@@ -30,7 +30,6 @@ import org.sonarqube.ws.Issues;
 
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 
 class BanditReportTest {
 
@@ -45,9 +44,7 @@ class BanditReportTest {
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT, "py", "no_rule");
     ORCHESTRATOR.executeBuild(
       SonarScanner.create()
-        .setProjectDir(new File("projects/bandit_project"))
-        .setScannerVersion(DEFAULT_SCANNER_VERSION)
-    );
+        .setProjectDir(new File("projects/bandit_project")));
 
     List<Issues.Issue> issues = issues(PROJECT);
     assertThat(issues).hasSize(1);

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CPDTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CPDTest.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.getMeasureAsDouble;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -57,8 +56,7 @@ class CPDTest {
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1.0-SNAPSHOT")
       .setSourceDirs(".")
-      .setSourceEncoding("UTF-8")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setSourceEncoding("UTF-8");
     ORCHESTRATOR.executeBuild(build);
   }
 

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CoverageTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CoverageTest.java
@@ -30,7 +30,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CoverageTest {
@@ -60,7 +59,6 @@ class CoverageTest {
 
   private static void basicCoverageReports(String utReportPath) {
     SonarScanner build = SonarScanner.create()
-      .setScannerVersion(DEFAULT_SCANNER_VERSION)
       .setProjectDir(new File(COVERAGE_PROJECT))
       .setProperty(DEPRECATED_COVERAGE_REPORT_PATH, "someReport")
       .setProperty(COVERAGE_REPORT_PATHS, utReportPath+",it-coverage1.xml,it-coverage2.xml");
@@ -81,7 +79,6 @@ class CoverageTest {
   @Test
   void default_values() {
     SonarScanner build = SonarScanner.create()
-      .setScannerVersion(DEFAULT_SCANNER_VERSION)
       .setProjectDir(new File(COVERAGE_PROJECT));
     ORCHESTRATOR.executeBuild(build);
 
@@ -97,7 +94,6 @@ class CoverageTest {
   @Test
   void empty_property() {
     SonarScanner build = SonarScanner.create()
-      .setScannerVersion(DEFAULT_SCANNER_VERSION)
       .setProjectDir(new File(COVERAGE_PROJECT))
       .setProperty(DEPRECATED_COVERAGE_REPORT_PATH, "")
       .setProperty(COVERAGE_REPORT_PATHS, "");
@@ -114,7 +110,6 @@ class CoverageTest {
   @Test
   void empty_coverage_report() {
     SonarScanner build = SonarScanner.create()
-      .setScannerVersion(DEFAULT_SCANNER_VERSION)
       .setProjectDir(new File(COVERAGE_PROJECT))
       .setProperty(DEPRECATED_COVERAGE_REPORT_PATH, EMPTY_XML)
       .setProperty(COVERAGE_REPORT_PATHS, EMPTY_XML);

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CustomRulesTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/CustomRulesTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,8 +50,7 @@ class CustomRulesTest {
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_NAME)
       .setProjectVersion("1.0")
-      .setSourceDirs("src")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setSourceDirs("src");
     orchestrator.executeBuild(build);
   }
 

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/Flake8ReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/Flake8ReportTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,7 +44,6 @@ class Flake8ReportTest {
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT, "py", "no_rule");
     ORCHESTRATOR.executeBuild(
       SonarScanner.create()
-        .setScannerVersion(DEFAULT_SCANNER_VERSION)
         .setProjectDir(new File("projects/flake8_project")));
 
     List<Issues.Issue> issues = issues(PROJECT);

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Measures.Measure;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.getMeasure;
 import static com.sonar.python.it.plugin.TestsUtils.getMeasureAsDouble;
 import static com.sonar.python.it.plugin.TestsUtils.getMeasureAsInt;
@@ -80,8 +79,7 @@ class MetricsTest {
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1.0-SNAPSHOT")
       .setTestDirs("test")
-      .setSourceDirs("src")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setSourceDirs("src");
     buildResult = orchestrator.executeBuild(build);
   }
 

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MypyReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MypyReportTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,9 +44,7 @@ class MypyReportTest {
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT, "py", "no_rule");
     ORCHESTRATOR.executeBuild(
       SonarScanner.create()
-        .setProjectDir(new File("projects/mypy_project"))
-        .setScannerVersion(DEFAULT_SCANNER_VERSION)
-    );
+        .setProjectDir(new File("projects/mypy_project")));
 
     List<Issues.Issue> issues = issues(PROJECT);
     assertThat(issues).hasSize(5);

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/NoSonarTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/NoSonarTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -49,8 +48,7 @@ class NoSonarTest {
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1.0-SNAPSHOT")
-      .setSourceDirs(".")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setSourceDirs(".");
     ORCHESTRATOR.executeBuild(build);
   }
 

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/PylintReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/PylintReportTest.java
@@ -26,7 +26,6 @@ import java.io.File;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -91,8 +90,7 @@ class PylintReportTest {
         .setProjectKey(projectKey)
         .setProjectName(projectKey)
         .setProjectDir(new File("projects/pylint_project"))
-        .setProperty(property, reportPaths)
-        .setScannerVersion(DEFAULT_SCANNER_VERSION));
+        .setProperty(property, reportPaths));
   }
 
 }

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/RuffReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/RuffReportTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Common;
 import org.sonarqube.ws.Issues;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.issues;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,9 +44,8 @@ class RuffReportTest {
     ORCHESTRATOR.getServer().provisionProject(PROJECT, PROJECT);
     ORCHESTRATOR.getServer().associateProjectToQualityProfile(PROJECT, "py", "no_rule");
     ORCHESTRATOR.executeBuild(
-      SonarScanner.create()
-        .setScannerVersion(DEFAULT_SCANNER_VERSION)
-        .setProjectDir(new File("projects/ruff_project")));
+        SonarScanner.create()
+            .setProjectDir(new File("projects/ruff_project")));
 
     List<Issues.Issue> issues = issues(PROJECT).stream().sorted(Comparator.comparing(Issues.Issue::getRule))
         .toList();

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestReportTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestReportTest.java
@@ -32,7 +32,6 @@ import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.assertProjectMeasures;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,8 +52,7 @@ class TestReportTest {
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectDir(new File("projects/nosetests_project"))
-      .setProperty("sonar.python.xunit.reportPath", testReportPath)
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setProperty("sonar.python.xunit.reportPath", testReportPath);
   }
 
   @Test

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestRulesTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestRulesTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.sonarqube.ws.Issues;
 import org.sonarqube.ws.client.issues.SearchRequest;
 
-import static com.sonar.python.it.plugin.TestsUtils.DEFAULT_SCANNER_VERSION;
 import static com.sonar.python.it.plugin.TestsUtils.newWsClient;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,8 +50,7 @@ class TestRulesTest {
       .setProjectDir(new File("projects/test_code"))
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_NAME)
-      .setProjectVersion("1.0")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setProjectVersion("1.0");
   }
 
   @Test

--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestsUtils.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/TestsUtils.java
@@ -47,8 +47,6 @@ public final class TestsUtils {
   private static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
   private static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
 
-  static final String DEFAULT_SCANNER_VERSION = "6.0.0.4432";
-
   public static final FileLocation PLUGIN_LOCATION = FileLocation.byWildcardMavenFilename(new File("../../../sonar-python-plugin/target"), "sonar-python-plugin-*.jar");
 
   public static final OrchestratorExtension ORCHESTRATOR = OrchestratorExtension.builderEnv()

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.python.it.RulingHelper.DEFAULT_SCANNER_VERSION;
 import static org.sonar.python.it.RulingHelper.bugRuleKeys;
 import static org.sonar.python.it.RulingHelper.getOrchestrator;
 
@@ -182,8 +181,7 @@ class PythonExtendedRulingTest {
       .setProperty("sonar.lits.dump.new", FileLocation.of(String.format("target/actual_extended/%s", projectKey)).getFile().getAbsolutePath())
       .setProperty("sonar.cpd.exclusions", "**/*")
       .setProperty("sonar.internal.analysis.failFast", "true")
-      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
   }
 
   void executeBuild(SonarScanner build) throws IOException {

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonExtendedRulingTest.java
@@ -174,7 +174,6 @@ class PythonExtendedRulingTest {
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1")
-      .setLanguage("py")
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
       .setProperty("sonar.lits.dump.old", FileLocation.of(String.format("src/test/resources/expected_extended/%s", projectKey)).getFile().getAbsolutePath())

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -218,7 +218,6 @@ class PythonPrAnalysisTest {
       .setProjectKey(projectKey)
       .setProjectName(projectKey)
       .setProjectVersion("1")
-      .setLanguage("py")
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
       .setProperty("sonar.lits.dump.old", FileLocation.of("src/test/resources/expected_pr_analysis/" + scenario).getFile().getAbsolutePath())

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -42,7 +42,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.python.it.RulingHelper.DEFAULT_SCANNER_VERSION;
 import static org.sonar.python.it.RulingHelper.getMeasure;
 import static org.sonar.python.it.RulingHelper.getOrchestrator;
 
@@ -226,8 +225,7 @@ class PythonPrAnalysisTest {
       .setProperty("sonar.lits.dump.new", FileLocation.of("target/actual").getFile().getAbsolutePath())
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.internal.analysis.failFast", "true")
-      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
   }
 
 

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
@@ -68,7 +68,6 @@ class PythonRulingTest {
       .setProjectKey(PROJECT_KEY)
       .setProjectName(PROJECT_KEY)
       .setProjectVersion("1")
-      .setLanguage("py")
       .setSourceEncoding("UTF-8")
       .setSourceDirs(".")
       .setProperty("sonar.lits.dump.old", FileLocation.of("src/test/resources/expected").getFile().getAbsolutePath())

--- a/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonRulingTest.java
@@ -40,7 +40,6 @@ import org.sonarsource.analyzer.commons.ProfileGenerator;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Collections.singletonList;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.sonar.python.it.RulingHelper.DEFAULT_SCANNER_VERSION;
 import static org.sonar.python.it.RulingHelper.getOrchestrator;
 
 class PythonRulingTest {
@@ -77,8 +76,7 @@ class PythonRulingTest {
       .setProperty("sonar.cpd.exclusions", "**/*")
       .setProperty("sonar.lits.differences", litsDifferencesFile.getAbsolutePath())
       .setProperty("sonar.internal.analysis.failFast", "true")
-      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m")
-      .setScannerVersion(DEFAULT_SCANNER_VERSION);
+      .setEnvironmentVariable("SONAR_RUNNER_OPTS", "-Xmx2000m");
     ORCHESTRATOR.executeBuild(build);
 
     String issueDifferences = issues(PROJECT_KEY).stream()

--- a/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
@@ -41,8 +41,6 @@ class RulingHelper {
 
   private static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
   private static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
-  public static final String DEFAULT_SCANNER_VERSION = "6.0.0.4432";
-
 
   static OrchestratorExtension getOrchestrator(Edition sonarEdition) {
     var builder = OrchestratorExtension.builderEnv()

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
     <maven.project.version>2.2.1</maven.project.version>
     <mockito.version>4.11.0</mockito.version>
     <sonar.version>9.9.1.69595</sonar.version>
-    <sonar.orchestrator.version>4.0.0.404</sonar.orchestrator.version>
+    <sonar.orchestrator.version>5.0.0.2065</sonar.orchestrator.version>
     <sonar.api.version>10.1.0.809</sonar.api.version>
     <sonar-analyzer-commons.version>2.7.0.1482</sonar-analyzer-commons.version>
     <sonarlint-core.version>8.18.0.70939</sonarlint-core.version>


### PR DESCRIPTION
- **Revert "SONARPY-1946 Update scanner version in QA tests (#1836)"**
- **SONARPY-1950 Revert scanner update for ITs and update Orchestrator instead**
