### PR TITLE
SONARPY-2124 Ensure parameters types of imported project functions have their declared type populated.

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
@@ -22,4 +22,6 @@ package org.sonar.python.types.v2;
 public interface TypeWrapper {
 
   PythonType type();
+
+  TypeWrapper UNKNOWN_TYPE_WRAPPER = new SimpleTypeWrapper(PythonType.UNKNOWN);
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -54,6 +54,7 @@ import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ClassSymbolImpl;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
+import org.sonar.python.semantic.SymbolUtils;
 import org.sonar.python.tree.ExpressionStatementImpl;
 import org.sonar.python.tree.TreeUtils;
 import org.sonar.python.types.v2.ClassType;
@@ -705,6 +706,7 @@ class TypeInferenceV2Test {
     var modFile = pythonFile("mod.py");
     projectLevelSymbolTable.addModule(tree, "", modFile);
     ProjectLevelTypeTable projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable);
+    var modFileId = SymbolUtils.pathOf(modFile).toString();
 
     var intType = projectLevelTypeTable.lazyTypesContext().getOrCreateLazyType("int").resolve();
     var dictType = projectLevelTypeTable.lazyTypesContext().getOrCreateLazyType("dict").resolve();
@@ -721,8 +723,8 @@ class TypeInferenceV2Test {
     FunctionType foo2Type = (FunctionType) ((ExpressionStatement) fileInput.statements().statements().get(2)).expressions().get(0).typeV2();
     assertThat(foo2Type.parameters()).extracting(ParameterV2::declaredType).extracting(TypeWrapper::type).containsExactly(dictType, aType);
     assertThat(foo2Type.parameters()).extracting(ParameterV2::location).containsExactly(
-      new LocationInFile(modFile.uri().getPath(), 3, 9, 3, 17),
-      new LocationInFile(modFile.uri().getPath(), 3, 19, 3, 24));
+      new LocationInFile(modFileId, 3, 9, 3, 17),
+      new LocationInFile(modFileId, 3, 19, 3, 24));
   }
 
   @Test


### PR DESCRIPTION
This pull request includes several changes to improve type handling and testing in the `SymbolsModuleTypeProvider` class and its associated test cases. The changes focus on enhancing the type inference mechanism and refactoring the code for better maintainability.

### Improvements to type handling:

* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java`](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370R54): Added `TypeWrapper` import to support type wrapping.
* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java`](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370L212-R219): Refactored `convertParameter` method to be non-static and updated it to use `TypeWrapper` for parameter type handling.

### Code refactoring:

* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java`](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370L124-R125): Changed method reference in `convertToFunctionType` from `SymbolsModuleTypeProvider::convertParameter` to `this::convertParameter` for better encapsulation.

### Testing enhancements:

* [`python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java`](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR696-R722): Added a new test `inferFunctionParameterTypesMultiFile` to verify the type inference for function parameters across multiple files.