### PR TITLE
SONARPY 2123b

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/FunctionSymbolImpl.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/FunctionSymbolImpl.java
@@ -429,6 +429,10 @@ public class FunctionSymbolImpl extends SymbolImpl implements FunctionSymbol {
       this.declaredType = type;
     }
 
+    public SymbolsProtos.Type getProtobufType() {
+      return protobufType;
+    }
+
     @CheckForNull
     public String annotatedTypeName() {
       return annotatedTypeName;

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -27,6 +27,8 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.types.v2.ClassType;
+import org.sonar.python.types.v2.LazyTypeWrapper;
+import org.sonar.python.types.v2.TypeWrapper;
 import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.PythonType;
 
@@ -36,7 +38,7 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
   String name;
   Set<Member> members = new HashSet<>();
   List<PythonType> attributes = new ArrayList<>();
-  List<PythonType> superClasses = new ArrayList<>();
+  List<TypeWrapper> superClasses = new ArrayList<>();
   List<PythonType> metaClasses = new ArrayList<>();
   boolean hasDecorators = false;
   LocationInFile definitionLocation;
@@ -62,12 +64,17 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
     return this;
   }
 
-  public List<PythonType> superClasses() {
+  public List<TypeWrapper> superClasses() {
     return superClasses;
   }
 
+  public ClassTypeBuilder addSuperClass(PythonType type) {
+    superClasses.add(new LazyTypeWrapper(type));
+    return this;
+  }
+
   public ClassTypeBuilder withSuperClasses(PythonType... types) {
-    superClasses.addAll(Arrays.asList(types));
+    Arrays.stream(types).forEach(this::addSuperClass);
     return this;
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -34,8 +34,10 @@ import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.tree.TreeUtils;
 import org.sonar.python.types.v2.FunctionType;
+import org.sonar.python.types.v2.LazyTypeWrapper;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.SimpleTypeWrapper;
 import org.sonar.python.types.v2.TypeOrigin;
 
 import static org.sonar.python.tree.TreeUtils.locationInFile;
@@ -155,7 +157,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
       if (anyParameter.is(Tree.Kind.PARAMETER)) {
         addParameter((Parameter) anyParameter, fileId, parameterState, projectLevelTypeTable);
       } else {
-        parameters.add(new ParameterV2(null, PythonType.UNKNOWN, false,
+        parameters.add(new ParameterV2(null, new SimpleTypeWrapper(PythonType.UNKNOWN), false,
           parameterState.keywordOnly, parameterState.positionalOnly, false, false, locationInFile(anyParameter, fileId)));
       }
     }
@@ -166,7 +168,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     Token starToken = parameter.starToken();
     if (parameterName != null) {
       ParameterType parameterType = getParameterType(parameter, projectLevelTypeTable);
-      this.parameters.add(new ParameterV2(parameterName.name(), parameterType.pythonType(), parameter.defaultValue() != null,
+      this.parameters.add(new ParameterV2(parameterName.name(), new LazyTypeWrapper(parameterType.pythonType()), parameter.defaultValue() != null,
         parameterState.keywordOnly, parameterState.positionalOnly, parameterType.isKeywordVariadic(), parameterType.isPositionalVariadic(), locationInFile(parameter, fileId)));
       if (starToken != null) {
         hasVariadicParameter = true;

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -56,7 +56,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
   private static final String CLASS_METHOD_DECORATOR = "classmethod";
   private static final String STATIC_METHOD_DECORATOR = "staticmethod";
 
-  public FunctionTypeBuilder fromFunctionDef(FunctionDef functionDef) {
+  public FunctionTypeBuilder fromFunctionDef(FunctionDef functionDef, @Nullable String fileId) {
     this.name = functionDef.name().name();
     this.attributes = new ArrayList<>();
     this.parameters = new ArrayList<>();
@@ -65,7 +65,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     isInstanceMethod = isInstanceMethod(functionDef);
     ParameterList parameterList = functionDef.parameters();
     if (parameterList != null) {
-      createParameterNames(parameterList.all(), null);
+      createParameterNames(parameterList.all(), fileId);
     }
     return this;
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -66,7 +66,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     isInstanceMethod = isInstanceMethod(functionDef);
     ParameterList parameterList = functionDef.parameters();
     if (parameterList != null) {
-      createParameterNames(parameterList.all(), fileId,  projectLevelTypeTable);
+      createParameterNames(parameterList.all(), fileId, projectLevelTypeTable);
     }
     return this;
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/FunctionTypeBuilder.java
@@ -28,6 +28,7 @@ import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.plugins.python.api.tree.AnyParameter;
 import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Name;
+import org.sonar.plugins.python.api.tree.Parameter;
 import org.sonar.plugins.python.api.tree.ParameterList;
 import org.sonar.plugins.python.api.tree.Token;
 import org.sonar.plugins.python.api.tree.Tree;
@@ -56,7 +57,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
   private static final String CLASS_METHOD_DECORATOR = "classmethod";
   private static final String STATIC_METHOD_DECORATOR = "staticmethod";
 
-  public FunctionTypeBuilder fromFunctionDef(FunctionDef functionDef, @Nullable String fileId) {
+  public FunctionTypeBuilder fromFunctionDef(FunctionDef functionDef, @Nullable String fileId, ProjectLevelTypeTable projectLevelTypeTable) {
     this.name = functionDef.name().name();
     this.attributes = new ArrayList<>();
     this.parameters = new ArrayList<>();
@@ -65,7 +66,7 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     isInstanceMethod = isInstanceMethod(functionDef);
     ParameterList parameterList = functionDef.parameters();
     if (parameterList != null) {
-      createParameterNames(parameterList.all(), fileId);
+      createParameterNames(parameterList.all(), fileId,  projectLevelTypeTable);
     }
     return this;
   }
@@ -141,18 +142,18 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     return this;
   }
 
-  private void createParameterNames(List<AnyParameter> parameterTrees, @Nullable String fileId) {
+  private void createParameterNames(List<AnyParameter> parameterTrees, @Nullable String fileId, ProjectLevelTypeTable projectLevelTypeTable) {
     ParameterState parameterState = new ParameterState();
     parameterState.positionalOnly = parameterTrees.stream().anyMatch(param -> Optional.of(param)
       .filter(p -> p.is(Tree.Kind.PARAMETER))
-      .map(p -> ((org.sonar.plugins.python.api.tree.Parameter) p).starToken())
+      .map(p -> ((Parameter) p).starToken())
       .map(Token::value)
       .filter("/"::equals)
       .isPresent()
     );
     for (AnyParameter anyParameter : parameterTrees) {
       if (anyParameter.is(Tree.Kind.PARAMETER)) {
-        addParameter((org.sonar.plugins.python.api.tree.Parameter) anyParameter, fileId, parameterState);
+        addParameter((Parameter) anyParameter, fileId, parameterState, projectLevelTypeTable);
       } else {
         parameters.add(new ParameterV2(null, PythonType.UNKNOWN, false,
           parameterState.keywordOnly, parameterState.positionalOnly, false, false, locationInFile(anyParameter, fileId)));
@@ -160,11 +161,11 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     }
   }
 
-  private void addParameter(org.sonar.plugins.python.api.tree.Parameter parameter, @Nullable String fileId, ParameterState parameterState) {
+  private void addParameter(Parameter parameter, @Nullable String fileId, ParameterState parameterState, ProjectLevelTypeTable projectLevelTypeTable) {
     Name parameterName = parameter.name();
     Token starToken = parameter.starToken();
     if (parameterName != null) {
-      ParameterType parameterType = getParameterType(parameter);
+      ParameterType parameterType = getParameterType(parameter, projectLevelTypeTable);
       this.parameters.add(new ParameterV2(parameterName.name(), parameterType.pythonType(), parameter.defaultValue() != null,
         parameterState.keywordOnly, parameterState.positionalOnly, parameterType.isKeywordVariadic(), parameterType.isPositionalVariadic(), locationInFile(parameter, fileId)));
       if (starToken != null) {
@@ -183,10 +184,11 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
     }
   }
 
-  private ParameterType getParameterType(org.sonar.plugins.python.api.tree.Parameter parameter) {
+  private ParameterType getParameterType(Parameter parameter, ProjectLevelTypeTable projectLevelTypeTable) {
     boolean isPositionalVariadic = false;
     boolean isKeywordVariadic = false;
     Token starToken = parameter.starToken();
+    var parameterType = Optional.ofNullable(parameter.name()).map(Name::typeV2).orElse(PythonType.UNKNOWN);
     if (starToken != null) {
       // https://docs.python.org/3/reference/compound_stmts.html#function-definitions
       hasVariadicParameter = true;
@@ -194,15 +196,16 @@ public class FunctionTypeBuilder implements TypeBuilder<FunctionType> {
         // if the form “*identifier” is present, it is initialized to a tuple receiving any excess positional parameters
         isPositionalVariadic = true;
         // Should set PythonType to TUPLE
+        parameterType = projectLevelTypeTable.getBuiltinsModule().resolveMember("tuple").orElse(PythonType.UNKNOWN);
       }
       if ("**".equals(starToken.value())) {
         //  If the form “**identifier” is present, it is initialized to a new ordered mapping receiving any excess keyword arguments
         isKeywordVariadic = true;
         // Should set PythonType to DICT
+        parameterType = projectLevelTypeTable.getBuiltinsModule().resolveMember("dict").orElse(PythonType.UNKNOWN);
       }
     }
-    // TODO: SONARPY-1773 handle parameter declared types
-    return new ParameterType(PythonType.UNKNOWN, isKeywordVariadic, isPositionalVariadic);
+    return new ParameterType(parameterType, isKeywordVariadic, isPositionalVariadic);
   }
 
   public static class ParameterState {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/LazyTypesContext.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/LazyTypesContext.java
@@ -22,7 +22,9 @@ package org.sonar.python.semantic.v2;
 import java.util.HashMap;
 import java.util.Map;
 import org.sonar.python.types.v2.LazyType;
+import org.sonar.python.types.v2.LazyTypeWrapper;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeWrapper;
 
 public class LazyTypesContext {
   private final Map<String, LazyType> lazyTypes;
@@ -31,6 +33,10 @@ public class LazyTypesContext {
   public LazyTypesContext(ProjectLevelTypeTable projectLevelTypeTable) {
     this.lazyTypes = new HashMap<>();
     this.projectLevelTypeTable = projectLevelTypeTable;
+  }
+
+  public TypeWrapper getOrCreateLazyTypeWrapper(String fullyQualifiedName) {
+    return new LazyTypeWrapper(getOrCreateLazyType(fullyQualifiedName));
   }
 
   public LazyType getOrCreateLazyType(String fullyQualifiedName) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ObjectTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ObjectTypeBuilder.java
@@ -41,7 +41,7 @@ public class ObjectTypeBuilder implements TypeBuilder<ObjectType> {
 
   @Override
   public TypeBuilder<ObjectType> withDefinitionLocation(LocationInFile definitionLocation) {
-    return null;
+    throw new IllegalStateException("Object type does not have definition location");
   }
 
   public ObjectTypeBuilder withTypeWrapper(TypeWrapper typeWrapper) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ObjectTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ObjectTypeBuilder.java
@@ -1,0 +1,74 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.semantic.v2;
+
+import java.util.List;
+import org.sonar.plugins.python.api.LocationInFile;
+import org.sonar.python.types.v2.Member;
+import org.sonar.python.types.v2.ObjectType;
+import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeSource;
+import org.sonar.python.types.v2.TypeWrapper;
+
+public class ObjectTypeBuilder implements TypeBuilder<ObjectType> {
+
+  private TypeWrapper typeWrapper;
+  private List<PythonType> attributes;
+  private List<Member> members;
+  private TypeSource typeSource;
+
+  @Override
+  public ObjectType build() {
+    return new ObjectType(typeWrapper, attributes, members, typeSource);
+  }
+
+  @Override
+  public TypeBuilder<ObjectType> withDefinitionLocation(LocationInFile definitionLocation) {
+    return null;
+  }
+
+  public ObjectTypeBuilder withTypeWrapper(TypeWrapper typeWrapper) {
+    this.typeWrapper = typeWrapper;
+    return this;
+  }
+
+  public ObjectTypeBuilder withAttributes(List<PythonType> attributes) {
+    this.attributes = attributes;
+    return this;
+  }
+
+  public ObjectTypeBuilder withMembers(List<Member> members) {
+    this.members = members;
+    return this;
+  }
+
+  public ObjectTypeBuilder withTypeSource(TypeSource typeSource) {
+    this.typeSource = typeSource;
+    return this;
+  }
+
+  public static ObjectTypeBuilder fromObjectType(ObjectType objectType) {
+    return new ObjectTypeBuilder()
+      .withTypeWrapper(objectType.typeWrapper())
+      .withAttributes(objectType.attributes())
+      .withMembers(objectType.members())
+      .withTypeSource(objectType.typeSource());
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
@@ -50,6 +50,7 @@ import org.sonar.python.types.v2.ModuleType;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.SimpleTypeWrapper;
 import org.sonar.python.types.v2.TypeOrigin;
 import org.sonar.python.types.v2.UnionType;
 
@@ -149,7 +150,7 @@ public class SymbolsModuleTypeProvider {
   private PythonType getReturnTypeFromSymbol(FunctionSymbol symbol) {
     var returnTypeFqns = getReturnTypeFqn(symbol);
     var returnTypeList = returnTypeFqns.stream().map(lazyTypesContext::getOrCreateLazyTypeWrapper).map(ObjectType::new).toList();
-    //TODO: Support type unions
+    //TODO Support type unions (SONARPY-2132)
     return returnTypeList.size() == 1 ? returnTypeList.get(0) : PythonType.UNKNOWN;
   }
 
@@ -210,7 +211,7 @@ public class SymbolsModuleTypeProvider {
 
   private ParameterV2 convertParameter(FunctionSymbol.Parameter parameter) {
     String parameterTypeFqn = getParameterFqn(parameter);
-    var parameterType = parameterTypeFqn == null ? PythonType.UNKNOWN : lazyTypesContext.getOrCreateLazyType(parameterTypeFqn);
+    var parameterType = parameterTypeFqn == null ? new SimpleTypeWrapper(PythonType.UNKNOWN) : lazyTypesContext.getOrCreateLazyTypeWrapper(parameterTypeFqn);
     return new ParameterV2(parameter.name(),
       parameterType,
       parameter.hasDefaultValue(),
@@ -249,7 +250,7 @@ public class SymbolsModuleTypeProvider {
   }
 
   @CheckForNull
-  private String getParameterFqn(FunctionSymbol.Parameter parameter) {
+  private static String getParameterFqn(FunctionSymbol.Parameter parameter) {
     if (parameter instanceof FunctionSymbolImpl.ParameterImpl parameterImpl) {
       if (parameterImpl.annotatedTypeName() != null) {
         return parameterImpl.annotatedTypeName();

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -283,7 +283,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
     TypeAnnotation typeAnnotation = functionDef.returnTypeAnnotation();
     if (typeAnnotation != null) {
       PythonType returnType = typeAnnotation.expression().typeV2();
-      functionTypeBuilder.withReturnType(returnType);
+      functionTypeBuilder.withReturnType(returnType == PythonType.UNKNOWN ? returnType : new ObjectType(returnType, TypeSource.TYPE_HINT));
       functionTypeBuilder.withTypeOrigin(TypeOrigin.LOCAL);
     }
     FunctionType functionType = functionTypeBuilder.build();

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -271,7 +271,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
 
   private FunctionType buildFunctionType(FunctionDef functionDef) {
     FunctionTypeBuilder functionTypeBuilder = new FunctionTypeBuilder()
-      .fromFunctionDef(functionDef)
+      .fromFunctionDef(functionDef, fileId)
       .withDefinitionLocation(locationInFile(functionDef.name(), fileId));
     ClassType owner = null;
     if (currentType() instanceof ClassType classType) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -271,7 +271,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
 
   private FunctionType buildFunctionType(FunctionDef functionDef) {
     FunctionTypeBuilder functionTypeBuilder = new FunctionTypeBuilder()
-      .fromFunctionDef(functionDef, fileId)
+      .fromFunctionDef(functionDef, fileId, projectLevelTypeTable)
       .withDefinitionLocation(locationInFile(functionDef.name(), fileId));
     ClassType owner = null;
     if (currentType() instanceof ClassType classType) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -227,7 +227,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
         if (argument instanceof RegularArgument regularArgument) {
           addParentClass(classTypeBuilder, regularArgument);
         } else {
-          classTypeBuilder.superClasses().add(PythonType.UNKNOWN);
+          classTypeBuilder.addSuperClass(PythonType.UNKNOWN);
         }
       });
   }
@@ -243,7 +243,7 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
       return;
     }
     PythonType argumentType = getTypeV2FromArgument(regularArgument);
-    classTypeBuilder.superClasses().add(argumentType);
+    classTypeBuilder.addSuperClass(argumentType);
     // TODO: SONARPY-1869 handle generics
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyTypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyTypeWrapper.java
@@ -1,0 +1,42 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public class LazyTypeWrapper implements TypeWrapper {
+  private PythonType type;
+
+  public LazyTypeWrapper(PythonType type) {
+    this.type = type;
+    if (type instanceof LazyType lazyType) {
+      lazyType.addConsumer(this::resolveLazyType);
+    }
+  }
+
+  public PythonType type() {
+    return TypeUtils.resolved(this.type);
+  }
+
+  public void resolveLazyType(PythonType pythonType) {
+    if (!(type instanceof LazyType)) {
+      throw new IllegalStateException("Trying to resolve an already resolved lazy type.");
+    }
+    this.type = pythonType;
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ParameterV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ParameterV2.java
@@ -26,7 +26,7 @@ import org.sonar.plugins.python.api.LocationInFile;
 @Beta
 public record ParameterV2(
   @Nullable String name,
-  PythonType declaredType,
+  TypeWrapper declaredType,
   boolean hasDefaultValue,
   boolean isKeywordOnly,
   boolean isPositionalOnly,

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/SimpleTypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/SimpleTypeWrapper.java
@@ -21,32 +21,12 @@ package org.sonar.python.types.v2;
 
 import java.util.Objects;
 
-public class LazyTypeWrapper implements TypeWrapper {
-  private PythonType type;
-
-  public LazyTypeWrapper(PythonType type) {
-    this.type = type;
-    if (type instanceof LazyType lazyType) {
-      lazyType.addConsumer(this::resolveLazyType);
-    }
-  }
-
-  public PythonType type() {
-    return TypeUtils.resolved(this.type);
-  }
-
-  public void resolveLazyType(PythonType pythonType) {
-    if (!(type instanceof LazyType)) {
-      throw new IllegalStateException("Trying to resolve an already resolved lazy type.");
-    }
-    this.type = pythonType;
-  }
-
+public class SimpleTypeWrapper implements TypeWrapper {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
     if (o == null || getClass() != o.getClass()) return false;
-    LazyTypeWrapper that = (LazyTypeWrapper) o;
+    SimpleTypeWrapper that = (SimpleTypeWrapper) o;
     return Objects.equals(type, that.type);
   }
 
@@ -55,9 +35,20 @@ public class LazyTypeWrapper implements TypeWrapper {
     return Objects.hashCode(type);
   }
 
+  private final PythonType type;
+
+  public SimpleTypeWrapper(PythonType type) {
+    this.type = type;
+  }
+
+  @Override
+  public PythonType type() {
+    return type;
+  }
+
   @Override
   public String toString() {
-    return "LazyTypeWrapper{" +
+    return "SimpleTypeWrapper{" +
       "type=" + type +
       '}';
   }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
@@ -220,7 +220,7 @@ public class TypeCheckBuilder {
           result.add(PythonType.UNKNOWN);
           queue.clear();
         } else if (currentType instanceof ClassType classType) {
-          queue.addAll(classType.superClasses());
+          queue.addAll(classType.superClasses().stream().map(TypeWrapper::type).toList());
         }
       }
       return result;

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
@@ -1,0 +1,25 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public interface TypeWrapper {
+
+  PythonType type();
+}

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
@@ -126,4 +126,12 @@ class TypeCheckerBuilderTest {
     );
   }
 
+  @Test
+  void objectTypeThrowsOnDefinitionLocation() {
+    var objectTypeBuilder = new ObjectTypeBuilder();
+    Assertions.assertThatThrownBy(() -> objectTypeBuilder.withDefinitionLocation(null))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Object type does not have definition location");
+  }
+
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -683,6 +683,16 @@ class TypeInferenceV2Test {
   }
 
   @Test
+  void inferFunctionParameterTypes7() {
+    FileInput root = inferTypes("""
+      a = int
+      def foo(param: a): ...
+      """);
+    var functionDef = (FunctionDef) root.statements().statements().get(1);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(INT_TYPE);
+  }
+
+  @Test
   void inferTypeForReassignedBuiltinsInsideFunction() {
     FileInput root = inferTypes("""
       def foo():

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -232,6 +232,22 @@ class TypeInferenceV2Test {
   }
 
   @Test
+  void parameterTypeFromTypeshed() {
+    FileInput root = inferTypes("""
+      from time import sleep 
+      sleep
+      """);
+
+    var sleep = (Name) ((ExpressionStatement) root.statements().statements().get(1)).expressions().get(0);
+    var sleepType = sleep.typeV2();
+    assertThat(sleepType)
+      .isInstanceOf(FunctionType.class)
+      .extracting(PythonType::name)
+      .isEqualTo("sleep");
+
+  }
+
+  @Test
   void simpleFunctionDef() {
     FileInput root = inferTypes("""
       def foo(a, b, c): ...

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -389,7 +389,7 @@ class TypeInferenceV2Test {
     assertThat(lastExpressionStatement.expressions().get(0).typeV2().unwrappedType()).isEqualTo(INT_TYPE);
     assertThat(lastExpressionStatement.expressions().get(0).typeV2().typeSource()).isEqualTo(TypeSource.TYPE_HINT);
 
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(INT_TYPE);
   }
 
   @Test
@@ -610,9 +610,9 @@ class TypeInferenceV2Test {
       """);
 
     var functionDef = (FunctionDef) root.statements().statements().get(0);
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(1).declaredType().unwrappedType()).isEqualTo(TUPLE_TYPE);
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(2).declaredType().unwrappedType()).isEqualTo(DICT_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(INT_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(1).declaredType().type().unwrappedType()).isEqualTo(TUPLE_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(2).declaredType().type().unwrappedType()).isEqualTo(DICT_TYPE);
   }
 
   @Test
@@ -625,7 +625,7 @@ class TypeInferenceV2Test {
       """);
 
     var functionDef = (FunctionDef) root.statements().statements().get(2);
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(PythonType.UNKNOWN);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(PythonType.UNKNOWN);
     assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(PythonType.UNKNOWN);
   }
 
@@ -642,7 +642,7 @@ class TypeInferenceV2Test {
     var functionDef = (FunctionDef) root.statements().statements().get(1);
     var classType = ((ClassDef) root.statements().statements().get(0)).name().typeV2();
 
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(classType);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(classType);
     assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(classType);
   }
 
@@ -658,7 +658,7 @@ class TypeInferenceV2Test {
     var functionDef = (FunctionDef) root.statements().statements().get(2);
     var patternType = ((Name) ((ExpressionStatementImpl) root.statements().statements().get(1)).expressions().get(0)).typeV2();
 
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(patternType);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(patternType);
     assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(patternType);
   }
 
@@ -670,7 +670,16 @@ class TypeInferenceV2Test {
       """);
 
     var functionDef = (FunctionDef) root.statements().statements().get(1);
-    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(INT_TYPE);
+  }
+
+  @Test
+  void inferFunctionParameterTypes6() {
+    FileInput root = inferTypes("""
+      def foo(param: dict): ...
+      """);
+    var functionDef = (FunctionDef) root.statements().statements().get(0);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(DICT_TYPE);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -602,12 +602,8 @@ class TypeInferenceV2Test {
   @Test
   void inferFunctionParameterTypes2() {
     FileInput root = inferTypes("""
-      class A:
-        def foo():
-          ...
-      class A:
-        def foo(param: int):
-          ...
+      class A: ...
+      class A: ...
       def foo(param: A) -> A:
         ...
       """);
@@ -650,6 +646,16 @@ class TypeInferenceV2Test {
     assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(patternType);
   }
 
+  @Test
+  void inferFunctionParameterTypes5() {
+    FileInput root = inferTypes("""
+      my_alias = int
+      def foo(param: my_alias): ...
+      """);
+
+    var functionDef = (FunctionDef) root.statements().statements().get(1);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
+  }
 
   @Test
   void inferTypeForReassignedBuiltinsInsideFunction() {

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -368,9 +368,11 @@ class TypeInferenceV2Test {
       """);
 
     var functionDef = (FunctionDef) root.statements().statements().get(0);
-    var lastExpressionStatement = (ExpressionStatement) functionDef.body().statements().get(functionDef.body().statements().size() -1);
-    Assertions.assertThat(lastExpressionStatement.expressions().get(0).typeV2().unwrappedType()).isEqualTo(INT_TYPE);
-    Assertions.assertThat(lastExpressionStatement.expressions().get(0).typeV2().typeSource()).isEqualTo(TypeSource.TYPE_HINT);
+    var lastExpressionStatement = (ExpressionStatement) functionDef.body().statements().get(functionDef.body().statements().size() - 1);
+    assertThat(lastExpressionStatement.expressions().get(0).typeV2().unwrappedType()).isEqualTo(INT_TYPE);
+    assertThat(lastExpressionStatement.expressions().get(0).typeV2().typeSource()).isEqualTo(TypeSource.TYPE_HINT);
+
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
   }
 
   @Test
@@ -581,6 +583,19 @@ class TypeInferenceV2Test {
     var lastType = lastExpressionStatement.expressions().get(0).typeV2();
 
     Assertions.assertThat(lastType.unwrappedType()).isEqualTo(INT_TYPE);
+  }
+
+  @Test
+  void inferFunctionParameterTypes() {
+    FileInput root = inferTypes("""
+      def foo(param: int, *args, **kwargs):
+        ...
+      """);
+
+    var functionDef = (FunctionDef) root.statements().statements().get(0);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(INT_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(1).declaredType().unwrappedType()).isEqualTo(TUPLE_TYPE);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(2).declaredType().unwrappedType()).isEqualTo(DICT_TYPE);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -53,6 +53,7 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ClassSymbolImpl;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
+import org.sonar.python.tree.ExpressionStatementImpl;
 import org.sonar.python.tree.TreeUtils;
 import org.sonar.python.types.v2.ClassType;
 import org.sonar.python.types.v2.FunctionType;
@@ -597,6 +598,58 @@ class TypeInferenceV2Test {
     assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(1).declaredType().unwrappedType()).isEqualTo(TUPLE_TYPE);
     assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(2).declaredType().unwrappedType()).isEqualTo(DICT_TYPE);
   }
+
+  @Test
+  void inferFunctionParameterTypes2() {
+    FileInput root = inferTypes("""
+      class A:
+        def foo():
+          ...
+      class A:
+        def foo(param: int):
+          ...
+      def foo(param: A) -> A:
+        ...
+      """);
+
+    var functionDef = (FunctionDef) root.statements().statements().get(2);
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(PythonType.UNKNOWN);
+    assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(PythonType.UNKNOWN);
+  }
+
+  @Test
+  void inferFunctionParameterTypes3() {
+    FileInput root = inferTypes("""
+      class A:
+        def foo():
+          ...
+      def foo(param: A) -> A:
+        ...
+      """);
+
+    var functionDef = (FunctionDef) root.statements().statements().get(1);
+    var classType = ((ClassDef) root.statements().statements().get(0)).name().typeV2();
+
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(classType);
+    assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(classType);
+  }
+
+  @Test
+  void inferFunctionParameterTypes4() {
+    FileInput root = inferTypes("""
+      from re import Pattern
+      Pattern
+      def foo(param: Pattern) -> Pattern:
+        ...
+      """);
+
+    var functionDef = (FunctionDef) root.statements().statements().get(2);
+    var patternType = ((Name) ((ExpressionStatementImpl) root.statements().statements().get(1)).expressions().get(0)).typeV2();
+
+    assertThat(((FunctionType) functionDef.name().typeV2()).parameters().get(0).declaredType().unwrappedType()).isEqualTo(patternType);
+    assertThat(((FunctionType) functionDef.name().typeV2()).returnType().unwrappedType()).isEqualTo(patternType);
+  }
+
 
   @Test
   void inferTypeForReassignedBuiltinsInsideFunction() {

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -93,7 +93,7 @@ public class ClassTypeTest {
     ClassType classC = classTypes.get(0);
     ClassType classB = classTypes.get(1);
     assertThat(classB.superClasses()).hasSize(1);
-    assertThat(classB.superClasses()).containsExactlyInAnyOrder(classC);
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).containsExactlyInAnyOrder(classC);
   }
 
   @Test
@@ -109,7 +109,7 @@ public class ClassTypeTest {
     ClassType classA = classTypes.get(1);
     ClassType classB = classTypes.get(2);
     assertThat(classB.superClasses()).hasSize(2);
-    assertThat(classB.superClasses()).containsExactlyInAnyOrder(classC, classA);
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).containsExactlyInAnyOrder(classC, classA);
   }
 
   @Test
@@ -118,7 +118,7 @@ public class ClassTypeTest {
       "class B(C): ..."
     );
     ClassType classC = classTypes.get(0);
-    assertThat(classC.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classC.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classC.hasUnresolvedHierarchy()).isTrue();
     assertThat(classC.hasMember("unknown")).isEqualTo(TriBool.UNKNOWN);
     assertThat(classC.instancesHaveMember("unknown")).isEqualTo(TriBool.UNKNOWN);
@@ -143,7 +143,7 @@ public class ClassTypeTest {
     ClassType classB = classTypes.get(1);
     assertThat(classB.superClasses()).hasSize(2);
     assertThat(classB.hasUnresolvedHierarchy()).isFalse();
-    var baseExceptionType = classB.superClasses().get(1);
+    var baseExceptionType = classB.superClasses().get(1).type();
     assertThat(baseExceptionType)
       .isInstanceOf(ClassType.class)
       .extracting(PythonType::name)
@@ -217,7 +217,7 @@ public class ClassTypeTest {
       "class C(foo()): ",
       "  pass");
     ClassType classType = classTypes.get(0);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -231,7 +231,7 @@ public class ClassTypeTest {
       "  pass");
     ClassType classType = classTypes.get(0);
     assertThat(classType.superClasses()).hasSize(1);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -242,7 +242,7 @@ public class ClassTypeTest {
       "class C(*foo): ",
       "  pass");
     ClassType classType = classTypes.get(0);
-    assertThat(classType.superClasses()).containsExactly(PythonType.UNKNOWN);
+    assertThat(classType.superClasses()).extracting(TypeWrapper::type).containsExactly(PythonType.UNKNOWN);
     assertThat(classType.hasUnresolvedHierarchy()).isTrue();
   }
 
@@ -347,7 +347,7 @@ public class ClassTypeTest {
     ClassType classB = classTypes.get(1);
     assertThat(classB.hasUnresolvedHierarchy()).isFalse();
     assertThat(classB.superClasses()).hasSize(1);
-    assertThat(classB.superClasses()).extracting(PythonType::name).containsExactly("A");
+    assertThat(classB.superClasses()).extracting(TypeWrapper::type).extracting(PythonType::name).containsExactly("A");
     assertThat(classB.hasMetaClass()).isFalse();
     assertThat(classB.instancesHaveMember("foo")).isEqualTo(TriBool.UNKNOWN);
   }
@@ -422,7 +422,7 @@ public class ClassTypeTest {
       "  def foo(): pass").get(1);
 
     assertThat(classB.members()).hasSize(1);
-    ClassType classA = (ClassType) classB.superClasses().get(0);
+    ClassType classA = (ClassType) classB.superClasses().get(0).type();
     assertThat(classA.members()).hasSize(1);
 
     assertThat(classB.resolveMember("foo")).isPresent();

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -146,7 +146,7 @@ class FunctionTypeTest {
     // TODO: SONARPY-1776 handle declared return type
     FunctionType functionType = functionType("def fn(p1: int): pass");
     assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
-    assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).extracting(PythonType::unwrappedType).containsExactly(INT_TYPE);
+    assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).extracting(TypeWrapper::type).extracting(PythonType::unwrappedType).containsExactly(INT_TYPE);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -152,7 +152,7 @@ class FunctionTypeTest {
   @Test
   void declared_return_type() {
     FunctionType functionType = functionType("def fn() -> int: ...");
-    assertThat(functionType.returnType()).isEqualTo(INT_TYPE);
+    assertThat(functionType.returnType().unwrappedType()).isEqualTo(INT_TYPE);
     functionType = functionType("def fn() -> unknown: ...");
     assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -143,10 +143,9 @@ class FunctionTypeTest {
 
   @Test
   void declaredTypes() {
-    // TODO: SONARPY-1776 handle declared return type
     FunctionType functionType = functionType("def fn(p1: int): pass");
     assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
-    assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).containsExactly(PythonType.UNKNOWN);
+    assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).extracting(PythonType::unwrappedType).containsExactly(INT_TYPE);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -143,6 +143,7 @@ class FunctionTypeTest {
 
   @Test
   void declaredTypes() {
+    // TODO: SONARPY-1776 handle declared return type
     FunctionType functionType = functionType("def fn(p1: int): pass");
     assertThat(functionType.returnType()).isEqualTo(PythonType.UNKNOWN);
     assertThat(functionType.parameters()).extracting(ParameterV2::declaredType).extracting(PythonType::unwrappedType).containsExactly(INT_TYPE);

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -101,7 +101,7 @@ class FunctionTypeTest {
     assertThat(functionType.parameters().get(0).isVariadic()).isFalse();
     assertThat(functionType.parameters().get(0).isKeywordVariadic()).isFalse();
     assertThat(functionType.parameters().get(0).isPositionalVariadic()).isFalse();
-    assertThat(functionType.parameters().get(0).location()).isNull();
+    assertThat(functionType.parameters().get(0).location()).isEqualTo(new LocationInFile(fileId, 1, 7, 1, 17));
 
     functionType = functionType("def fn(**kwargs): pass");
     assertThat(functionType.parameters()).hasSize(1);
@@ -186,6 +186,15 @@ class FunctionTypeTest {
 
     functionType = functionType("def foo(): ...");
     assertThat(functionType.owner()).isNull();
+  }
+
+  @Test
+  void location() {
+    FunctionType functionType = functionType("def fn(param: int, (a: str, b)): pass");
+    String fileId = SymbolUtils.pathOf(pythonFile).toString();
+    assertThat(functionType.definitionLocation()).contains(new LocationInFile(fileId, 1, 4, 1, 6));
+    assertThat(functionType.parameters().get(0).location()).isEqualTo(new LocationInFile(fileId, 1, 7, 1, 17));
+    assertThat(functionType.parameters().get(1).location()).isEqualTo(new LocationInFile(fileId, 1, 19, 1, 30));
   }
 
   public static FunctionType functionType(String... code) {

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
@@ -49,4 +49,12 @@ class LazyTypeWrapperTest {
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Trying to resolve an already resolved lazy type.");
   }
+
+  @Test
+  void testEquals() {
+    var lazyTypeWrapper = new LazyTypeWrapper(new LazyType("random", Mockito.mock(LazyTypesContext.class)));
+    assertThat(lazyTypeWrapper.equals(lazyTypeWrapper)).isTrue();
+    assertThat(lazyTypeWrapper.equals(null)).isFalse();
+    assertThat(lazyTypeWrapper.equals("str")).isFalse();
+  }
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/LazyTypeWrapperTest.java
@@ -1,0 +1,52 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonar.python.semantic.v2.LazyTypesContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.sonar.python.types.v2.TypesTestUtils.INT_TYPE;
+import static org.sonar.python.types.v2.TypesTestUtils.STR_TYPE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+
+class LazyTypeWrapperTest {
+
+
+  @Test
+  void lazyTypeIsResolvedWhenAccessed() {
+    LazyTypesContext lazyTypesContext = Mockito.mock(LazyTypesContext.class);
+    when(lazyTypesContext.resolveLazyType(Mockito.any())).thenReturn(INT_TYPE);
+    LazyType lazyType = new LazyType("random", lazyTypesContext);
+    LazyTypeWrapper lazyTypeWrapper = new LazyTypeWrapper(lazyType);
+    assertThat(lazyTypeWrapper.type()).isEqualTo(INT_TYPE);
+  }
+
+  @Test
+  void resolvingNonLazyTypeThrowsException() {
+    LazyTypeWrapper lazyTypeWrapper = new LazyTypeWrapper(INT_TYPE);
+    assertThatThrownBy(() -> lazyTypeWrapper.resolveLazyType(STR_TYPE))
+      .isInstanceOf(IllegalStateException.class)
+      .hasMessage("Trying to resolve an already resolved lazy type.");
+  }
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/SimpleTypeWrapperTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/SimpleTypeWrapperTest.java
@@ -1,0 +1,37 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SimpleTypeWrapperTest {
+
+  @Test
+  void testEquals() {
+    var simpleTypeWrapper = new SimpleTypeWrapper(PythonType.UNKNOWN);
+    assertThat(simpleTypeWrapper.equals(simpleTypeWrapper)).isTrue();
+    assertThat(simpleTypeWrapper.equals(null)).isFalse();
+    assertThat(simpleTypeWrapper.equals("str")).isFalse();
+  }
+
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -43,6 +43,7 @@ public class TypesTestUtils {
   public static final PythonType DICT_TYPE = BUILTINS.resolveMember("dict").get();
   public static final PythonType NONE_TYPE = BUILTINS.resolveMember("NoneType").get();
   public static final PythonType TYPE_TYPE = BUILTINS.resolveMember("type").get();
+  public static final PythonType EXCEPTION_TYPE = BUILTINS.resolveMember("Exception").get();
 
   public static FileInput parseAndInferTypes(String... code) {
     return parseAndInferTypes(PythonTestUtils.pythonFile(""), code);


### PR DESCRIPTION
- **SONARPY-2131 Support LazyType for super classes of ClassType**
- **SONARPY-2114 Migrate S5707 ExceptionCauseTypeCheck to the V2 type model**
- **SONARPY-2115 Migrate S1244 FloatingPointEqualityCheck to the V2 type model (#1954)**
- **SONARPY-2118 Ensure function parameter types are correctly mapped in V2 type model**
- **Add tests**
- **Fix test**
- **revert todo**
- **Address review comments**
- **SONARPY-2122 Ensure function parameters have a definition location (#1958)**
- **Support type wrappers in ObjectType**
- **Make FunctionType#returnType an ObjectType of a ClassType from type hint**
- **Make function parameter type support lazy type**
