### PR TITLE
SONARPY-2110 Make the ProjectLevelSymbolTable return the Descriptor model instead of the v1 Symbol model

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
@@ -164,6 +164,11 @@ public class ProjectLevelSymbolTable {
       .map(desc -> DescriptorUtils.symbolFromDescriptor(desc, this, null, createdSymbolsByDescriptor, createdSymbolsByFqn)).collect(Collectors.toSet());
   }
 
+  @CheckForNull
+  public Set<Descriptor> getDescriptorsFromModule(@Nullable String moduleName) {
+    return globalDescriptorsByModuleName.get(moduleName);
+  }
+
   public Map<String, Set<String>> importsByModule() {
     return Collections.unmodifiableMap(importsByModule);
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java
@@ -19,52 +19,34 @@
  */
 package org.sonar.python.semantic.v2;
 
-import java.util.ArrayDeque;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
-import org.sonar.plugins.python.api.symbols.AmbiguousSymbol;
-import org.sonar.plugins.python.api.symbols.ClassSymbol;
-import org.sonar.plugins.python.api.symbols.FunctionSymbol;
-import org.sonar.plugins.python.api.symbols.Symbol;
-import org.sonar.python.semantic.ClassSymbolImpl;
-import org.sonar.python.semantic.FunctionSymbolImpl;
+import org.sonar.python.index.Descriptor;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.v2.converter.AnyDescriptorToPythonTypeConverter;
-import org.sonar.python.types.v2.ClassType;
-import org.sonar.python.types.v2.FunctionType;
-import org.sonar.python.types.v2.LazyTypeWrapper;
-import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.ModuleType;
-import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
 import org.sonar.python.types.v2.TypeOrigin;
-import org.sonar.python.types.v2.TypeWrapper;
-import org.sonar.python.types.v2.UnionType;
 
 public class SymbolsModuleTypeProvider {
-  public static final String OBJECT_TYPE_FQN = "object";
   private final ProjectLevelSymbolTable projectLevelSymbolTable;
   private final ModuleType rootModule;
   private final LazyTypesContext lazyTypesContext;
-  private final AnyDescriptorToPythonTypeConverter anyDescriptorToPythonTypeConverter;
+  private final AnyDescriptorToPythonTypeConverter stubsDescriptorToPythonTypeConverter;
+  private final AnyDescriptorToPythonTypeConverter projectDescriptorToPythonTypeConverter;
 
   public SymbolsModuleTypeProvider(ProjectLevelSymbolTable projectLevelSymbolTable, LazyTypesContext lazyTypeContext) {
     this.projectLevelSymbolTable = projectLevelSymbolTable;
     this.lazyTypesContext = lazyTypeContext;
-    this.anyDescriptorToPythonTypeConverter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
+    this.stubsDescriptorToPythonTypeConverter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.STUB);
+    this.projectDescriptorToPythonTypeConverter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
 
     var rootModuleMembers = projectLevelSymbolTable.typeShedDescriptorsProvider().builtinDescriptors()
       .entrySet()
       .stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> anyDescriptorToPythonTypeConverter.convert(e.getValue())));
+      .collect(Collectors.toMap(Map.Entry::getKey, e -> stubsDescriptorToPythonTypeConverter.convert(e.getValue())));
     this.rootModule = new ModuleType(null, null, rootModuleMembers);
   }
 
@@ -88,147 +70,20 @@ public class SymbolsModuleTypeProvider {
   }
 
   private Optional<ModuleType> createModuleTypeFromProjectLevelSymbolTable(String moduleName, String moduleFqn, ModuleType parent) {
-    return Optional.ofNullable(projectLevelSymbolTable.getSymbolsFromModule(moduleFqn))
-      .map(projectModuleSymbols -> createModuleFromSymbols(moduleName, parent, projectModuleSymbols));
+    var retrieved = projectLevelSymbolTable.getDescriptorsFromModule(moduleFqn);
+    if (retrieved == null) {
+      return Optional.empty();
+    }
+    var members = retrieved.stream().collect(Collectors.toMap(Descriptor::name, projectDescriptorToPythonTypeConverter::convert));
+    return Optional.of(new ModuleType(moduleName, parent, members));
   }
 
   private Optional<ModuleType> createModuleTypeFromTypeShed(String moduleName, String moduleFqn, ModuleType parent) {
     var moduleMembers = projectLevelSymbolTable.typeShedDescriptorsProvider().descriptorsForModule(moduleFqn)
       .entrySet().stream()
-      .collect(Collectors.toMap(Map.Entry::getKey, e -> anyDescriptorToPythonTypeConverter.convert(e.getValue())));
+      .collect(Collectors.toMap(Map.Entry::getKey, e -> stubsDescriptorToPythonTypeConverter.convert(e.getValue())));
     return Optional.of(moduleMembers).filter(m -> !m.isEmpty())
       .map(m -> new ModuleType(moduleName, parent, m));
   }
 
