### PR TITLE
SONARPY-2215 Document absence of types when CFG is invalid

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/TypeInferenceV2.java
@@ -130,7 +130,6 @@ public class TypeInferenceV2 {
 
     ControlFlowGraph cfg = controlFlowGraphSupplier.get();
     if (cfg == null) {
-      // TODO SONARPY-2215: fix me
       return Map.of();
     }
     assignedNames.addAll(annotatedParameterNames);

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2656,6 +2656,16 @@ public class TypeInferenceV2Test {
     assertThat(typesBySymbol).isEmpty();
   }
 
+  @Test
+  void typeBySymbol_invalidCfg() {
+    // No types will be retrieved when the CFG is invalid
+    var typesBySymbol = inferTypesBySymbol("""
+      class A: ...
+      continue
+      """);
+    assertThat(typesBySymbol).isEmpty();
+  }
+
   private static Map<SymbolV2, Set<PythonType>> inferTypesBySymbol(String lines) {
     FileInput root = parse(lines);
     var symbolTable = new SymbolTableBuilderV2(root).build();


### PR DESCRIPTION
[SONARPY-2215](https://sonarsource.atlassian.net/browse/SONARPY-2215)

The CFG is invalid when the control flow structures produce an invalid program. They would result in an exception being raised, which means no symbol or type will be exported in this case.

[SONARPY-2215]: https://sonarsource.atlassian.net/browse/SONARPY-2215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