### PR TITLE
SONARPY-2170 Support detailed return types in Descriptor model

### DIFF
--- a/python-checks/src/test/resources/checks/nonCallableCalled.py
+++ b/python-checks/src/test/resources/checks/nonCallableCalled.py
@@ -388,3 +388,14 @@ def fp_typed_dict():
     # TypedDict is defined as "TypedDict: object" in typing_extensions.pyi
     # Despite actually being a function
     x = TypedDict('x', {'a': int, 'b': str}) # Noncompliant
+
+
+def function_type_is_callable():
+    import unittest
+    # unittest.skip() returns a Callable
+    unittest.skip("reason")() # OK
+
+
+def object_typevar():
+    scheduled = []
+    scheduled.pop()()  # OK

--- a/python-checks/src/test/resources/checks/use_of_empty_return_value.py
+++ b/python-checks/src/test/resources/checks/use_of_empty_return_value.py
@@ -67,3 +67,13 @@ def import_in_different_branch():
         import fcntl
     def lock():
         ret = fcntl.flock(..., ...)  # Noncompliant
+
+
+
+def smth():
+    import sys
+    options = trial.Options()
+    options.parseOptions(["--coverage"])
+    self.addCleanup(sys.settrace, sys.gettrace())
+    self.assertEqual(sys.gettrace(), options.tracer.globaltrace)
+

