### PR TITLE
SONARPY-2261 get rid of TypeInferenceV2.typesBySymbol field

### DIFF
--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -2888,8 +2888,7 @@ public class TypeInferenceV2Test {
     FileInput root = parse(lines);
     var symbolTable = new SymbolTableBuilderV2(root).build();
     var typeInferenceV2 = new TypeInferenceV2(PROJECT_LEVEL_TYPE_TABLE, pythonFile, symbolTable);
-    typeInferenceV2.inferTypes(root);
-    return typeInferenceV2.getTypesBySymbol();
+    return typeInferenceV2.inferTypes(root);
   }
 
   private static FileInput inferTypes(String lines) {


### PR DESCRIPTION
[SONARPY-2261](https://sonarsource.atlassian.net/browse/SONARPY-2261)



[SONARPY-2261]: https://sonarsource.atlassian.net/browse/SONARPY-2261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