### PR TITLE
SONARPY-2229 Fix FP on S2201 when instantiating the result of a type call

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/IgnoredPureOperationsCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/IgnoredPureOperationsCheck.java
@@ -298,23 +298,21 @@ public class IgnoredPureOperationsCheck extends PythonSubscriptionCheck {
     if (expression.is(Tree.Kind.CALL_EXPR)) {
       CallExpression callExpression = (CallExpression) expression;
       PythonType pythonType = callExpression.callee().typeV2();
-      if (typeChecker.typeCheckBuilder().isObjectType().check(pythonType) == TriBool.FALSE) {
-        PURE_FUNCTIONS.stream()
-          .filter(f -> typeChecker.typeCheckBuilder().isTypeWithName(f).check(pythonType).equals(TriBool.TRUE))
-          .findFirst()
-          .ifPresent(result -> ctx.addIssue(callExpression.callee(), String.format(MESSAGE_FORMAT, result)));
-      }
+      PURE_FUNCTIONS.stream()
+        .filter(f -> typeChecker.typeCheckBuilder().isTypeWithName(f).check(pythonType).equals(TriBool.TRUE))
+        .findFirst()
+        .ifPresent(result -> ctx.addIssue(callExpression.callee(), String.format(MESSAGE_FORMAT, result)));
     } else if (expression.is(Tree.Kind.SUBSCRIPTION)) {
       SubscriptionExpression subscriptionExpression = (SubscriptionExpression) expression;
       PythonType pythonType = subscriptionExpression.object().typeV2();
-      boolean isPureGetitemType = PURE_GETITEM_TYPES.stream().anyMatch(t -> typeChecker.typeCheckBuilder().isTypeWithName(t).check(pythonType).equals(TriBool.TRUE));
+      boolean isPureGetitemType = PURE_GETITEM_TYPES.stream().anyMatch(t -> typeChecker.typeCheckBuilder().isTypeOrInstanceWithName(t).check(pythonType).equals(TriBool.TRUE));
       if (isPureGetitemType) {
         ctx.addIssue(subscriptionExpression, String.format(MESSAGE_FORMAT, "__getitem__"));
       }
     } else if (expression.is(Tree.Kind.IN)) {
       InExpression inExpression = (InExpression) expression;
       PythonType pythonType = inExpression.rightOperand().typeV2();
-      boolean isPureContainsType = PURE_CONTAINS_TYPES.stream().anyMatch(t -> typeChecker.typeCheckBuilder().isTypeWithName(t).check(pythonType).equals(TriBool.TRUE));
+      boolean isPureContainsType = PURE_CONTAINS_TYPES.stream().anyMatch(t -> typeChecker.typeCheckBuilder().isTypeOrInstanceWithName(t).check(pythonType).equals(TriBool.TRUE));
       if (isPureContainsType) {
         ctx.addIssue(inExpression, String.format(MESSAGE_FORMAT, "__contains__"));
       }

--- a/python-checks/src/main/java/org/sonar/python/checks/IgnoredPureOperationsCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/IgnoredPureOperationsCheck.java
@@ -298,10 +298,12 @@ public class IgnoredPureOperationsCheck extends PythonSubscriptionCheck {
     if (expression.is(Tree.Kind.CALL_EXPR)) {
       CallExpression callExpression = (CallExpression) expression;
       PythonType pythonType = callExpression.callee().typeV2();
-      PURE_FUNCTIONS.stream()
-        .filter(f -> typeChecker.typeCheckBuilder().isTypeWithName(f).check(pythonType).equals(TriBool.TRUE))
-        .findFirst()
-        .ifPresent(result -> ctx.addIssue(callExpression.callee(), String.format(MESSAGE_FORMAT, result)));
+      if (typeChecker.typeCheckBuilder().isObjectType().check(pythonType) == TriBool.FALSE) {
+        PURE_FUNCTIONS.stream()
+          .filter(f -> typeChecker.typeCheckBuilder().isTypeWithName(f).check(pythonType).equals(TriBool.TRUE))
+          .findFirst()
+          .ifPresent(result -> ctx.addIssue(callExpression.callee(), String.format(MESSAGE_FORMAT, result)));
+      }
     } else if (expression.is(Tree.Kind.SUBSCRIPTION)) {
       SubscriptionExpression subscriptionExpression = (SubscriptionExpression) expression;
       PythonType pythonType = subscriptionExpression.object().typeV2();

--- a/python-checks/src/test/resources/checks/ignoredPureOperations.py
+++ b/python-checks/src/test/resources/checks/ignoredPureOperations.py
@@ -71,3 +71,8 @@ def edge_case():
 s = "hello"
 s.replace('o', 'x') # Noncompliant
 print(s)
+
+
+def type_calls(param):
+    X = type(param)
+    X() # OK, class instantiation could have a side effect

--- a/python-checks/src/test/resources/checks/ignoredPureOperations.py
+++ b/python-checks/src/test/resources/checks/ignoredPureOperations.py
@@ -74,5 +74,6 @@ print(s)
 
 
 def type_calls(param):
+    type(param) # Noncompliant
     X = type(param)
     X() # OK, class instantiation could have a side effect

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/TypeCheckBuilder.java
@@ -79,6 +79,11 @@ public class TypeCheckBuilder {
     return this;
   }
 
+  public TypeCheckBuilder isObjectType() {
+    predicates.add(new IsTypeKindPredicate(ObjectType.class));
+    return this;
+  }
+
   public TypeCheckBuilder isTypeWithName(String expectedName) {
     var expected = projectLevelTypeTable.getType(expectedName);
     predicates.add(new IsSameAsTypePredicate(expected));
@@ -240,4 +245,16 @@ public class TypeCheckBuilder {
     return types.stream().anyMatch(UnknownType.class::isInstance);
   }
 
+  static class IsTypeKindPredicate implements TypePredicate {
+    Class<? extends PythonType> typeKind;
+
+    public IsTypeKindPredicate(Class<? extends PythonType> typeClass) {
+      this.typeKind = typeClass;
+    }
+
+    @Override
+    public TriBool test(PythonType pythonType) {
+      return typeKind.isInstance(pythonType) ? TriBool.TRUE : TriBool.FALSE;
+    }
+  }
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/ProjectLevelTypeTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/ProjectLevelTypeTableTest.java
@@ -116,8 +116,8 @@ class ProjectLevelTypeTableTest {
     ClassType isoparserClass = (ClassType) ((ExpressionStatement) fileInput.statements().statements().get(1)).expressions().get(0).typeV2();
     // With this import syntax, we expect to retrieve the class defined in "dateutil/parser/isoparser.pyi", as "dateutil.parser.isoparser" must refer to a module
     assertThat(isoparserClass.name()).isEqualTo("isoparser");
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("dateutil.parser.isoparser.isoparser").check(isoparserClass)).isEqualTo(TriBool.TRUE);
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("dateutil.parser.isoparser").check(isoparserClass)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("dateutil.parser.isoparser.isoparser").check(isoparserClass)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("dateutil.parser.isoparser").check(isoparserClass)).isEqualTo(TriBool.TRUE);
 
     fileInput = parseAndInferTypes(projectLevelTypeTable, pythonFile("main.py"), """
       import dateutil.parser as parser_module
@@ -127,7 +127,7 @@ class ProjectLevelTypeTableTest {
     PythonType isoParserMember = parserModuleType.resolveMember("isoparser").get();
     assertThat(isoParserMember).isInstanceOf(ClassType.class);
     // Should be True
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("dateutil.parser.isoparser.isoparser").check(isoParserMember)).isEqualTo(TriBool.UNKNOWN);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("dateutil.parser.isoparser.isoparser").check(isoParserMember)).isEqualTo(TriBool.UNKNOWN);
 
     fileInput = parseAndInferTypes(projectLevelTypeTable, pythonFile("main.py"), """
       from dateutil.parser.isoparser import isoparser

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
@@ -22,10 +22,7 @@ package org.sonar.python.semantic.v2;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
-import org.sonar.python.types.v2.ClassType;
-import org.sonar.python.types.v2.FunctionType;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.PythonType;
 import org.sonar.python.types.v2.TriBool;
@@ -147,7 +144,7 @@ class TypeCheckerBuilderTest {
     var table = spy(new ProjectLevelTypeTable(symbolTable));
     when(table.getType("stubbed.unknown1")).thenReturn(new UnresolvedImportType("stubbed.unknown1"));
     when(table.getType("stubbed.unknown2")).thenReturn(new UnresolvedImportType("stubbed.unknown2"));
-    var builder = new TypeCheckBuilder(table).isTypeWithName("stubbed.unknown1");
+    var builder = new TypeCheckBuilder(table).isTypeOrInstanceWithName("stubbed.unknown1");
 
     var unknown1 = new UnresolvedImportType("stubbed.unknown1");
     var unknown2 = new UnresolvedImportType("stubbed.unknown2");
@@ -164,7 +161,7 @@ class TypeCheckerBuilderTest {
       TriBool.UNKNOWN
     );
 
-    var builderUnknownType = new TypeCheckBuilder(table).isTypeWithName("unknown");
+    var builderUnknownType = new TypeCheckBuilder(table).isTypeOrInstanceWithName("unknown");
 
     Assertions.assertThat(
       List.of(
@@ -185,19 +182,6 @@ class TypeCheckerBuilderTest {
     Assertions.assertThatThrownBy(() -> objectTypeBuilder.withDefinitionLocation(null))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Object type does not have definition location");
-  }
-
-  @Test
-  void isTypeKindTest() {
-    var symbolTable = ProjectLevelSymbolTable.empty();
-    var table = new ProjectLevelTypeTable(symbolTable);
-    var builder = new TypeCheckBuilder(table).isObjectType();
-    ObjectType objectType = Mockito.mock(ObjectType.class);
-    FunctionType functionType = Mockito.mock(FunctionType.class);
-    ClassType classType = Mockito.mock(ClassType.class);
-    Assertions.assertThat(builder.check(objectType)).isEqualTo(TriBool.TRUE);
-    Assertions.assertThat(builder.check(functionType)).isEqualTo(TriBool.FALSE);
-    Assertions.assertThat(builder.check(classType)).isEqualTo(TriBool.FALSE);
   }
 
 }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
@@ -22,7 +22,10 @@ package org.sonar.python.semantic.v2;
 import java.util.List;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
+import org.sonar.python.types.v2.ClassType;
+import org.sonar.python.types.v2.FunctionType;
 import org.sonar.python.types.v2.ObjectType;
 import org.sonar.python.types.v2.PythonType;
 import org.sonar.python.types.v2.TriBool;
@@ -182,6 +185,19 @@ class TypeCheckerBuilderTest {
     Assertions.assertThatThrownBy(() -> objectTypeBuilder.withDefinitionLocation(null))
       .isInstanceOf(IllegalStateException.class)
       .hasMessage("Object type does not have definition location");
+  }
+
+  @Test
+  void isTypeKindTest() {
+    var symbolTable = ProjectLevelSymbolTable.empty();
+    var table = new ProjectLevelTypeTable(symbolTable);
+    var builder = new TypeCheckBuilder(table).isObjectType();
+    ObjectType objectType = Mockito.mock(ObjectType.class);
+    FunctionType functionType = Mockito.mock(FunctionType.class);
+    ClassType classType = Mockito.mock(ClassType.class);
+    Assertions.assertThat(builder.check(objectType)).isEqualTo(TriBool.TRUE);
+    Assertions.assertThat(builder.check(functionType)).isEqualTo(TriBool.FALSE);
+    Assertions.assertThat(builder.check(classType)).isEqualTo(TriBool.FALSE);
   }
 
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypeCheckerTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypeCheckerTest.java
@@ -243,13 +243,15 @@ class TypeCheckerTest {
     ObjectType intLiteralType = (ObjectType) intLiteral.typeV2();
     assertThat(intLiteralType.unwrappedType()).isEqualTo(INT_TYPE);
 
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("int").check(intLiteralType)).isEqualTo(TriBool.TRUE);
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("str").check(intLiteralType)).isEqualTo(TriBool.FALSE);
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("unknown").check(intLiteralType)).isEqualTo(TriBool.UNKNOWN);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("int").check(intLiteralType)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("str").check(intLiteralType)).isEqualTo(TriBool.FALSE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("unknown").check(intLiteralType)).isEqualTo(TriBool.UNKNOWN);
+    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("int").check(intLiteralType)).isEqualTo(TriBool.FALSE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("int").check(intLiteralType.unwrappedType())).isEqualTo(TriBool.TRUE);
 
     fileInput = parseAndInferTypes("round(42.42)");
     var roundType = ((CallExpression) ((ExpressionStatement) fileInput.statements().statements().get(0)).expressions().get(0)).callee().typeV2();
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("round").check(roundType)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("round").check(roundType)).isEqualTo(TriBool.TRUE);
 
     fileInput = parseAndInferTypes(
       """
@@ -258,9 +260,9 @@ class TypeCheckerTest {
         """
     );
     var responseType = ((CallExpression) ((ExpressionStatement) fileInput.statements().statements().get(1)).expressions().get(0)).callee().typeV2();
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("flask.Response").check(responseType)).isEqualTo(TriBool.TRUE);
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("flask.wrappers.Response").check(responseType)).isEqualTo(TriBool.TRUE);
-    assertThat(typeChecker.typeCheckBuilder().isTypeWithName("flask.app.Response").check(responseType)).isEqualTo(TriBool.UNKNOWN);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("flask.Response").check(responseType)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("flask.wrappers.Response").check(responseType)).isEqualTo(TriBool.TRUE);
+    assertThat(typeChecker.typeCheckBuilder().isTypeOrInstanceWithName("flask.app.Response").check(responseType)).isEqualTo(TriBool.UNKNOWN);
   }
 
   @Test
