### PR TITLE
SONARPY-2144 Implement fully-qualified name for type inference V2

### DIFF
--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java
@@ -52,7 +52,7 @@ public class PythonVisitorContext extends PythonInputFileContext {
     symbolTableBuilder.visitFileInput(rootTree);
     var symbolTable = new SymbolTableBuilderV2(rootTree).build();
     var projectLevelTypeTable = new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty(), new TypeShed(ProjectLevelSymbolTable.empty()));
-    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable).inferTypes(rootTree);
+    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable, symbolTableBuilder.fullyQualifiedModuleName()).inferTypes(rootTree);
     this.typeChecker = new TypeChecker(projectLevelTypeTable);
   }
 
@@ -61,12 +61,13 @@ public class PythonVisitorContext extends PythonInputFileContext {
     super(pythonFile, workingDirectory, cacheContext);
     this.rootTree = rootTree;
     this.parsingException = null;
-    new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
+    var symbolTableBuilder = new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable);
+    symbolTableBuilder.visitFileInput(rootTree);
 
     var symbolTable = new SymbolTableBuilderV2(rootTree)
       .build();
     var projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable, new TypeShed(projectLevelSymbolTable));
-    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable).inferTypes(rootTree);
+    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable, symbolTableBuilder.fullyQualifiedModuleName()).inferTypes(rootTree);
     this.typeChecker = new TypeChecker(projectLevelTypeTable);
   }
 
@@ -75,11 +76,12 @@ public class PythonVisitorContext extends PythonInputFileContext {
     super(pythonFile, workingDirectory, cacheContext, sonarProduct);
     this.rootTree = rootTree;
     this.parsingException = null;
-    new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable).visitFileInput(rootTree);
+    var symbolTableBuilder = new SymbolTableBuilder(packageName, pythonFile, projectLevelSymbolTable);
+    symbolTableBuilder.visitFileInput(rootTree);
     var symbolTable = new SymbolTableBuilderV2(rootTree)
       .build();
     var projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable, typeShed);
