### PR TITLE
NO-JIRA: Updated protobuf library version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <sonar-analyzer-commons.version>2.13.0.3004</sonar-analyzer-commons.version>
     <sonarlint-core.version>8.18.0.70939</sonarlint-core.version>
     <sslr.version>1.23</sslr.version>
-    <protobuf.version>3.25.1</protobuf.version>
+    <protobuf.version>3.25.5</protobuf.version>
     <woodstox.version>6.2.7</woodstox.version>
     <gson.version>2.8.9</gson.version>
 


### PR DESCRIPTION
This update should fix the ws alert without any changes to the outcome of typeshed serialization