@@ -288,8 +290,8 @@ class TypeCheckerTest {
       """
     );
     var aType = ((ExpressionStatement) fileInput.statements().statements().get(1)).expressions().get(0).typeV2();
-    assertThat(localTypeChecker.typeCheckBuilder().isTypeWithName("my_package.mod.A").check(aType)).isEqualTo(TriBool.TRUE);
-    assertThat(localTypeChecker.typeCheckBuilder().isTypeWithName("my_package.mod.B").check(aType)).isEqualTo(TriBool.FALSE);
-    assertThat(localTypeChecker.typeCheckBuilder().isTypeWithName("my_package.unknown.A").check(aType)).isEqualTo(TriBool.UNKNOWN);
+    assertThat(localTypeChecker.typeCheckBuilder().isTypeOrInstanceWithName("my_package.mod.A").check(aType)).isEqualTo(TriBool.TRUE);
+    assertThat(localTypeChecker.typeCheckBuilder().isTypeOrInstanceWithName("my_package.mod.B").check(aType)).isEqualTo(TriBool.FALSE);
+    assertThat(localTypeChecker.typeCheckBuilder().isTypeOrInstanceWithName("my_package.unknown.A").check(aType)).isEqualTo(TriBool.UNKNOWN);
   }
 }


### PR DESCRIPTION
This is admittedly a very naive approach to fix this FP.

However, I believe that this deserves a broader discussion, considering SONARPY-2013 to allow for easier manipulation of type predicates.
I also considered adding a proper `PythonType#kind` API to avoid checking for instances. However, I feel this can still be done later if the need proves real.

 