### PR TITLE
SONARPY-2114 Migrate S5707 ExceptionCauseTypeCheck to the V2 type model

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.types.v2.ClassType;
+import org.sonar.python.types.v2.LazyTypeWrapper;
+import org.sonar.python.types.v2.TypeWrapper;
 import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.PythonType;
 
@@ -36,7 +38,7 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
   String name;
   Set<Member> members = new HashSet<>();
   List<PythonType> attributes = new ArrayList<>();
-  List<PythonType> superClasses = new ArrayList<>();
+  List<TypeWrapper> superClasses = new ArrayList<>();
   List<PythonType> metaClasses = new ArrayList<>();
   boolean hasDecorators = false;
   LocationInFile definitionLocation;
@@ -62,12 +64,17 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
     return this;
   }
 
-  public List<PythonType> superClasses() {
+  public List<TypeWrapper> superClasses() {
     return superClasses;
   }
 
+  public ClassTypeBuilder addSuperClass(PythonType type) {
+    superClasses.add(new LazyTypeWrapper(type));
+    return this;
+  }
+
   public ClassTypeBuilder withSuperClasses(PythonType... types) {
-    superClasses.addAll(Arrays.asList(types));
+    Arrays.stream(types).forEach(this::addSuperClass);
     return this;
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -227,7 +227,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
         if (argument instanceof RegularArgument regularArgument) {
           addParentClass(classTypeBuilder, regularArgument);
         } else {
-          classTypeBuilder.superClasses().add(PythonType.UNKNOWN);
+          classTypeBuilder.addSuperClass(PythonType.UNKNOWN);
         }
       });
   }
@@ -243,7 +243,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
       return;
     }
     PythonType argumentType = getTypeV2FromArgument(regularArgument);
