### PR TITLE
SONARPY-2203 Migrate S2201 IgnoredPureOperationsCheck to the new type model

### DIFF
--- a/python-checks/src/test/resources/checks/ignoredPureOperations.py
+++ b/python-checks/src/test/resources/checks/ignoredPureOperations.py
@@ -9,7 +9,7 @@ def basic_calls():
     no_such_function(1)
 
 def string_calls():
-    "hello".capitalize() # Noncompliant
+    "hello".capitalize() # Noncompliant {{The return value of "str.capitalize" must be used.}}
     s0 = "hello".capitalize()
     s1 = "hello"
     s1.capitalize() # Noncompliant

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
@@ -79,6 +79,12 @@ public class TypeCheckBuilder {
     return this;
   }
 
+  public TypeCheckBuilder isTypeWithName(String expectedName) {
+    var expected = projectLevelTypeTable.getType(expectedName);
+    predicates.add(new IsSameAsTypePredicate(expected));
+    return this;
+  }
+
   interface TypePredicate {
     TriBool test(PythonType pythonType);
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -50,10 +50,13 @@ public class TypesTestUtils {
   }
 
   public static FileInput parseAndInferTypes(PythonFile pythonFile, String... code) {
+    return parseAndInferTypes(PROJECT_LEVEL_TYPE_TABLE, pythonFile, code);
+  }
+
+  public static FileInput parseAndInferTypes(ProjectLevelTypeTable typeTable, PythonFile pythonFile, String... code) {
     FileInput fileInput = PythonTestUtils.parseWithoutSymbols(code);
-    var symbolTable = new SymbolTableBuilderV2(fileInput)
-      .build();
-    new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable).inferTypes(fileInput);
+    var symbolTable = new SymbolTableBuilderV2(fileInput).build();
+    new TypeInferenceV2(typeTable, pythonFile, symbolTable).inferTypes(fileInput);
     return fileInput;
   }
 }


### PR DESCRIPTION
Note: this PR includes two tickets (SONARPY-2203 and its prerequisite, SONARPY-2201) that can actually be reviewed independently. The limitation in re-exported stub symbols (e.g `flask.Response`) will be tackled in SONARPY-2209.