-  private ModuleType createModuleFromSymbols(@Nullable String name, @Nullable ModuleType parent, Collection<Symbol> symbols) {
-    var members = new HashMap<String, PythonType>();
-    Map<Symbol, PythonType> createdTypesBySymbol = new HashMap<>();
-    symbols.forEach(symbol -> {
-      var type = convertToType(symbol, createdTypesBySymbol);
-      members.put(symbol.name(), type);
-    });
-    var module = new ModuleType(name, parent);
-    module.members().putAll(members);
-
-    Optional.ofNullable(parent)
-      .map(ModuleType::members)
-      .ifPresent(m -> m.put(name, module));
-
-    return module;
-  }
-
-  private PythonType convertToFunctionType(FunctionSymbol symbol, Map<Symbol, PythonType> createdTypesBySymbol) {
-    if (createdTypesBySymbol.containsKey(symbol)) {
-      return createdTypesBySymbol.get(symbol);
-    }
-
-    var parameters = symbol.parameters()
-      .stream()
-      .map(this::convertParameter)
-      .toList();
-
-    var returnType = PythonType.UNKNOWN;
-
-    TypeOrigin typeOrigin = symbol.isStub() ? TypeOrigin.STUB : TypeOrigin.LOCAL;
-
-    FunctionTypeBuilder functionTypeBuilder =
-      new FunctionTypeBuilder(symbol.name())
-        .withAttributes(List.of())
-        .withParameters(parameters)
-        .withReturnType(returnType)
-        .withTypeOrigin(typeOrigin)
-        .withAsynchronous(symbol.isAsynchronous())
-        .withHasDecorators(symbol.hasDecorators())
-        .withInstanceMethod(symbol.isInstanceMethod())
-        .withHasVariadicParameter(symbol.hasVariadicParameter())
-        .withDefinitionLocation(symbol.definitionLocation());
-    FunctionType functionType = functionTypeBuilder.build();
-    createdTypesBySymbol.put(symbol, functionType);
-    return functionType;
-  }
-
-  PythonType resolvePossibleLazyType(String fullyQualifiedName) {
-    if (rootModule == null) {
-      // If root module has not been created yet, return lazy type
-      return lazyTypesContext.getOrCreateLazyType(fullyQualifiedName);
-    }
-    PythonType currentType = rootModule;
-    String[] fqnParts = fullyQualifiedName.split("\\.");
-    var fqnPartsQueue = new ArrayDeque<>(Arrays.asList(fqnParts));
-    while (!fqnPartsQueue.isEmpty()) {
-      var memberName = fqnPartsQueue.poll();
-      var memberOpt = currentType.resolveMember(memberName);
-      if (memberOpt.isEmpty()) {
-        if (currentType instanceof ModuleType) {
-          // The type is part of an unresolved submodule
-          // Create a lazy type for it
-          return lazyTypesContext.getOrCreateLazyType(fullyQualifiedName);
-        } else {
-          // The type is an unknown member of an already resolved type
-          // Default to UNKNOWN
-          return PythonType.UNKNOWN;
-        }
-      }
-      currentType = memberOpt.get();
-    }
-    return currentType;
-  }
-
-  private PythonType convertToClassType(ClassSymbol symbol, Map<Symbol, PythonType> createdTypesBySymbol) {
-    if (createdTypesBySymbol.containsKey(symbol)) {
-      return createdTypesBySymbol.get(symbol);
-    }
-    ClassType classType = new ClassType(symbol.name(), symbol.definitionLocation());
-    createdTypesBySymbol.put(symbol, classType);
-    Set<Member> members =
-      symbol.declaredMembers().stream().map(m -> new Member(m.name(), convertToType(m, createdTypesBySymbol))).collect(Collectors.toSet());
-    classType.members().addAll(members);
-
-    Optional.of(symbol)
-      .filter(ClassSymbolImpl.class::isInstance)
-      .map(ClassSymbolImpl.class::cast)
-      .filter(ClassSymbolImpl::shouldSearchHierarchyInTypeshed)
-      .map(ClassSymbol::superClassesFqn)
-      .map(fqns -> fqns.stream().map(this::resolvePossibleLazyType))
-      .or(() -> Optional.of(symbol)
-        .map(ClassSymbol::superClasses)
-        .map(Collection::stream)
-        .map(symbols -> symbols.map(s -> convertToType(s, createdTypesBySymbol))))
-      .stream()
-      .flatMap(Function.identity())
-      .map(LazyTypeWrapper::new)
-      .forEach(classType.superClasses()::add);
-
-    return classType;
-  }
-
-  private ParameterV2 convertParameter(FunctionSymbol.Parameter parameter) {
-    var typeWrapper = Optional.ofNullable(((FunctionSymbolImpl.ParameterImpl) parameter).annotatedTypeName())
-      .map(lazyTypesContext::getOrCreateLazyTypeWrapper)
-      .orElse(TypeWrapper.UNKNOWN_TYPE_WRAPPER);
-
-    return new ParameterV2(parameter.name(),
-      typeWrapper,
-      parameter.hasDefaultValue(),
-      parameter.isKeywordOnly(),
-      parameter.isPositionalOnly(),
-      parameter.isKeywordVariadic(),
-      parameter.isPositionalVariadic(),
-      parameter.location());
-  }
-
-  private PythonType convertToUnionType(AmbiguousSymbol ambiguousSymbol, Map<Symbol, PythonType> createdTypesBySymbol) {
-    Set<PythonType> pythonTypes = ambiguousSymbol.alternatives().stream().map(a -> convertToType(a, createdTypesBySymbol)).collect(Collectors.toSet());
-    return new UnionType(pythonTypes);
-  }
-
-  private PythonType convertToType(Symbol symbol, Map<Symbol, PythonType> createdTypesBySymbol) {
-    return switch (symbol.kind()) {
-      case CLASS -> convertToClassType((ClassSymbol) symbol, createdTypesBySymbol);
-      case FUNCTION -> convertToFunctionType((FunctionSymbol) symbol, createdTypesBySymbol);
-      case AMBIGUOUS -> convertToUnionType((AmbiguousSymbol) symbol, createdTypesBySymbol);
-      // Symbols that are neither classes or function nor ambiguous symbols whose alternatives are all classes or functions are considered of unknown type
-      case OTHER -> PythonType.UNKNOWN;
-    };
-  }
 }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AnyDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AnyDescriptorToPythonTypeConverter.java
