### PR TITLE
SONARPY-2296 Fix quality issues: ensure calls to Name#symbolV2 are ch…

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/FlowSensitiveTypeInference.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/FlowSensitiveTypeInference.java
@@ -39,7 +39,6 @@ import org.sonar.plugins.python.api.tree.Statement;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.cfg.fixpoint.ForwardAnalysis;
 import org.sonar.python.cfg.fixpoint.ProgramState;
-import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
 import org.sonar.python.semantic.v2.SymbolV2;
 import org.sonar.python.semantic.v2.TypeTable;
 import org.sonar.python.types.v2.PythonType;
@@ -123,9 +122,13 @@ public class FlowSensitiveTypeInference extends ForwardAnalysis {
     if (name == null || !trackedVars.contains(name.symbolV2())) {
       return;
     }
+    SymbolV2 symbol = name.symbolV2();
+    if (symbol == null) {
+      return;
+    }
 
     var type = parameterTypesByName.getOrDefault(name.name(), PythonType.UNKNOWN);
-    state.setTypes(name.symbolV2(), new HashSet<>(Set.of(type)));
+    state.setTypes(symbol, new HashSet<>(Set.of(type)));
     updateTree(name, state);
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/PropagationVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/PropagationVisitor.java
@@ -74,6 +74,9 @@ public class PropagationVisitor extends BaseTreeVisitor {
     super.visitFunctionDef(functionDef);
     Name name = functionDef.name();
     var symbol = name.symbolV2();
+    if (symbol == null) {
+      return;
+    }
     Definition definition = new Definition(symbol, name);
     definitionsByDefinitionStatement.computeIfAbsent(functionDef, k -> new HashSet<>()).add(definition);
     propagationsByLhs.computeIfAbsent(symbol, s -> new HashSet<>()).add(definition);
@@ -84,6 +87,9 @@ public class PropagationVisitor extends BaseTreeVisitor {
     super.visitClassDef(classDef);
     var name = classDef.name();
     var symbol = name.symbolV2();
+    if (symbol == null) {
+      return;
+    }
     var definition = new Definition(symbol, name);
     definitionsByDefinitionStatement.computeIfAbsent(classDef, k -> new HashSet<>()).add(definition);
     propagationsByLhs.computeIfAbsent(symbol, s -> new HashSet<>()).add(definition);
@@ -186,8 +192,11 @@ public class PropagationVisitor extends BaseTreeVisitor {
   }
 
   private void processAssignment(Statement assignmentStatement, Expression lhsExpression, Expression rhsExpression){
-    if (lhsExpression instanceof Name lhs && lhs.symbolV2() != null) {
+    if (lhsExpression instanceof Name lhs) {
       var symbol = lhs.symbolV2();
+      if (symbol == null) {
+        return;
+      }
       var assignment = new Assignment(symbol, lhs, rhsExpression, propagationsByLhs);
       assignmentsByAssignmentStatement.put(assignmentStatement, assignment);
       propagationsByLhs.computeIfAbsent(symbol, s -> new HashSet<>()).add(assignment);

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -259,8 +259,11 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
     ClassType classType = classTypeBuilder.build();
 
     if (currentType() instanceof ClassType ownerClass) {
-      PythonType memberType = className.symbolV2().hasSingleBindingUsage() ? classType : PythonType.UNKNOWN;
-      ownerClass.members().add(new Member(classType.name(), memberType));
+      SymbolV2 symbolV2 = className.symbolV2();
+      if (symbolV2 != null) {
+        PythonType memberType = symbolV2.hasSingleBindingUsage() ? classType : PythonType.UNKNOWN;
+        ownerClass.members().add(new Member(classType.name(), memberType));
+      }
     }
     return classType;
   }
@@ -335,8 +338,9 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
       functionTypeBuilder.withTypeOrigin(TypeOrigin.LOCAL);
     }
     FunctionType functionType = functionTypeBuilder.build();
-    if (owner != null) {
-      if (functionDef.name().symbolV2().hasSingleBindingUsage()) {
+    SymbolV2 symbolV2 = functionDef.name().symbolV2();
+    if (owner != null && symbolV2 != null) {
+      if (symbolV2.hasSingleBindingUsage()) {
         owner.members().add(new Member(functionType.name(), functionType));
       } else {
         owner.members().add(new Member(functionType.name(), PythonType.UNKNOWN));


### PR DESCRIPTION
[SONARPY-2296](https://sonarsource.atlassian.net/browse/SONARPY-2296)

Note: the added conditions are defensive and most of them should never be reachable in actual code, as symbols for parameters, functions, classes, etc... can't actually be null.
The underlying problem of nullability of symbolsV2 should be addressed through SONARPY-2259 and SONARPY-2260.


[SONARPY-2296]: https://sonarsource.atlassian.net/browse/SONARPY-2296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