### PR TITLE
SONARPY-1974: fix false positive for unused variable (assignment expression in generator expression)

### DIFF
--- a/python-checks/src/test/java/org/sonar/python/checks/UnusedLocalVariableCheckTest.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/UnusedLocalVariableCheckTest.java
@@ -176,6 +176,20 @@ class UnusedLocalVariableCheckTest {
   }
 
   @Test
+  void assignmentExpressionQuickFixTest() {
+    var check = new UnusedLocalVariableCheck();
+    var before = "def foo():\n" +
+      "  if any((i := j) % 2 == 1 for j in range(3)):\n" +
+      "    return";
+    var after = "def foo():\n" +
+            "  if any(j % 2 == 1 for j in range(3)):\n" +
+            "    return";
+
+    PythonQuickFixVerifier.verify(check, before, after);
+    PythonQuickFixVerifier.verifyQuickFixMessages(check, before, "Remove assignment target");
+  }
+
+  @Test
   void multipleAssignmentQuickFixTest() {
     var check = new UnusedLocalVariableCheck();
 

--- a/python-checks/src/test/resources/checks/unusedLocalVariable.py
+++ b/python-checks/src/test/resources/checks/unusedLocalVariable.py
@@ -166,3 +166,9 @@ def correct_scope_for_assignment_target_in_generator_expression():
     lines = ['#comment', 'normal']
     if any((comment := line).startswith('#') for line in lines):
         return comment
+
+def unused_assignment_target_in_generator_expression():
+    lines = ['#comment', 'normal']
+    if any((comment := line).startswith('#') for line in lines): # Noncompliant {{Remove the unused local variable "comment".}}
+#           ^^^^^^^
+        return

--- a/python-checks/src/test/resources/checks/unusedLocalVariable.py
+++ b/python-checks/src/test/resources/checks/unusedLocalVariable.py
@@ -161,3 +161,8 @@ def global_variable_modified():
 def annotated_assignment_null_value():
     value: str # Noncompliant
     value = "hello"
+
+def correct_scope_for_assignment_target_in_generator_expression():
+    lines = ['#comment', 'normal']
+    if any((comment := line).startswith('#') for line in lines):
+        return comment

--- a/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
@@ -47,8 +47,8 @@ import org.sonar.python.types.TypeShed;
 class Scope {
 
   final Tree rootTree;
-  private PythonFile pythonFile;
-  private String fullyQualifiedModuleName;
+  private final PythonFile pythonFile;
+  private final String fullyQualifiedModuleName;
   private final ProjectLevelSymbolTable projectLevelSymbolTable;
   private final Scope parent;
   final Map<String, Symbol> symbolsByName = new HashMap<>();

--- a/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/Scope.java
@@ -150,6 +150,10 @@ class Scope {
     }
   }
 
+  Scope parent() {
+    return parent;
+  }
+
   private ClassSymbolImpl copyClassSymbol(String symbolName, ClassSymbolImpl originalClassSymbol, Set<Symbol> alreadyVisitedSymbols) {
     // Must use symbolName to preserve import aliases
     ClassSymbolImpl classSymbol = (ClassSymbolImpl) ClassSymbolImpl.copyFrom(symbolName, originalClassSymbol);

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
@@ -95,12 +95,12 @@ import static org.sonar.python.semantic.SymbolUtils.resolveTypeHierarchy;
 
 // SymbolTable based on https://docs.python.org/3/reference/executionmodel.html#naming-and-binding
 public class SymbolTableBuilder extends BaseTreeVisitor {
-  private String fullyQualifiedModuleName;
-  private List<String> filePath;
+  private final String fullyQualifiedModuleName;
+  private final List<String> filePath;
   private final ProjectLevelSymbolTable projectLevelSymbolTable;
   private Map<Tree, Scope> scopesByRootTree;
   private FileInput fileInput = null;
-  private Set<Tree> assignmentLeftHandSides = new HashSet<>();
+  private final Set<Tree> assignmentLeftHandSides = new HashSet<>();
   private final PythonFile pythonFile;
   private final Set<String> importedModulesFQN = new HashSet<>();
 
@@ -250,7 +250,7 @@ public class SymbolTableBuilder extends BaseTreeVisitor {
 
   private class ScopeVisitor extends BaseTreeVisitor {
 
-    private Deque<Tree> scopeRootTrees = new LinkedList<>();
+    private final Deque<Tree> scopeRootTrees = new LinkedList<>();
     protected Scope moduleScope;
 
     Tree currentScopeRootTree() {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
@@ -551,7 +551,12 @@ public class SymbolTableBuilder extends BaseTreeVisitor {
 
     @Override
     public void visitAssignmentExpression(AssignmentExpression assignmentExpression) {
-      addBindingUsage(assignmentExpression.lhsName(), Usage.Kind.ASSIGNMENT_LHS);
+      final Scope scope = currentScope();
+      if (scope.rootTree.is(Kind.GENERATOR_EXPR)) {
+        scope.parent().addBindingUsage(assignmentExpression.lhsName(), Usage.Kind.ASSIGNMENT_LHS, null);
+      } else {
+        addBindingUsage(assignmentExpression.lhsName(), Usage.Kind.ASSIGNMENT_LHS);
+      }
       super.visitAssignmentExpression(assignmentExpression);
     }
 


### PR DESCRIPTION
- Add test case for scope of assignment expression target.
- Hoist target of assignment expression in generator expression to surrounding scope — See [PEP 572](https://peps.python.org/pep-0572/#scope-of-the-target).
- Add final modifiers to fields where appropriate
- Add test case for quick fix in assignment expression
- Add quick fix to remove assignment target from assignment expression
- Add true positive test case for unused target in assignment expression

(I wasn't able to verify these commits against the SonarQube Next instance without an access token.)