### PR TITLE
SONARPY-1985 Infer a function return type based on its type hint for locally defined functions

### DIFF
--- a/python-checks/src/test/resources/checks/confusingTypeChecking/nonCallableCalled.py
+++ b/python-checks/src/test/resources/checks/confusingTypeChecking/nonCallableCalled.py
@@ -49,3 +49,9 @@ def decorators(decorator: Callable, non_callable: str):
     def bar():
         ...
 
+def local_function() -> int:
+    ...
+
+def calling_local_function():
+    x = local_function()
+    x() # Noncompliant

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -35,6 +35,7 @@ import org.sonar.python.tree.TreeUtils;
 import org.sonar.python.types.v2.FunctionType;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 
 import static org.sonar.python.tree.TreeUtils.locationInFile;
 
@@ -49,6 +50,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
   private boolean isInstanceMethod;
   private PythonType owner;
   private PythonType returnType = PythonType.UNKNOWN;
+  private TypeOrigin typeOrigin = TypeOrigin.STUB;
   private LocationInFile definitionLocation;
 
   private static final String CLASS_METHOD_DECORATOR = "classmethod";
@@ -110,6 +112,11 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     return this;
   }
 
+  public FunctionTypeBuilder withTypeOrigin(TypeOrigin typeOrigin) {
+    this.typeOrigin = typeOrigin;
+    return this;
+  }
+
   @Override
   public FunctionTypeBuilder withDefinitionLocation(@Nullable LocationInFile definitionLocation) {
     this.definitionLocation = definitionLocation;
@@ -118,7 +125,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
 
   public FunctionType build() {
     return new FunctionType(
-      name, attributes, parameters, returnType, isAsynchronous, hasDecorators, isInstanceMethod, hasVariadicParameter, owner, definitionLocation
+      name, attributes, parameters, returnType, typeOrigin, isAsynchronous, hasDecorators, isInstanceMethod, hasVariadicParameter, owner, definitionLocation
     );
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
@@ -47,6 +47,7 @@ import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.ModuleType;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 import org.sonar.python.types.v2.UnionType;
 
 public class SymbolsModuleTypeProvider {
@@ -122,12 +123,14 @@ public class SymbolsModuleTypeProvider {
     InferredType inferredType = ((FunctionSymbolImpl) symbol).declaredReturnType();
     ClassSymbol classSymbol = inferredType.runtimeTypeSymbol();
     var returnType = resolveReturnType(createdTypesBySymbol, classSymbol);
+    TypeOrigin typeOrigin = symbol.isStub() ? TypeOrigin.STUB : TypeOrigin.LOCAL;
 
     FunctionTypeBuilder functionTypeBuilder =
       new FunctionTypeBuilder(symbol.name())
         .withAttributes(List.of())
         .withParameters(parameters)
         .withReturnType(returnType)
+        .withTypeOrigin(typeOrigin)
         .withAsynchronous(symbol.isAsynchronous())
         .withHasDecorators(symbol.hasDecorators())
         .withInstanceMethod(symbol.isInstanceMethod())

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -79,6 +79,7 @@ import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.ModuleType;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 import org.sonar.python.types.v2.TypeSource;
 import org.sonar.python.types.v2.UnionType;
 
@@ -257,13 +258,13 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
     scan(functionDef.decorators());
     scan(functionDef.typeParams());
     scan(functionDef.parameters());
+    scan(functionDef.returnTypeAnnotation());
     FunctionType functionType = buildFunctionType(functionDef);
     ((NameImpl) functionDef.name()).typeV2(functionType);
     inTypeScope(functionType, () -> {
       // TODO: check scope accuracy
       scan(functionDef.typeParams());
       scan(functionDef.parameters());
-      scan(functionDef.returnTypeAnnotation());
       scan(functionDef.body());
     });
   }
@@ -278,6 +279,12 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
     }
     if (owner != null) {
       functionTypeBuilder.withOwner(owner);
+    }
+    TypeAnnotation typeAnnotation = functionDef.returnTypeAnnotation();
+    if (typeAnnotation != null) {
+      PythonType returnType = typeAnnotation.expression().typeV2();
+      functionTypeBuilder.withReturnType(returnType);
+      functionTypeBuilder.withTypeOrigin(TypeOrigin.LOCAL);
     }
     FunctionType functionType = functionTypeBuilder.build();
     if (owner != null) {

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/FunctionType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/FunctionType.java
@@ -35,6 +35,7 @@ public final class FunctionType implements PythonType {
   private final List<PythonType> attributes;
   private final List<ParameterV2> parameters;
   private PythonType returnType;
+  private final TypeOrigin typeOrigin;
   private final boolean isAsynchronous;
   private final boolean hasDecorators;
   private final boolean isInstanceMethod;
@@ -50,6 +51,7 @@ public final class FunctionType implements PythonType {
     List<PythonType> attributes,
     List<ParameterV2> parameters,
     PythonType returnType,
+    TypeOrigin typeOrigin,
     boolean isAsynchronous,
     boolean hasDecorators,
     boolean isInstanceMethod,
@@ -61,6 +63,7 @@ public final class FunctionType implements PythonType {
     this.attributes = attributes;
     this.parameters = parameters;
     this.returnType = returnType;
+    this.typeOrigin = typeOrigin;
     this.isAsynchronous = isAsynchronous;
     this.hasDecorators = hasDecorators;
     this.isInstanceMethod = isInstanceMethod;
@@ -127,5 +130,9 @@ public final class FunctionType implements PythonType {
       throw new IllegalStateException("Trying to resolve an already resolved lazy type.");
     }
     this.returnType = pythonType;
+  }
+
+  public TypeOrigin typeOrigin() {
+    return typeOrigin;
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeOrigin.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeOrigin.java
@@ -1,0 +1,25 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public enum TypeOrigin {
+  LOCAL,
+  STUB
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -33,6 +33,7 @@ import org.sonar.python.semantic.v2.TypeInferenceV2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.python.PythonTestUtils.parseWithoutSymbols;
+import static org.sonar.python.types.v2.TypesTestUtils.INT_TYPE;
 import static org.sonar.python.types.v2.TypesTestUtils.PROJECT_LEVEL_TYPE_TABLE;
 
 class FunctionTypeTest {
@@ -146,6 +147,14 @@ class FunctionTypeTest {
     FunctionType functionType = functionType("def fn(p1: int): pass");
     assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
     assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).containsExactly(PythonType.UNKNOWN);
+  }
+
+  @Test
+  void declared_return_type() {
+    FunctionType functionType = functionType("def fn() -> int: ...");
+    assertThat(functionType.returnType()).isEqualTo(INT_TYPE);
+    functionType = functionType("def fn() -> unknown: ...");
+    assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
   }
 
   @Test


### PR DESCRIPTION
It would probably make sense to review this only after SONARPY-2024 is merged, and this PR is rebased.

I have my doubts on the introduction of `TypeOrigin` and would be happy to discuss it. I feel it actually should be included in `TypeSource`, but I felt this would complexify the propagation of type sources, so this solution felt like a simpler step, that we can revisit later.