@@ -24,25 +24,29 @@ import java.util.Map;
 import org.sonar.python.index.Descriptor;
 import org.sonar.python.semantic.v2.LazyTypesContext;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 
 public class AnyDescriptorToPythonTypeConverter {
 
   private static final DescriptorToPythonTypeConverter UNKNOWN_DESCRIPTOR_CONVERTER = new UnknownDescriptorToPythonTypeConverter();
   private final Map<Descriptor.Kind, DescriptorToPythonTypeConverter> converters;
   private final LazyTypesContext lazyTypesContext;
+  private final TypeOrigin typeOrigin;
 
-  public AnyDescriptorToPythonTypeConverter(LazyTypesContext lazyTypesContext) {
+  public AnyDescriptorToPythonTypeConverter(LazyTypesContext lazyTypesContext, TypeOrigin typeOrigin) {
     this.lazyTypesContext = lazyTypesContext;
+    this.typeOrigin = typeOrigin;
     converters = new EnumMap<>(Map.of(
       Descriptor.Kind.CLASS, new ClassDescriptorToPythonTypeConverter(),
       Descriptor.Kind.FUNCTION, new FunctionDescriptorToPythonTypeConverter(),
       Descriptor.Kind.VARIABLE, new VariableDescriptorToPythonTypeConverter(),
       Descriptor.Kind.AMBIGUOUS, new AmbiguousDescriptorToPythonTypeConverter()
     ));
+
   }
 
   public PythonType convert(Descriptor from) {
-    var ctx = new ConversionContext(lazyTypesContext, this::convert);
+    var ctx = new ConversionContext(lazyTypesContext, this::convert, typeOrigin);
     return convert(ctx, from);
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AnyDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AnyDescriptorToPythonTypeConverter.java
@@ -31,11 +31,9 @@ public class AnyDescriptorToPythonTypeConverter {
   private static final DescriptorToPythonTypeConverter UNKNOWN_DESCRIPTOR_CONVERTER = new UnknownDescriptorToPythonTypeConverter();
   private final Map<Descriptor.Kind, DescriptorToPythonTypeConverter> converters;
   private final LazyTypesContext lazyTypesContext;
-  private final TypeOrigin typeOrigin;
 
-  public AnyDescriptorToPythonTypeConverter(LazyTypesContext lazyTypesContext, TypeOrigin typeOrigin) {
+  public AnyDescriptorToPythonTypeConverter(LazyTypesContext lazyTypesContext) {
     this.lazyTypesContext = lazyTypesContext;
-    this.typeOrigin = typeOrigin;
     converters = new EnumMap<>(Map.of(
       Descriptor.Kind.CLASS, new ClassDescriptorToPythonTypeConverter(),
       Descriptor.Kind.FUNCTION, new FunctionDescriptorToPythonTypeConverter(),
@@ -45,7 +43,7 @@ public class AnyDescriptorToPythonTypeConverter {
 
   }
 
-  public PythonType convert(Descriptor from) {
+  public PythonType convert(Descriptor from, TypeOrigin typeOrigin) {
     var ctx = new ConversionContext(lazyTypesContext, this::convert, typeOrigin);
     return convert(ctx, from);
   }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/ConversionContext.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/ConversionContext.java
@@ -24,20 +24,27 @@ import java.util.Deque;
 import org.sonar.python.index.Descriptor;
 import org.sonar.python.semantic.v2.LazyTypesContext;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 
 public class ConversionContext {
   private final LazyTypesContext lazyTypesContext;
   private final DescriptorToPythonTypeConverter converter;
   private final Deque<PythonType> parents;
+  private final TypeOrigin typeOrigin;
 
-  public ConversionContext(LazyTypesContext lazyTypesContext, DescriptorToPythonTypeConverter converter) {
+  public ConversionContext(LazyTypesContext lazyTypesContext, DescriptorToPythonTypeConverter converter, TypeOrigin typeOrigin) {
     this.lazyTypesContext = lazyTypesContext;
     this.converter = converter;
     this.parents = new ArrayDeque<>();
+    this.typeOrigin = typeOrigin;
   }
 
   public LazyTypesContext lazyTypesContext() {
     return lazyTypesContext;
+  }
+
+  public TypeOrigin typeOrigin() {
+    return typeOrigin;
   }
 
   public PythonType convert(Descriptor from) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/FunctionDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/FunctionDescriptorToPythonTypeConverter.java
@@ -26,7 +26,6 @@ import org.sonar.python.index.FunctionDescriptor;
 import org.sonar.python.semantic.v2.FunctionTypeBuilder;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
-import org.sonar.python.types.v2.TypeOrigin;
 import org.sonar.python.types.v2.TypeUtils;
 
 public class FunctionDescriptorToPythonTypeConverter implements DescriptorToPythonTypeConverter {
@@ -50,7 +49,7 @@ public class FunctionDescriptorToPythonTypeConverter implements DescriptorToPyth
       .map(TypeUtils::ensureWrappedObjectType)
       .orElse(PythonType.UNKNOWN);
 
-    var typeOrigin = TypeOrigin.STUB;
+    var typeOrigin = ctx.typeOrigin();
 
     var hasVariadicParameter = hasVariadicParameter(parameters);
 

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -722,7 +722,7 @@ class TypeInferenceV2Test {
     assertThat(fooType.parameters().get(0).declaredType().type().unwrappedType()).isEqualTo(intType);
 
     FunctionType foo2Type = (FunctionType) ((ExpressionStatement) fileInput.statements().statements().get(2)).expressions().get(0).typeV2();
-    assertThat(foo2Type.parameters()).extracting(ParameterV2::declaredType).extracting(TypeWrapper::type).containsExactly(dictType, aType);
+    assertThat(foo2Type.parameters()).extracting(ParameterV2::declaredType).extracting(TypeWrapper::type).extracting(PythonType::unwrappedType).containsExactly(dictType, aType);
     assertThat(foo2Type.parameters()).extracting(ParameterV2::location).containsExactly(
       new LocationInFile(modFileId, 3, 9, 3, 17),
       new LocationInFile(modFileId, 3, 19, 3, 24));
@@ -2321,7 +2321,7 @@ class TypeInferenceV2Test {
 
     ClassSymbol symbol = Mockito.mock(ClassSymbolImpl.class);
     Mockito.when(symbol.kind()).thenReturn(Symbol.Kind.OTHER);
-    assertThat(symbolsModuleTypeProvider.resolvePossibleLazyType("typing.Iterable.unknown")).isEqualTo(PythonType.UNKNOWN);
+    assertThat(PROJECT_LEVEL_TYPE_TABLE.lazyTypesContext().getOrCreateLazyType("typing.Iterable.unknown").resolve()).isEqualTo(PythonType.UNKNOWN);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/ConversionContextTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/ConversionContextTest.java
@@ -25,6 +25,7 @@ import org.mockito.Mockito;
 import org.sonar.python.index.Descriptor;
 import org.sonar.python.semantic.v2.LazyTypesContext;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 
 class ConversionContextTest {
 
@@ -32,7 +33,7 @@ class ConversionContextTest {
   void lazyTypeContextTest() {
     var expectedLazyTypeContext = Mockito.mock(LazyTypesContext.class);
     var rootConverter = Mockito.mock(DescriptorToPythonTypeConverter.class);
-    var ctx = new ConversionContext(expectedLazyTypeContext, rootConverter);
+    var ctx = new ConversionContext(expectedLazyTypeContext, rootConverter, TypeOrigin.LOCAL);
     var lazyTypesContext = ctx.lazyTypesContext();
     Assertions.assertSame(expectedLazyTypeContext, lazyTypesContext);
   }
@@ -41,7 +42,7 @@ class ConversionContextTest {
   void parentsTest() {
     var expectedLazyTypeContext = Mockito.mock(LazyTypesContext.class);
     var rootConverter = Mockito.mock(DescriptorToPythonTypeConverter.class);
-    var ctx = new ConversionContext(expectedLazyTypeContext, rootConverter);
+    var ctx = new ConversionContext(expectedLazyTypeContext, rootConverter, TypeOrigin.LOCAL);
     var firstParent = Mockito.mock(PythonType.class);
     var secondParent = Mockito.mock(PythonType.class);
 
@@ -63,7 +64,7 @@ class ConversionContextTest {
 
     var lazyTypeContext = Mockito.mock(LazyTypesContext.class);
     var rootConverter = Mockito.mock(DescriptorToPythonTypeConverter.class);
-    var ctx = new ConversionContext(lazyTypeContext, rootConverter);
+    var ctx = new ConversionContext(lazyTypeContext, rootConverter, TypeOrigin.LOCAL);
 
     Mockito.when(rootConverter.convert(ctx, descriptor))
       .thenReturn(expectedType);

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
@@ -41,6 +41,7 @@ import org.sonar.python.types.v2.Member;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.ParameterV2;
 import org.sonar.python.types.v2.PythonType;
+import org.sonar.python.types.v2.TypeOrigin;
 import org.sonar.python.types.v2.TypeWrapper;
 import org.sonar.python.types.v2.UnionType;
 
@@ -59,7 +60,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void ambiguousDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
 
     var descriptorAlternative1 = Mockito.mock(FunctionDescriptor.class);
 
@@ -118,7 +119,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void classDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
     var descriptor = Mockito.mock(ClassDescriptor.class);
 
     var parentClassName = "Parent";
@@ -156,7 +157,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void functionDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
     var descriptor = Mockito.mock(FunctionDescriptor.class);
 
     var returnTypeName = "Returned";
@@ -206,7 +207,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void variableDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
     var descriptor = Mockito.mock(VariableDescriptor.class);
 
     var variableTypeName = "Returned";

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
@@ -60,7 +60,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void ambiguousDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
 
     var descriptorAlternative1 = Mockito.mock(FunctionDescriptor.class);
 
@@ -104,7 +104,7 @@ class DescriptorToPythonTypeConverterTest {
     Mockito.when(descriptor.kind()).thenReturn(Descriptor.Kind.AMBIGUOUS);
     Mockito.when(descriptor.alternatives()).thenReturn(Set.of(descriptorAlternative1, descriptorAlternative2));
 
-    var type = (UnionType) converter.convert(descriptor);
+    var type = (UnionType) converter.convert(descriptor, TypeOrigin.LOCAL);
     Assertions.assertThat(type.candidates())
       .hasSize(2);
 
@@ -119,7 +119,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void classDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
     var descriptor = Mockito.mock(ClassDescriptor.class);
 
     var parentClassName = "Parent";
@@ -141,7 +141,7 @@ class DescriptorToPythonTypeConverterTest {
     Mockito.when(lazyTypesContext.resolveLazyType(Mockito.argThat(lt -> parentClassName.equals(lt.fullyQualifiedName()))))
       .thenReturn(resolvedParent);
 
-    var type = (ClassType) converter.convert(descriptor);
+    var type = (ClassType) converter.convert(descriptor, TypeOrigin.LOCAL);
     Assertions.assertThat(type.name()).isEqualTo("Sample");
     
     Assertions.assertThat(type.superClasses())
@@ -157,7 +157,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void functionDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
     var descriptor = Mockito.mock(FunctionDescriptor.class);
 
     var returnTypeName = "Returned";
@@ -190,7 +190,7 @@ class DescriptorToPythonTypeConverterTest {
     Mockito.when(lazyTypesContext.resolveLazyType(Mockito.argThat(lt -> returnTypeName.equals(lt.fullyQualifiedName()))))
       .thenReturn(resolvedReturnType);
 
-    var type = (FunctionType) converter.convert(descriptor);
+    var type = (FunctionType) converter.convert(descriptor, TypeOrigin.LOCAL);
     Assertions.assertThat(type.name()).isEqualTo("Sample");
 
     Assertions.assertThat(type.parameters()).hasSize(1);
@@ -207,7 +207,7 @@ class DescriptorToPythonTypeConverterTest {
   @Test
   void variableDescriptorConversionTest() {
     var lazyTypesContext = Mockito.mock(LazyTypesContext.class);
-    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext, TypeOrigin.LOCAL);
+    var converter = new AnyDescriptorToPythonTypeConverter(lazyTypesContext);
     var descriptor = Mockito.mock(VariableDescriptor.class);
 
     var variableTypeName = "Returned";
@@ -223,7 +223,7 @@ class DescriptorToPythonTypeConverterTest {
     Mockito.when(lazyTypesContext.resolveLazyType(Mockito.argThat(lt -> variableTypeName.equals(lt.fullyQualifiedName()))))
       .thenReturn(resolvedVariableType);
 
-    var type = (ObjectType) converter.convert(descriptor);
+    var type = (ObjectType) converter.convert(descriptor, TypeOrigin.LOCAL);
     Assertions.assertThat(type)
       .extracting(PythonType::unwrappedType)
       .isSameAs(resolvedVariableType);


### PR DESCRIPTION
This pull request introduces several changes to the `python-frontend` module, focusing on enhancing the handling of Python type descriptors and improving type conversion mechanisms. The most important changes include the addition of a new method to retrieve descriptors from a module, updates to the `SymbolsModuleTypeProvider` class to use different type converters, and modifications to the `AnyDescriptorToPythonTypeConverter` class to handle type origins.

### Enhancements to Type Descriptor Handling:

* [`python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java`](diffhunk://#diff-b7ec63b867f8e4e30a2a2b2bc9d6f30cc63a272de1ec7d2d6795323270764a18R167-R171): Added a new method `getDescriptorsFromModule` to retrieve descriptors from a module.

### Updates to SymbolsModuleTypeProvider:

* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/SymbolsModuleTypeProvider.java`](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370L22-R50): Updated to use `stubsDescriptorToPythonTypeConverter` and `projectDescriptorToPythonTypeConverter` instead of a single `anyDescriptorToPythonTypeConverter`. This change ensures that type origins are correctly handled. [[1]](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370L22-R50) [[2]](diffhunk://#diff-768ca79d1818e5bdd6d0645830cbe0a58fb72767a54437eef94bf17face10370L91-L233)

### Modifications to Type Converters:

* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AnyDescriptorToPythonTypeConverter.java`](diffhunk://#diff-9ab2859150eb1d2ce8046c80a8f06907c18654823452a9dd1a33d040e9c48b41R27-R49): Enhanced to include `TypeOrigin` as a parameter, allowing the differentiation between stub and local types during conversion.
* [`python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/ConversionContext.java`](diffhunk://#diff-cbf8d9b5d10e51dabc8d226cf593eab2a19aff001cabb41150993634f2711b52R27-R49): Updated to store and utilize `TypeOrigin` during type conversion processes.

### Test Adjustments:

* Various test files (`ConversionContextTest`, `DescriptorToPythonTypeConverterTest`, `TypeInferenceV2Test`) were updated to reflect the changes in type conversion and ensure the correctness of the new implementations. [[1]](diffhunk://#diff-c19b02e07e0ce0cfe7e25bfee028c73cc1d2b8d11d9820f485bd7f0b139c258cL725-R725) [[2]](diffhunk://#diff-2dc101bd60c21461535f12c275d062d8d256d97e26b98ba3d8af6c1098b3eac8R28-R36) [[3]](diffhunk://#diff-33e5c389e0cbac00af5f958a77f0456916c6aa9978c0dfeb23aa622016888b91R44)