### PR TITLE
SONARPY-2276 Fix FPs on S930 when an object method is assigned to a variable

### DIFF
--- a/python-checks/src/test/resources/checks/argumentNumber.py
+++ b/python-checks/src/test/resources/checks/argumentNumber.py
@@ -214,3 +214,20 @@ def logging_api():
 def foo(day, tz):
     b = datetime.date.fromordinal(day).replace(tzinfo=tz) # FN SONARPY-1472
     a = datetime.datetime.fromordinal(day).replace(tzinfo=tz) # OK
+
+
+def bound_and_unbound_methods():
+    class ClassWithMethod:
+        def some_method(self, param): ...
+
+    unbound_method = ClassWithMethod.some_method
+    bound_method = ClassWithMethod().some_method
+
+    unbound_method(1, 2) # OK
+    bound_method(1) # OK
+
+    unbound_method() # FN SONARPY-2285
+    unbound_method(1) # FN SONARPY-2285
+    unbound_method(1, 2, 3) # FN SONARPY-2285
+    bound_method() # FN SONARPY-2285
+    bound_method(1, 2) # FN SONARPY-2285

--- a/python-checks/src/test/resources/checks/argumentNumberImported.py
+++ b/python-checks/src/test/resources/checks/argumentNumberImported.py
@@ -3,3 +3,7 @@ def fn(p): pass
 class A():
     def meth(self, p1): pass
     def foo(p1): pass
+
+
+reassigned_unbound_meth = A.meth
+reassigned_bound_meth = a().meth

--- a/python-checks/src/test/resources/checks/argumentNumberWithImport.py
+++ b/python-checks/src/test/resources/checks/argumentNumberWithImport.py
@@ -1,5 +1,7 @@
 from argumentNumberImported import fn, A
 import argumentNumberImported
+from argumentNumberImported import reassigned_unbound_meth as aliased_unbound
+from argumentNumberImported import reassigned_bound_meth as aliased_bound
 
 fn(1, 2) # Noncompliant
 fn(1) # OK
@@ -12,3 +14,26 @@ def stub_functions():
     a.meth(42)
     a.meth(42, 43) # Noncompliant
     argumentNumberImported.fn(1)
+
+
+def calling_reassigned_imported_valid_usages():
+    # SONARPY-2285: Bound and unbound methods are currently not exported
+    argumentNumberImported.reassigned_unbound_meth(1, 2)
+    argumentNumberImported.reassigned_bound_meth(1)
+
+    aliased_unbound(1, 2)
+    aliased_bound(1)
+
+def calling_reassigned_imported_noncompliant():
+    # SONARPY-2285: Bound and unbound methods are currently not exported
+    argumentNumberImported.reassigned_unbound_meth() # FN SONARPY-2285
+    argumentNumberImported.reassigned_unbound_meth(42, 43) # FN SONARPY-2285
+    argumentNumberImported.reassigned_bound_meth() # FN SONARPY-2285
+    argumentNumberImported.reassigned_bound_meth(42, 43) # FN SONARPY-2285
+
+    aliased_unbound() # FN SONARPY-2285
+    aliased_unbound(1, 2, 3) # FN SONARPY-2285
+
+    aliased_bound() # FN SONARPY-2285
+    aliased_bound(42, 43) # FN SONARPY-2285
+


### PR DESCRIPTION
[SONARPY-2276](https://sonarsource.atlassian.net/browse/SONARPY-2276)



[SONARPY-2276]: https://sonarsource.atlassian.net/browse/SONARPY-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

SONARPY-2285 has been created to handle bound/unbound methods in a more deliberate way. For now, we just ignore them when handling with re-exports.

It is to be noted that S930 has not been migrated to the new type model yet (only the cross-file analysis was impacted through descriptors). I've still added tests to document the current behavior (no issues raised on bound/unbound methods assigned to variables) that hopefully will help avoid problems when performing the migration.

Ruling tests are still red, due to some other yet unfixed issues.

Note: I suggest merging this PR in 2 commits, so that commits on the converter implementation (still not on master) can be squashed together.