### PR TITLE
SONARPY-2188 Introduce UnresolvedImportedType

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/types/v2/UnresolvedImportType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/UnresolvedImportType.java
@@ -1,0 +1,29 @@
+/*
+ * SonarQube Python Plugin
+ * Copyright (C) 2011-2024 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+package org.sonar.python.types.v2;
+
+public record UnresolvedImportType(String importedPath) implements PythonType{
+  @Override
+  public String toString() {
+    return "UnresolvedImportType{" +
+      "importName='" + importedPath + '\'' +
+      '}';
+  }
+}

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2419,7 +2419,7 @@ class TypeInferenceV2Test {
       import opentracing.tracer.Tracer as ottt
       ottt
       """);
-    assertThat(statement.typeV2()).isInstanceOf(UnknownType.class);
+    assertThat(statement.typeV2()).isInstanceOf(UnresolvedImportType.class);
   }
 
   @Test


### PR DESCRIPTION
This pull request introduces a new `UnresolvedImportType` to handle unknown imports in Python files and updates the type inference logic accordingly. Additionally, it includes several test updates to verify the new behavior.

### Type Inference Enhancements:

* Added `UnresolvedImportType` class to handle unresolved imports. (`python-frontend/src/main/java/org/sonar/python/types/v2/UnresolvedImportType.java`)
* Updated `TrivialTypeInferenceVisitor` to set `UnresolvedImportType` for unknown imports. (`python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java`) [[1]](diffhunk://#diff-edd371feac3d157599dedc38debd59d2507df3152d55b8784600e47d59c52fd8R85-R86) [[2]](diffhunk://#diff-edd371feac3d157599dedc38debd59d2507df3152d55b8784600e47d59c52fd8L310-R313) [[3]](diffhunk://#diff-edd371feac3d157599dedc38debd59d2507df3152d55b8784600e47d59c52fd8R324-R334) [[4]](diffhunk://#diff-edd371feac3d157599dedc38debd59d2507df3152d55b8784600e47d59c52fd8R360-R364)

### Test Updates:

* Modified tests to assert the new `UnresolvedImportType` behavior. (`python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java`) [[1]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL146-R153) [[2]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL212-R216) [[3]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL228-R235)
* Replaced `Assertions.assertThat` with `assertThat` for consistency. (`python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java`) [[1]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL29) [[2]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL94-R94) [[3]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL323-R327) [[4]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL337-R341) [[5]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL352-R356) [[6]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL364-R368) [[7]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL459-R463) [[8]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL472-R476) [[9]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL485-R490) [[10]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL499-R505) [[11]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL515-R519) [[12]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL527-R531) [[13]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL540-R544) [[14]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL554-R558) [[15]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL574-R579) [[16]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL589-R593) [[17]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL819-R829) [[18]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL836-R840) [[19]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL853-R863)