-    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable).inferTypes(rootTree);
+    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable, symbolTableBuilder.fullyQualifiedModuleName()).inferTypes(rootTree);
     this.typeChecker = new TypeChecker(projectLevelTypeTable);
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java
@@ -96,7 +96,6 @@ import static org.sonar.python.semantic.SymbolUtils.resolveTypeHierarchy;
 
 // SymbolTable based on https://docs.python.org/3/reference/executionmodel.html#naming-and-binding
 public class SymbolTableBuilder extends BaseTreeVisitor {
-  private String fullyQualifiedModuleName;
   private List<String> filePath;
   private final ProjectLevelSymbolTable projectLevelSymbolTable;
   private Map<Tree, Scope> scopesByRootTree;
@@ -104,6 +103,7 @@ public class SymbolTableBuilder extends BaseTreeVisitor {
   private Set<Tree> assignmentLeftHandSides = new HashSet<>();
   private final PythonFile pythonFile;
   private final Set<String> importedModulesFQN = new HashSet<>();
+  private String fullyQualifiedModuleName;
 
   public SymbolTableBuilder(PythonFile pythonFile) {
     fullyQualifiedModuleName = null;
@@ -114,6 +114,10 @@ public class SymbolTableBuilder extends BaseTreeVisitor {
 
   public Set<String> importedModulesFQN() {
     return Collections.unmodifiableSet(importedModulesFQN);
+  }
+
+  public String fullyQualifiedModuleName() {
+    return fullyQualifiedModuleName;
   }
 
   public SymbolTableBuilder(String packageName, PythonFile pythonFile) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -48,15 +48,17 @@ public class TypeInferenceV2 {
   private final ProjectLevelTypeTable projectLevelTypeTable;
   private final SymbolTable symbolTable;
   private final PythonFile pythonFile;
+  private final String fullyQualifiedModuleName;
 
-  public TypeInferenceV2(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile, SymbolTable symbolTable) {
+  public TypeInferenceV2(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile, SymbolTable symbolTable, String fullyQualifiedModuleName) {
     this.projectLevelTypeTable = projectLevelTypeTable;
     this.symbolTable = symbolTable;
     this.pythonFile = pythonFile;
+    this.fullyQualifiedModuleName = fullyQualifiedModuleName;
   }
 
   public void inferTypes(FileInput fileInput) {
-    TrivialTypeInferenceVisitor trivialTypeInferenceVisitor = new TrivialTypeInferenceVisitor(projectLevelTypeTable, pythonFile);
+    TrivialTypeInferenceVisitor trivialTypeInferenceVisitor = new TrivialTypeInferenceVisitor(projectLevelTypeTable, pythonFile, fullyQualifiedModuleName);
     fileInput.accept(trivialTypeInferenceVisitor);
 
     inferTypesAndMemberAccessSymbols(fileInput);

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -90,19 +90,21 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
 
   private final ProjectLevelTypeTable projectLevelTypeTable;
   private final String fileId;
+  private final String moduleName;
 
   private final Deque<PythonType> typeStack = new ArrayDeque<>();
 
-  public TrivialTypeInferenceVisitor(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile) {
+  public TrivialTypeInferenceVisitor(ProjectLevelTypeTable projectLevelTypeTable, PythonFile pythonFile, String moduleName) {
     this.projectLevelTypeTable = projectLevelTypeTable;
     Path path = pathOf(pythonFile);
     this.fileId = path != null ? path.toString() : pythonFile.toString();
+    this.moduleName = moduleName;
   }
 
 
   @Override
   public void visitFileInput(FileInput fileInput) {
-    var type = new ModuleType("somehow get its name");
+    var type = new ModuleType(moduleName);
     inTypeScope(type, () -> super.visitFileInput(fileInput));
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyType.java
@@ -39,6 +39,7 @@ public class LazyType implements PythonType {
     consumers = new ArrayDeque<>();
   }
 
+  @Override
   public String fullyQualifiedName() {
     return fullyQualifiedName;
   }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ModuleType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ModuleType.java
@@ -94,4 +94,10 @@ public final class ModuleType implements PythonType {
     return members;
   }
 
+  @Override
+  public String fullyQualifiedName() {
+    String s = name == null ? "" : name;
+    return (parent == null || parent.name == null) ? s : (parent.fullyQualifiedName() + "." + name);
+  }
+
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/PythonType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/PythonType.java
@@ -79,4 +79,20 @@ public interface PythonType {
   default TypeSource typeSource() {
     return TypeSource.EXACT;
   }
+
+  default PythonType owner() {
+    return null;
+  }
+
+  @Beta
+  default String fullyQualifiedName() {
+    return Optional.ofNullable(this.owner())
+      .map(owner -> {
+        var ownerFQN = owner.fullyQualifiedName();
+        if (ownerFQN.isEmpty()) {
+          return name();
+        }
+        return owner.fullyQualifiedName() + "." + name();
+      }).orElse(null);
+  }
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2608,7 +2608,7 @@ class TypeInferenceV2Test {
 
     var symbolTable = new SymbolTableBuilderV2(root)
       .build();
-    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable).inferTypes(root);
+    new TypeInferenceV2(projectLevelTypeTable, pythonFile, symbolTable, "thisfile").inferTypes(root);
     return root;
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -81,6 +81,7 @@ public class ClassTypeTest {
 
     assertThat(classType.instancesHaveMember("foo")).isEqualTo(TriBool.TRUE);
     assertThat(classType.instancesHaveMember("bar")).isEqualTo(TriBool.FALSE);
+    assertThat(classType.fullyQualifiedName()).isEqualTo("thisfile.C");
   }
 
   @Test
@@ -173,7 +174,7 @@ public class ClassTypeTest {
       "C = \"hello\"");
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
 
     ClassDef classDef = (ClassDef) fileInput.statements().statements().get(0);
     PythonType pythonType = classDef.name().typeV2();
@@ -197,7 +198,7 @@ public class ClassTypeTest {
     );
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
 
     ClassDef classDef = (ClassDef) fileInput.statements().statements().get(1);
     PythonType pythonType = classDef.name().typeV2();
@@ -564,7 +565,7 @@ public class ClassTypeTest {
     );
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
     ClassDef firstDef = (ClassDef) fileInput.statements().statements().get(0);
     ClassDef innerClass = (ClassDef) firstDef.body().statements().get(0);
     FunctionDef functionDef = (FunctionDef) firstDef.body().statements().get(1);
@@ -613,7 +614,7 @@ public class ClassTypeTest {
     FileInput fileInput = parseWithoutSymbols(code);
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
     return PythonTestUtils.getAllDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF))
       .stream()
       .map(ClassDef.class::cast)

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java
@@ -171,16 +171,21 @@ class FunctionTypeTest {
   void owner() {
     FileInput fileInput = parseWithoutSymbols(
       "class A:",
-      "  def foo(self): pass"
+      "  def foo(self): pass",
+      "def foo2(): pass"
     );
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "").inferTypes(fileInput);
 
     ClassDef classDef = (ClassDef) PythonTestUtils.getAllDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF)).get(0);
     FunctionDef functionDef = (FunctionDef) PythonTestUtils.getAllDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF)).get(0);
 
     FunctionType functionType = (FunctionType) functionDef.name().typeV2();
+
+    var foo2Type = (FunctionType) ((FunctionDef) PythonTestUtils.getAllDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF)).get(1)).name().typeV2();
+    assertThat(foo2Type.fullyQualifiedName()).isEqualTo("foo2");
+
     ClassType classType = (ClassType) classDef.name().typeV2();
     assertThat(functionType.owner()).isEqualTo(classType);
 
@@ -201,7 +206,7 @@ class FunctionTypeTest {
     FileInput fileInput = parseWithoutSymbols(code);
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
     FunctionDef functionDef = (FunctionDef) PythonTestUtils.getAllDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF)).get(0);
     return (FunctionType) functionDef.name().typeV2();
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ModuleTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ModuleTypeTest.java
@@ -52,4 +52,14 @@ class ModuleTypeTest {
     var moduleString = module.toString();
     Assertions.assertThat(moduleString).isEqualTo("ModuleType{name='pkg', members={}}");
   }
+
+  @Test
+  void fqn() {
+    var root = new ModuleType(null);
+    Assertions.assertThat(root.fullyQualifiedName()).isEmpty();
+    var module = new ModuleType("pkg", root);
+    Assertions.assertThat(module.fullyQualifiedName()).isEqualTo("pkg");
+    var subModule = new ModuleType("sub", module);
+    Assertions.assertThat(subModule.fullyQualifiedName()).isEqualTo("pkg.sub");
+  }
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -53,7 +53,7 @@ public class TypesTestUtils {
     FileInput fileInput = PythonTestUtils.parseWithoutSymbols(code);
     var symbolTable = new SymbolTableBuilderV2(fileInput)
       .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable, "thisfile").inferTypes(fileInput);
     return fileInput;
   }
 }


### PR DESCRIPTION
This pull request introduces several changes to improve type inference and fully qualified name (FQN) handling in the Python plugin. The changes include modifications to constructors, the addition of new methods, and updates to test cases to ensure proper functionality.

### Enhancements to Type Inference:

* [`python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVisitorContext.java`](diffhunk://#diff-6e88351b8e51746d1436c9a7822aef910665f6c1f8f872dddea4cd1bf97d26dfL55-R55): Updated the `TypeInferenceV2` constructor calls to include the fully qualified module name. [[1]](diffhunk://#diff-6e88351b8e51746d1436c9a7822aef910665f6c1f8f872dddea4cd1bf97d26dfL55-R55) [[2]](diffhunk://#diff-6e88351b8e51746d1436c9a7822aef910665f6c1f8f872dddea4cd1bf97d26dfL64-R70) [[3]](diffhunk://#diff-6e88351b8e51746d1436c9a7822aef910665f6c1f8f872dddea4cd1bf97d26dfL78-R84)
* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java`](diffhunk://#diff-eec1b73f429a1d595addcaa68100d1296a18e21ebbcd3ed650efc0291bc74023R51-R61): Added a new parameter `fullyQualifiedModuleName` to the `TypeInferenceV2` constructor and updated the `TrivialTypeInferenceVisitor` instantiation accordingly.

### Symbol Table Enhancements:

* [`python-frontend/src/main/java/org/sonar/python/semantic/SymbolTableBuilder.java`](diffhunk://#diff-cd7ad848a8deec53c5b53cd02db130cc607139cfb65bfaa91c9d1c433bb56bc0L99-R106): Introduced a new method `fullyQualifiedModuleName()` and moved the `fullyQualifiedModuleName` field to the top of the class. [[1]](diffhunk://#diff-cd7ad848a8deec53c5b53cd02db130cc607139cfb65bfaa91c9d1c433bb56bc0L99-R106) [[2]](diffhunk://#diff-cd7ad848a8deec53c5b53cd02db130cc607139cfb65bfaa91c9d1c433bb56bc0R119-R122)

### Fully Qualified Name (FQN) Additions:

* [`python-frontend/src/main/java/org/sonar/python/types/v2/ModuleType.java`](diffhunk://#diff-8162d7a6282a3881898dad9d6b7c28fef212bab9d31d0f0c2f86efee1a1b5b8eR97-R102): Added the `fullyQualifiedName()` method to return the FQN of the module.
* [`python-frontend/src/main/java/org/sonar/python/types/v2/PythonType.java`](diffhunk://#diff-5e93a5ae264eba473ae53671be83f05a7ebb56e358dedec3e235e93c1028ee58R82-R97): Introduced the `fullyQualifiedName()` method to provide the FQN for Python types.

### Test Case Updates:

* [`python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java`](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR133-R134): Added new assertions to test the fully qualified names of imported types and modules. [[1]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR133-R134) [[2]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR217-R219) [[3]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR235-R242) [[4]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR2374) [[5]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cR2559-R2601) [[6]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL2558-R2611)
* [`python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java`](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475R84): Updated test cases to include assertions for fully qualified names. [[1]](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475R84) [[2]](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475L176-R177) [[3]](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475L200-R201) [[4]](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475L567-R568) [[5]](diffhunk://#diff-9e2368bb304fe328825893c7133c670d407298b2a0398a64675513ca34b6e475L616-R617)
* [`python-frontend/src/test/java/org/sonar/python/types/v2/FunctionTypeTest.java`](diffhunk://#diff-675bcb3b8a2bdcdce1a56b2125889181dd32ec190fae05c1c32355a82259934aL174-R188): Added assertions to verify the fully qualified names of functions. [[1]](diffhunk://#diff-675bcb3b8a2bdcdce1a56b2125889181dd32ec190fae05c1c32355a82259934aL174-R188) [[2]](diffhunk://#diff-675bcb3b8a2bdcdce1a56b2125889181dd32ec190fae05c1c32355a82259934aL204-R209)
* [`python-frontend/src/test/java/org/sonar/python/types/v2/ModuleTypeTest.java`](diffhunk://#diff-a59f46228ae33d2f248ece3d419c2f83840c480615bc7f131b37dbe25fb3aea2R55-R64): Introduced new tests to verify the fully qualified names of modules.
* [`python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java`](diffhunk://#diff-c266c1be236246e9eb1a683d3fcef5c4d526ce834c4db01d39614c7cf73b3ee2L56-R56): Modified utility methods to accommodate the new `fullyQualifiedModuleName` parameter.

These changes collectively enhance the handling of fully qualified names and improve the robustness of type inference in the Python plugin.