--- a/python-frontend/src/main/java/org/sonar/python/index/FunctionDescriptor.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/FunctionDescriptor.java
@@ -39,9 +39,18 @@ public class FunctionDescriptor implements Descriptor {
   private final LocationInFile definitionLocation;
   @Nullable
   private final String annotatedReturnTypeName;
+  @Nullable
+  private final TypeAnnotationDescriptor typeAnnotationDescriptor;
+
 
   public FunctionDescriptor(String name, @Nullable String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
     boolean isInstanceMethod, List<String> decorators, boolean hasDecorators, @Nullable LocationInFile definitionLocation, @Nullable String annotatedReturnTypeName) {
+    this(name, fullyQualifiedName, parameters, isAsynchronous, isInstanceMethod, decorators, hasDecorators, definitionLocation, annotatedReturnTypeName, null);
+  }
+
+  public FunctionDescriptor(String name, @Nullable String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
+    boolean isInstanceMethod, List<String> decorators, boolean hasDecorators, @Nullable LocationInFile definitionLocation,
+    @Nullable String annotatedReturnTypeName, @Nullable TypeAnnotationDescriptor typeAnnotationDescriptor) {
 
     this.name = name;
     this.fullyQualifiedName = fullyQualifiedName;
@@ -52,6 +61,7 @@ public class FunctionDescriptor implements Descriptor {
     this.hasDecorators = hasDecorators;
     this.definitionLocation = definitionLocation;
     this.annotatedReturnTypeName = annotatedReturnTypeName;
+    this.typeAnnotationDescriptor = typeAnnotationDescriptor;
   }
 
   @Override
@@ -97,6 +107,11 @@ public class FunctionDescriptor implements Descriptor {
   @CheckForNull
   public String annotatedReturnTypeName() {
     return annotatedReturnTypeName;
+  }
+
+  @CheckForNull
+  public TypeAnnotationDescriptor typeAnnotationDescriptor() {
+    return typeAnnotationDescriptor;
   }
 
   public static class Parameter  {
@@ -172,6 +187,7 @@ public class FunctionDescriptor implements Descriptor {
     private boolean hasDecorators = false;
     private LocationInFile definitionLocation = null;
     private String annotatedReturnTypeName = null;
+    private TypeAnnotationDescriptor typeAnnotationDescriptor = null;
 
     public FunctionDescriptorBuilder withName(String name) {
       this.name = name;
@@ -218,9 +234,14 @@ public class FunctionDescriptor implements Descriptor {
       return this;
     }
 
+    public FunctionDescriptorBuilder withTypeAnnotationDescriptor(@Nullable TypeAnnotationDescriptor typeAnnotationDescriptor) {
+      this.typeAnnotationDescriptor = typeAnnotationDescriptor;
+      return this;
+    }
+
     public FunctionDescriptor build() {
       return new FunctionDescriptor(name, fullyQualifiedName, parameters, isAsynchronous, isInstanceMethod, decorators,
-        hasDecorators, definitionLocation, annotatedReturnTypeName);
+        hasDecorators, definitionLocation, annotatedReturnTypeName, typeAnnotationDescriptor);
     }
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/index/TypeAnnotationDescriptor.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/TypeAnnotationDescriptor.java
@@ -1,0 +1,72 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.index;
+
+import java.util.List;
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+public class TypeAnnotationDescriptor {
+
+  String prettyPrintedName;
+  TypeKind kind;
+  List<TypeAnnotationDescriptor> args;
+  String fullyQualifiedName;
+
+  public TypeAnnotationDescriptor(String prettyPrintedName, TypeKind kind, List<TypeAnnotationDescriptor> args, @Nullable String fullyQualifiedName) {
+    this.prettyPrintedName = prettyPrintedName;
+    this.kind = kind;
+    this.args = args;
+    this.fullyQualifiedName = fullyQualifiedName;
+  }
+
+  public String prettyPrintedName() {
+    return prettyPrintedName;
+  }
+
+  public TypeKind kind() {
+    return kind;
+  }
+
+  public List<TypeAnnotationDescriptor> args() {
+    return args;
+  }
+
+  @CheckForNull
+  public String fullyQualifiedName() {
+    return fullyQualifiedName;
+  }
+
+  public enum TypeKind {
+    INSTANCE,
+    UNION,
+    TYPE,
+    TUPLE,
+    TYPE_VAR,
+    ANY,
+    NONE,
+    TYPE_ALIAS,
+    CALLABLE,
+    LITERAL,
+    UNINHABITED,
+    UNBOUND,
+    TYPED_DICT
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/FunctionDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/FunctionDescriptorToPythonTypeConverter.java
@@ -32,9 +32,11 @@ import org.sonar.python.types.v2.TypeUtils;
 public class FunctionDescriptorToPythonTypeConverter implements DescriptorToPythonTypeConverter {
 
   private final ParameterConverter parameterConverter;
+  private final TypeAnnotationToPythonTypeConverter typeAnnotationConverter;
 
   public FunctionDescriptorToPythonTypeConverter() {
     parameterConverter = new ParameterConverter();
+    typeAnnotationConverter = new TypeAnnotationToPythonTypeConverter();
   }
 
   public PythonType convert(ConversionContext ctx, FunctionDescriptor from) {
@@ -43,8 +45,8 @@ public class FunctionDescriptorToPythonTypeConverter implements DescriptorToPyth
       .map(parameter -> parameterConverter.convert(ctx, parameter))
       .toList();
 
-    var returnType = Optional.ofNullable(from.annotatedReturnTypeName())
-      .map(fqn -> (PythonType) ctx.lazyTypesContext().getOrCreateLazyType(fqn))
+    PythonType returnType = Optional.ofNullable(from.typeAnnotationDescriptor())
+      .map(typeAnnotation -> typeAnnotationConverter.convert(ctx, typeAnnotation))
       .map(TypeUtils::ensureWrappedObjectType)
       .orElse(PythonType.UNKNOWN);
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/TypeAnnotationToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/TypeAnnotationToPythonTypeConverter.java
@@ -1,0 +1,90 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.semantic.v2.converter;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.sonar.python.index.TypeAnnotationDescriptor;
+import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.UnionType;
+
+public class TypeAnnotationToPythonTypeConverter {
+
+  public PythonType convert(ConversionContext context, TypeAnnotationDescriptor type) {
+    switch (type.kind()) {
+      case INSTANCE:
+        String fullyQualifiedName = type.fullyQualifiedName();
+        if (fullyQualifiedName == null) {
+          return PythonType.UNKNOWN;
+        }
+        // _SpecialForm is the type used for some special types, like Callable, Union, TypeVar, ...
+        // It comes from CPython impl: https://github.com/python/cpython/blob/e39ae6bef2c357a88e232dcab2e4b4c0f367544b/Lib/typing.py#L439
+        // This doesn't seem to be very precisely specified in typeshed, because it has special semantic.
+        // To avoid FPs, we treat it as ANY
+        if ("typing._SpecialForm".equals(fullyQualifiedName)) {
+          return PythonType.UNKNOWN;
+        }
+        return fullyQualifiedName.isEmpty() ? PythonType.UNKNOWN : context.lazyTypesContext().getOrCreateLazyType(fullyQualifiedName);
+      case TYPE:
+        return context.lazyTypesContext().getOrCreateLazyType("type");
+      case TYPE_ALIAS:
+        return convert(context, type.args().get(0));
+      case CALLABLE:
+        // this should be handled as a function type - see SONARPY-953
+        return context.lazyTypesContext().getOrCreateLazyType("function");
+      case UNION:
+        return UnionType.or(type.args().stream().map(t -> convert(context, t)).toList());
+      case TUPLE:
+        return context.lazyTypesContext().getOrCreateLazyType("tuple");
+      case NONE:
+        return context.lazyTypesContext().getOrCreateLazyType("NoneType");
+      case TYPED_DICT:
+        // SONARPY-2179: This case only makes sense for parameter types, which are not supported yet
+        return context.lazyTypesContext().getOrCreateLazyType("dict");
+      case TYPE_VAR:
+        return Optional.of(type)
+          .filter(TypeAnnotationToPythonTypeConverter::filterTypeVar)
+          .map(TypeAnnotationDescriptor::fullyQualifiedName)
+          .map(context.lazyTypesContext()::getOrCreateLazyType)
+          .map(PythonType.class::cast)
+          .orElse(PythonType.UNKNOWN);
+      default:
+        return PythonType.UNKNOWN;
+    }
+  }
+
+  private static final Set<String> EXCLUDING_TYPE_VAR_FQN_PATTERNS = Set.of(
+    "object",
+    "^builtins\\.object$",
+    // ref: SONARPY-1477
+    "^_ctypes\\._CanCastTo$");
+
+  public static boolean filterTypeVar(TypeAnnotationDescriptor type) {
+    return Optional.of(type)
+      // Filtering self returning methods until the SONARPY-1472 will be solved
+      .filter(Predicate.not(t -> t.prettyPrintedName().endsWith(".Self")))
+      .map(TypeAnnotationDescriptor::fullyQualifiedName)
+      .filter(Predicate.not(String::isEmpty))
+      // We ignore TypeVar referencing "builtins.object" or "object" to avoid false positives
+      .filter(fqn -> EXCLUDING_TYPE_VAR_FQN_PATTERNS.stream().noneMatch(fqn::matches))
+      .isPresent();
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/TypeAnnotationToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/TypeAnnotationToPythonTypeConverter.java
@@ -22,9 +22,10 @@ package org.sonar.python.semantic.v2.converter;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.sonar.python.index.TypeAnnotationDescriptor;
+import org.sonar.python.types.v2.LazyUnionType;
 import org.sonar.python.types.v2.PythonType;
-import org.sonar.python.types.v2.UnionType;
 
 public class TypeAnnotationToPythonTypeConverter {
 
@@ -51,7 +52,7 @@ public class TypeAnnotationToPythonTypeConverter {
         // this should be handled as a function type - see SONARPY-953
         return context.lazyTypesContext().getOrCreateLazyType("function");
       case UNION:
-        return UnionType.or(type.args().stream().map(t -> convert(context, t)).toList());
+        return new LazyUnionType(type.args().stream().map(t -> convert(context, t)).collect(Collectors.toSet()));
       case TUPLE:
         return context.lazyTypesContext().getOrCreateLazyType("tuple");
       case NONE:

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/FunctionSymbolToDescriptorConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/FunctionSymbolToDescriptorConverter.java
@@ -22,14 +22,17 @@ package org.sonar.python.semantic.v2.typeshed;
 import java.util.Collection;
 import java.util.Optional;
 import org.sonar.python.index.FunctionDescriptor;
+import org.sonar.python.index.TypeAnnotationDescriptor;
 import org.sonar.python.types.protobuf.SymbolsProtos;
 
 public class FunctionSymbolToDescriptorConverter {
 
   private final ParameterSymbolToDescriptorConverter parameterConverter;
+  private final TypeSymbolToDescriptorConverter typeConverter;
 
   public FunctionSymbolToDescriptorConverter() {
     parameterConverter = new ParameterSymbolToDescriptorConverter();
+    typeConverter = new TypeSymbolToDescriptorConverter();
   }
 
   public FunctionDescriptor convert(SymbolsProtos.FunctionSymbol functionSymbol) {
@@ -38,7 +41,12 @@ public class FunctionSymbolToDescriptorConverter {
 
   public FunctionDescriptor convert(SymbolsProtos.FunctionSymbol functionSymbol, boolean isParentIsAClass) {
     var fullyQualifiedName = TypeShedUtils.normalizedFqn(functionSymbol.getFullyQualifiedName());
-    var returnType = TypeShedUtils.getTypesNormalizedFqn(functionSymbol.getReturnAnnotation());
+    TypeAnnotationDescriptor typeAnnotationDescriptor = null;
+    if (functionSymbol.hasReturnAnnotation()) {
+      SymbolsProtos.Type returnAnnotation = functionSymbol.getReturnAnnotation();
+      typeAnnotationDescriptor = typeConverter.convert(returnAnnotation);
+    }
+    String returnType = TypeShedUtils.getTypesNormalizedFqn(functionSymbol.getReturnAnnotation());
     var decorators = Optional.of(functionSymbol)
       .map(SymbolsProtos.FunctionSymbol::getResolvedDecoratorNamesList)
       .stream()
@@ -56,9 +64,9 @@ public class FunctionSymbolToDescriptorConverter {
       .withIsInstanceMethod(isInstanceMethod)
       .withHasDecorators(functionSymbol.getHasDecorators())
       .withAnnotatedReturnTypeName(returnType)
+      .withTypeAnnotationDescriptor(typeAnnotationDescriptor)
       .withDecorators(decorators)
       .withParameters(parameters)
       .build();
   }
-
 }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/TypeSymbolToDescriptorConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/TypeSymbolToDescriptorConverter.java
@@ -1,0 +1,40 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.semantic.v2.typeshed;
+
+import java.util.List;
+import org.sonar.python.index.TypeAnnotationDescriptor;
+import org.sonar.python.types.protobuf.SymbolsProtos;
+
+public class TypeSymbolToDescriptorConverter {
+
+  TypeAnnotationDescriptor convert(SymbolsProtos.Type type) {
+    List<TypeAnnotationDescriptor> args = type.getArgsList().stream()
+      .map(this::convert)
+      .toList();
+    TypeAnnotationDescriptor.TypeKind kind = TypeAnnotationDescriptor.TypeKind.valueOf(type.getKind().name());
+    String normalizedFqn = TypeShedUtils.normalizedFqn(type.getFullyQualifiedName());
+    return new TypeAnnotationDescriptor(
+      type.getPrettyPrintedName(),
+      kind,
+      args,
+      normalizedFqn);
+  }
+}

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
@@ -188,6 +188,10 @@ public final class ClassType implements PythonType {
       // TODO: instances of NamedTuple are type
       return TriBool.TRUE;
     }
+    if ("function".equals(this.name) && "__call__".equals(memberName)) {
+      // __call__ is not formally defined on function, but is present
+      return TriBool.TRUE;
+    }
     return resolveMember(memberName).isPresent() ? TriBool.TRUE : TriBool.FALSE;
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyType.java
@@ -26,7 +26,7 @@ import java.util.function.Consumer;
 import org.sonar.plugins.python.api.LocationInFile;
 import org.sonar.python.semantic.v2.LazyTypesContext;
 
-public class LazyType implements PythonType {
+public class LazyType implements PythonType, ResolvableType {
 
   String fullyQualifiedName;
   private final Queue<Consumer<PythonType>> consumers;

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
@@ -19,23 +19,25 @@
  */
 package org.sonar.python.types.v2;
 
-public class TypeUtils {
+import java.util.HashSet;
+import java.util.Set;
 
-  private TypeUtils() {
+public class LazyUnionType implements PythonType, ResolvableType {
 
+  Set<PythonType> candidates;
+
+  public LazyUnionType(Set<PythonType> candidates) {
+    this.candidates = candidates;
   }
 
-  static PythonType resolved(PythonType pythonType) {
-    if (pythonType instanceof ResolvableType resolvableType) {
-      return resolvableType.resolve();
+  public PythonType resolve() {
+    Set<PythonType> resolvedCandidates = new HashSet<>();
+    for (PythonType candidate : candidates) {
+      if (candidate instanceof LazyType lazyType) {
+        candidate = lazyType.resolve();
+      }
+      resolvedCandidates.add(candidate);
     }
-    return pythonType;
-  }
-
-  public static PythonType ensureWrappedObjectType(PythonType pythonType) {
-    if (!(pythonType instanceof ObjectType)) {
-      return new ObjectType(pythonType);
-    }
-    return pythonType;
+    return new UnionType(resolvedCandidates);
   }
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ResolvableType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ResolvableType.java
@@ -19,23 +19,6 @@
  */
 package org.sonar.python.types.v2;
 
-public class TypeUtils {
-
-  private TypeUtils() {
-
-  }
-
-  static PythonType resolved(PythonType pythonType) {
-    if (pythonType instanceof ResolvableType resolvableType) {
-      return resolvableType.resolve();
-    }
-    return pythonType;
-  }
-
-  public static PythonType ensureWrappedObjectType(PythonType pythonType) {
-    if (!(pythonType instanceof ObjectType)) {
-      return new ObjectType(pythonType);
-    }
-    return pythonType;
-  }
+public interface ResolvableType {
+  PythonType resolve();
 }

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeWrapper.java
@@ -26,6 +26,9 @@ public interface TypeWrapper {
   TypeWrapper UNKNOWN_TYPE_WRAPPER = new SimpleTypeWrapper(PythonType.UNKNOWN);
 
   static TypeWrapper of(PythonType type) {
-    return type instanceof LazyType ? new LazyTypeWrapper(type) : new SimpleTypeWrapper(type);
+    if (type instanceof ResolvableType) {
+      return new LazyTypeWrapper(type);
+    }
+    return new SimpleTypeWrapper(type);
   }
 }

--- a/python-frontend/src/test/java/org/sonar/python/index/FunctionDescriptorTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/index/FunctionDescriptorTest.java
@@ -23,7 +23,6 @@ package org.sonar.python.index;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.symbols.FunctionSymbol;
 
@@ -33,7 +32,6 @@ import static org.sonar.python.index.DescriptorToProtobufTestUtils.assertDescrip
 import static org.sonar.python.index.DescriptorsToProtobuf.fromProtobuf;
 import static org.sonar.python.index.DescriptorsToProtobuf.toProtobuf;
 import static org.sonar.python.index.DescriptorUtils.descriptor;
-import static org.sonar.python.index.DescriptorsToProtobuf.toProtobufModuleDescriptor;
 
 class FunctionDescriptorTest {
 

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2366,6 +2366,18 @@ class TypeInferenceV2Test {
   }
 
   @Test
+  void returnTypeOfTypeshedSymbol() {
+    FileInput fileInput = inferTypes("""
+      from sys import gettrace
+      gettrace
+      """);
+    FunctionType functionType = ((FunctionType) ((ExpressionStatement) fileInput.statements().statements().get(1)).expressions().get(0).typeV2());
+    PythonType returnType = functionType.returnType();
+    // TODO: Missing assertions
+    assertThat(returnType.unwrappedType()).isInstanceOf(UnionType.class);
+  }
+
+  @Test
   void isInstanceTests() {
     var xType = lastExpression("""
       def foo(x: int):

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2373,8 +2373,8 @@ class TypeInferenceV2Test {
       """);
     FunctionType functionType = ((FunctionType) ((ExpressionStatement) fileInput.statements().statements().get(1)).expressions().get(0).typeV2());
     PythonType returnType = functionType.returnType();
-    // TODO: Missing assertions
-    assertThat(returnType.unwrappedType()).isInstanceOf(UnionType.class);
+    UnionType unionType = (UnionType) returnType.unwrappedType();
+    assertThat(unionType.candidates()).extracting(PythonType::name).containsExactlyInAnyOrder("function", "NoneType");
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
@@ -29,6 +29,7 @@ import org.sonar.python.index.AmbiguousDescriptor;
 import org.sonar.python.index.ClassDescriptor;
 import org.sonar.python.index.Descriptor;
 import org.sonar.python.index.FunctionDescriptor;
+import org.sonar.python.index.TypeAnnotationDescriptor;
 import org.sonar.python.index.VariableDescriptor;
 import org.sonar.python.semantic.v2.ClassTypeBuilder;
 import org.sonar.python.semantic.v2.LazyTypesContext;
@@ -164,6 +165,12 @@ class DescriptorToPythonTypeConverterTest {
     Mockito.when(descriptor.kind()).thenReturn(Descriptor.Kind.FUNCTION);
     Mockito.when(descriptor.name()).thenReturn("Sample");
     Mockito.when(descriptor.annotatedReturnTypeName()).thenReturn(returnTypeName);
+
+    TypeAnnotationDescriptor typeAnnotationDescriptor = Mockito.mock(TypeAnnotationDescriptor.class);
+    Mockito.when(typeAnnotationDescriptor.kind()).thenReturn(TypeAnnotationDescriptor.TypeKind.INSTANCE);
+    Mockito.when(typeAnnotationDescriptor.fullyQualifiedName()).thenReturn(returnTypeName);
+    Mockito.when(descriptor.typeAnnotationDescriptor()).thenReturn(typeAnnotationDescriptor);
+
     Mockito.when(descriptor.parameters()).thenReturn(List.of(
       new FunctionDescriptor.Parameter(
         "p1",

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/LazyUnionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/LazyUnionTypeTest.java
@@ -1,0 +1,43 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.sonar.python.semantic.v2.LazyTypesContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+import static org.sonar.python.types.v2.TypesTestUtils.FLOAT_TYPE;
+import static org.sonar.python.types.v2.TypesTestUtils.INT_TYPE;
+
+class LazyUnionTypeTest {
+
+  @Test
+  void lazyUnionTypeResolvesNestedLazyTypesWhenAccessed() {
+    LazyTypesContext lazyTypesContext = Mockito.mock(LazyTypesContext.class);
+    when(lazyTypesContext.resolveLazyType(Mockito.any())).thenReturn(INT_TYPE);
+    LazyType lazyType = new LazyType("random", lazyTypesContext);
+    LazyUnionType lazyUnionType = new LazyUnionType(Set.of(lazyType, FLOAT_TYPE));
+    UnionType unionType = (UnionType) lazyUnionType.resolve();
+    assertThat(unionType.candidates()).containsExactlyInAnyOrder(INT_TYPE, FLOAT_TYPE);
+  }
+}

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
@@ -171,6 +171,13 @@ class ObjectTypeTest {
   }
 
   @Test
+  void function_is_callable() {
+      ClassType classType = new ClassType("function");
+      assertThat(classType.instancesHaveMember("__call__")).isEqualTo(TriBool.TRUE);
+      assertThat(classType.instancesHaveMember("other")).isEqualTo(TriBool.FALSE);
+  }
+
+  @Test
   void objectType_of_unknown() {
     // TODO SONARPY-1875: Ensure this is the behavior we want (do we even want it possible to have object of unknown? Maybe replace with UnionType when implemented
     ObjectType objectType = new ObjectType(PythonType.UNKNOWN, List.of(), List.of());


### PR DESCRIPTION
This change is a bit rough, in the sense that the `FunctionDescriptor` model can now hold 2 representations of return type. One is `annotatedReturnTypeName`, as a `String`, which historically has been used for locally defined functions. The other is `TypeAnnotationDescriptor` which is a representation that is closer to our protobuf model used for Typeshed symbols. 

Note: only return types are taken care of in the PR. SONARPY-2179 has been created to handle parameters as well.