### PR TITLE
SONARPY-2282 Update Cirrus modules to v3

### DIFF
--- a/.cirrus.star
+++ b/.cirrus.star
@@ -1,4 +1,4 @@
-load("github.com/SonarSource/cirrus-modules@v2", "load_features")
+load("github.com/SonarSource/cirrus-modules@v3", "load_features")
 
 def main(ctx):
     return load_features(ctx)

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -33,7 +33,6 @@ win_vm_definition: &WINDOWS_VM_DEFINITION
     platform: windows
     region: eu-central-1
     type: t3.xlarge
-    subnet_id: ${CIRRUS_AWS_SUBNET}
     use_ssd: true
 
 build_container_definition: &BUILD_CONTAINER_DEFINITION
@@ -45,7 +44,6 @@ build_container_definition: &BUILD_CONTAINER_DEFINITION
     builder_role: cirrus-builder
     builder_image: docker-builder-v*
     builder_instance_type: t3.small
-    builder_subnet_id: ${CIRRUS_AWS_SUBNET}
     region: eu-central-1
     namespace: default
     cpu: 2


### PR DESCRIPTION
[SONARPY-2282](https://sonarsource.atlassian.net/browse/SONARPY-2282)



[SONARPY-2282]: https://sonarsource.atlassian.net/browse/SONARPY-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