-    classTypeBuilder.superClasses().add(argumentType);
+    classTypeBuilder.addSuperClass(argumentType);
     // TODO: SONARPY-1869 handle generics
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyTypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyTypeWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public class LazyTypeWrapper implements TypeWrapper {
+  private PythonType type;
+
+  public LazyTypeWrapper(PythonType type) {
+    this.type = type;
+    if (type instanceof LazyType lazyType) {
+      lazyType.addConsumer(this::resolveLazyType);
+    }
+  }
+
+  public PythonType type() {
+    return TypeUtils.resolved(this.type);
+  }
+
+  public void resolveLazyType(PythonType pythonType) {
+    if (!(type instanceof LazyType)) {
+      throw new IllegalStateException("Trying to resolve an already resolved lazy type.");
+    }
+    this.type = pythonType;
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
@@ -220,7 +220,7 @@ public class TypeCheckBuilder {
           result.add(PythonType.UNKNOWN);
           queue.clear();
         } else if (currentType instanceof ClassType classType) {
-          queue.addAll(classType.superClasses());
+          queue.addAll(classType.superClasses().stream().map(TypeWrapper::type).toList());
         }
       }
       return result;

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
@@ -1,0 +1,25 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public interface TypeWrapper {
+
+  PythonType type();
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -93,7 +93,7 @@ public class ClassTypeTest {
     ClassType classC = classTypes.get(0);
     ClassType classB = classTypes.get(1);
     assertThat(classB.superClasses()).hasSize(1);
-    assertThat(classB.superClasses()).containsExactlyInAnyOrder(classC);
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).containsExactlyInAnyOrder(classC);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class ClassTypeTest {
     ClassType classA = classTypes.get(1);
     ClassType classB = classTypes.get(2);
     assertThat(classB.superClasses()).hasSize(2);
-    assertThat(classB.superClasses()).containsExactlyInAnyOrder(classC, classA);
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).containsExactlyInAnyOrder(classC, classA);
   }
 
   @Test
@@ -118,7 +118,7 @@ public class ClassTypeTest {
       "class B(C): ..."
     );
     ClassType classC = classTypes.get(0);
-    assertThat(classC.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classC.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classC.hasUnresolvedHierarchy()).isTrue();
     assertThat(classC.hasMember("unknown")).isEqualTo(TriBool.UNKNOWN);
     assertThat(classC.instancesHaveMember("unknown")).isEqualTo(TriBool.UNKNOWN);
@@ -143,7 +143,7 @@ public class ClassTypeTest {
     ClassType classB = classTypes.get(1);
     assertThat(classB.superClasses()).hasSize(2);
     assertThat(classB.hasUnresolvedHierarchy()).isFalse();
-    var baseExceptionType = classB.superClasses().get(1);
+    var baseExceptionType = classB.superClasses().get(1).type();
     assertThat(baseExceptionType)
       .isInstanceOf(ClassType.class)
       .extracting(PythonType::name)
@@ -217,7 +217,7 @@ public class ClassTypeTest {
       "class C(foo()): ",
       "  pass");
     ClassType classType = classTypes.get(0);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -231,7 +231,7 @@ public class ClassTypeTest {
       "  pass");
     ClassType classType = classTypes.get(0);
     assertThat(classType.superClasses()).hasSize(1);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -242,7 +242,7 @@ public class ClassTypeTest {
       "class C(*foo): ",
       "  pass");
     ClassType classType = classTypes.get(0);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -347,7 +347,7 @@ public class ClassTypeTest {
     ClassType classB = classTypes.get(1);
     assertThat(classB.hasUnresolvedHierarchy()).isFalse();
     assertThat(classB.superClasses()).hasSize(1);
-    assertThat(classB.superClasses()).extracting(PythonType::name).containsExactly("A");
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).extracting(PythonType::name).containsExactly("A");
     assertThat(classB.hasMetaClass()).isFalse();
     assertThat(classB.instancesHaveMember("foo")).isEqualTo(TriBool.UNKNOWN);
   }
@@ -422,7 +422,7 @@ public class ClassTypeTest {
       "  def foo(): pass").get(1);
 
     assertThat(classB.members()).hasSize(1);
-    ClassType classA = (ClassType) classB.superClasses().get(0);
+    ClassType classA = (ClassType) classB.superClasses().get(0).type();
     assertThat(classA.members()).hasSize(1);
 
     assertThat(classB.resolveMember("foo")).isPresent();

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonar.python.semantic.v2.LazyTypesContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.sonar.python.types.v2.TypesTestUtils.INT_TYPE;
+import static org.sonar.python.types.v2.TypesTestUtils.STR_TYPE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class LazyTypeWrapperTest {
+
+
+  @Test
+  void lazyTypeIsResolvedWhenAccessed() {
+    LazyTypesContext lazyTypesContext = Mockito.mock(LazyTypesContext.class);
+    when(lazyTypesContext.resolveLazyType(Mockito.any())).thenReturn(INT_TYPE);
+    LazyType lazyType = new LazyType("random", lazyTypesContext);
+    LazyTypeWrapper lazyTypeWrapper = new LazyTypeWrapper(lazyType);
+    assertThat(lazyTypeWrapper.type()).isEqualTo(INT_TYPE);
+  }
+
+  @Test
+  void resolvingNonLazyTypeThrowsException() {
+    LazyTypeWrapper lazyTypeWrapper = new LazyTypeWrapper(INT_TYPE);
+    assertThatThrownBy(() -> lazyTypeWrapper.resolveLazyType(STR_TYPE))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Trying to resolve an already resolved lazy type.");
+  }
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -43,6 +43,7 @@ public class TypesTestUtils {
   public static final PythonType DICT_TYPE = BUILTINS.resolveMember("dict").get();
   public static final PythonType NONE_TYPE = BUILTINS.resolveMember("NoneType").get();
   public static final PythonType TYPE_TYPE = BUILTINS.resolveMember("type").get();
+  public static final PythonType EXCEPTION_TYPE = BUILTINS.resolveMember("Exception").get();
 
   public static FileInput parseAndInferTypes(String... code) {
     return parseAndInferTypes(PythonTestUtils.pythonFile(""), code);


### PR DESCRIPTION
Notes:
- If this approach of using a `TypeWrapper` is accepted, I think it would make sense to refactor the implementation of `FunctionType#returnType` to use it as well, instead of special casing it. I didn't make this refactor here, to keep this PR simple. However, I think we could then create another ticket/PR to harmonize our implementations.
- I am not fully certain of the terminology around `TypeWrapper`, given we already have `ObjectType#unwrappedType` that serves a different purpose. I wouldn't want this to be confusing, and I am open to suggestions in case another name makes more sense.
- I also have doubts about whether `TypeWrapper` should be exposed in the various APIs (as it currently is) or if it should be made transparent by converting them on the fly to `PythonType.`. I chose the first approach for simplicity and also to avoid converting collections such as  `List<TypeWrapper>` to `List<PythonType>` on each call, but I'm open to revisit it.