### PR TITLE
SONARPY-2319 Add unit test case on S5886 when annotated return type is imported and has fields members only

### DIFF
--- a/python-checks/src/test/java/org/sonar/python/checks/FunctionReturnTypeCheckTest.java
+++ b/python-checks/src/test/java/org/sonar/python/checks/FunctionReturnTypeCheckTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.python.checks;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.sonar.python.checks.utils.PythonCheckVerifier;
 
@@ -33,4 +34,13 @@ class FunctionReturnTypeCheckTest {
   void additionalTest() {
     PythonCheckVerifier.verifyNoIssue("src/test/resources/checks/functionReturnTypeAdditionalTests.py", new FunctionReturnTypeCheck());
   }
+
+  @Test
+  void importedTypesTest() {
+    PythonCheckVerifier.verify(List.of(
+      "src/test/resources/checks/functionReturnTypeImported.py",
+      "src/test/resources/checks/functionReturnTypeImporting.py"
+    ), new FunctionReturnTypeCheck());
+  }
+  
 }

--- a/python-checks/src/test/resources/checks/functionReturnTypeImported.py
+++ b/python-checks/src/test/resources/checks/functionReturnTypeImported.py
@@ -1,0 +1,7 @@
+from typing import NamedTuple
+
+class ImportedFieldMembersOnlyNamedTuple(NamedTuple):
+  id: str
+
+class ImportedMethodMembersOnlyNamedTuple(NamedTuple):
+  def id(self): ...

--- a/python-checks/src/test/resources/checks/functionReturnTypeImporting.py
+++ b/python-checks/src/test/resources/checks/functionReturnTypeImporting.py
@@ -1,0 +1,14 @@
+from typing import NamedTuple
+from functionReturnTypeImported import ImportedFieldMembersOnlyNamedTuple, ImportedMethodMembersOnlyNamedTuple
+
+def get_imported_field_members_only_named_tuple() -> ImportedFieldMembersOnlyNamedTuple:
+  return None # FN SONARPY-2316
+
+def get_imported_method_members_only_named_tuple() -> ImportedMethodMembersOnlyNamedTuple:
+  return None # Noncompliant
+
+class LocallyDefinedFieldMembersOnlyNamedTuple(NamedTuple):
+  id: str
+
+def get_locally_defined_field_members_only_named_tuple() -> LocallyDefinedFieldMembersOnlyNamedTuple:
+  return None # Noncompliant


### PR DESCRIPTION
[SONARPY-2319](https://sonarsource.atlassian.net/browse/SONARPY-2319)



[SONARPY-2319]: https://sonarsource.atlassian.net/browse/SONARPY-2319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