### PR TITLE
SONARPY-2051 Single quotes should not count as escaped characters in TokenEnricher or IPynbNotebookParser

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/tree/TokenEnricher.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TokenEnricher.java
@@ -28,7 +28,7 @@ import org.sonar.python.IPythonLocation;
 
 public class TokenEnricher {
 
-  private static final Set<Character> ESCAPED_CHARS = Set.of('"', '\'', '\\', '\b', '\f', '\n', '\r', '\t');
+  private static final Set<Character> ESCAPED_CHARS = Set.of('"', '\\', '\b', '\f', '\n', '\r', '\t');
 
   private TokenEnricher() {
   }

--- a/python-frontend/src/test/java/org/sonar/python/tree/TokenEnricherTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/tree/TokenEnricherTest.java
@@ -157,4 +157,18 @@ class TokenEnricherTest {
     assertThat(trivias.get(0).token().column()).isEqualTo(300);
     assertThat(trivias.get(0).token().includedEscapeChars()).isZero();
   }
+
+  @Test
+  void shouldComputeCorrectlyForSingleQuote() {
+    var code = "a = '1'";
+    var expectedTokens = lexer.lex(code);
+    var escapedChars = new LinkedHashMap<Integer, Integer>();
+    escapedChars.put(4, 305);
+    escapedChars.put(6, 308);
+    var tokens = TokenEnricher.enrichTokens(expectedTokens, Map.of(1, new IPythonLocation(100, 300, escapedChars)));
+    var stringToken = tokens.get(2);
+    assertThat(stringToken.line()).isEqualTo(100);
+    assertThat(stringToken.column()).isEqualTo(304);
+    assertThat(stringToken.includedEscapeChars()).isZero();
+  }
 }

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IpynbNotebookParser.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/IpynbNotebookParser.java
@@ -205,7 +205,7 @@ public class IpynbNotebookParser {
     for (int i = 1; i < sourceLine.length(); ++i) {
       char c = arr[i];
       switch (c) {
-        case '"', '\'', '\\':
+        case '"', '\\':
           numberOfExtraChars++;
           colMap.put(i, i + colOffSet + count + numberOfExtraChars);
           break;


### PR DESCRIPTION
- **SONARPY-2040 Add the sonar.ipynb.file.suffixes property**
- **SONARPY-2051 Single quotes should not count as escaped characters in TokenEnricher**
