### PR TITLE
SONARPY-2326 Add Version 3.13 as supported version of Python

### DIFF
--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVersionUtils.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVersionUtils.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_310;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_311;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_312;
+import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_313;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_36;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_37;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_38;
@@ -42,7 +43,8 @@ public class PythonVersionUtils {
     V_39(3, 9, "39"),
     V_310(3, 10, "310"),
     V_311(3, 11, "311"),
-    V_312(3, 12, "312");
+    V_312(3, 12, "312"),
+    V_313(3, 13, "313");
 
     private final int major;
     private final int minor;
@@ -96,9 +98,10 @@ public class PythonVersionUtils {
     Map.entry("3.9", V_39),
     Map.entry("3.10", V_310),
     Map.entry("3.11", V_311),
-    Map.entry("3.12", V_312));
+    Map.entry("3.12", V_312),
+    Map.entry("3.13", V_313));
   private static final Version MIN_SUPPORTED_VERSION = V_36;
-  public static final Version MAX_SUPPORTED_VERSION = V_312;
+  public static final Version MAX_SUPPORTED_VERSION = V_313;
   private static final Logger LOG = LoggerFactory.getLogger(PythonVersionUtils.class);
   public static final String PYTHON_VERSION_KEY = "sonar.python.version";
 

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVersionUtils.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/PythonVersionUtils.java
@@ -178,6 +178,13 @@ public class PythonVersionUtils {
       .allMatch(version -> version.compare(required.major(), required.minor()) >= 0);
   }
 
+  /**
+   * @return the set of versions which are supported but not serialized due to SONARPY-1522
+   */
+  public static Set<Version> getNotSerializedVersions() {
+    return EnumSet.of(V_312, V_313);
+  }
+
   private static void logErrorMessage(String propertyValue) {
     LOG.warn(
       "Error while parsing value of parameter '{}' ({}). Versions must be specified as MAJOR_VERSION.MINOR_VERSION (e.g. \"3.7, 3.8\")",

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/ProtoUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/typeshed/ProtoUtils.java
@@ -54,8 +54,10 @@ public class ProtoUtils {
       return true;
     }
     // TODO: SONARPY-1522 - remove this workaround when we will have all the stubs for Python 3.12.
-    if (supportedPythonVersions.stream().allMatch(PythonVersionUtils.Version.V_312.serializedValue()::equals)
-      && validForPythonVersions.contains(PythonVersionUtils.Version.V_311.serializedValue())) {
+    Set<String> notSerializedVersions =
+      PythonVersionUtils.getNotSerializedVersions().stream().map(PythonVersionUtils.Version::serializedValue).collect(Collectors.toSet());
+    if (notSerializedVersions.containsAll(supportedPythonVersions)
+        && validForPythonVersions.contains(PythonVersionUtils.Version.V_311.serializedValue())) {
       return true;
     }
     HashSet<String> intersection = new HashSet<>(validForPythonVersions);

--- a/python-frontend/src/main/java/org/sonar/python/types/TypeShed.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/TypeShed.java
@@ -235,8 +235,9 @@ public class TypeShed {
       return true;
     }
     // TODO: SONARPY-1522 - remove this workaround when we will have all the stubs for Python 3.12.
-    if (supportedPythonVersions.stream().allMatch(PythonVersionUtils.Version.V_312.serializedValue()::equals)
-      && validForPythonVersions.contains(PythonVersionUtils.Version.V_311.serializedValue())) {
+    Set<String> notSerializedVersions = PythonVersionUtils.getNotSerializedVersions().stream().map(PythonVersionUtils.Version::serializedValue).collect(Collectors.toSet());
+    if (notSerializedVersions.containsAll(supportedPythonVersions)
+        && validForPythonVersions.contains(PythonVersionUtils.Version.V_311.serializedValue())) {
       return true;
     }
     HashSet<String> intersection = new HashSet<>(validForPythonVersions);

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVersionUtilsTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVersionUtilsTest.java
@@ -19,6 +19,7 @@
  */
 package org.sonar.plugins.python.api;
 
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -31,6 +32,7 @@ import static org.junit.Assert.assertTrue;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_310;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_311;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_312;
+import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_313;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_36;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_37;
 import static org.sonar.plugins.python.api.PythonVersionUtils.Version.V_38;
@@ -41,26 +43,28 @@ class PythonVersionUtilsTest {
   @RegisterExtension
   public LogTesterJUnit5 logTester = new LogTesterJUnit5().setLevel(Level.DEBUG);
 
+  private static final List<PythonVersionUtils.Version> allVersions = List.of(V_36, V_37, V_38, V_39, V_310, V_311, V_312, V_313);
+
   @Test
   void supportedVersions() {
-    assertThat(PythonVersionUtils.fromString("")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
-    assertThat(PythonVersionUtils.fromString(",")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
-    assertThat(PythonVersionUtils.fromString("2.7")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
-    assertThat(PythonVersionUtils.fromString("2")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
-    assertThat(PythonVersionUtils.fromString("3")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
+    assertThat(PythonVersionUtils.fromString("")).hasSameElementsAs(allVersions);
+    assertThat(PythonVersionUtils.fromString(",")).hasSameElementsAs(allVersions);
+    assertThat(PythonVersionUtils.fromString("2.7")).hasSameElementsAs(allVersions);
+    assertThat(PythonVersionUtils.fromString("2")).hasSameElementsAs(allVersions);
+    assertThat(PythonVersionUtils.fromString("3")).hasSameElementsAs(allVersions);
     assertThat(PythonVersionUtils.fromString("3.8, 3.9")).containsExactlyInAnyOrder(V_38, V_39);
-    assertThat(PythonVersionUtils.fromString("2.7, 3.9")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
+    assertThat(PythonVersionUtils.fromString("2.7, 3.9")).hasSameElementsAs(allVersions);
     assertThat(PythonVersionUtils.fromString("3.10")).containsExactlyInAnyOrder(V_310);
   }
 
   @Test
   void version_out_of_range() {
-    assertThat(PythonVersionUtils.fromString("4")).containsExactlyInAnyOrder(V_312);
-    assertThat(logTester.logs(Level.WARN)).contains("No explicit support for version 4. Python version has been set to 3.12.");
-    assertThat(PythonVersionUtils.fromString("1")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
+    assertThat(PythonVersionUtils.fromString("4")).containsExactlyInAnyOrder(V_313);
+    assertThat(logTester.logs(Level.WARN)).contains("No explicit support for version 4. Python version has been set to 3.13.");
+    assertThat(PythonVersionUtils.fromString("1")).hasSameElementsAs(allVersions);
     assertThat(logTester.logs(Level.WARN)).contains("No explicit support for version 1. Support for Python versions prior to 3 is deprecated.");
-    assertThat(PythonVersionUtils.fromString("3.13")).containsExactlyInAnyOrder(V_312);
-    assertThat(logTester.logs(Level.WARN)).contains("No explicit support for version 3.13. Python version has been set to 3.12.");
+    assertThat(PythonVersionUtils.fromString("3.14")).containsExactlyInAnyOrder(V_313);
+    assertThat(logTester.logs(Level.WARN)).contains("No explicit support for version 3.14. Python version has been set to 3.13.");
     assertThat(PythonVersionUtils.fromString("3.12")).containsExactlyInAnyOrder(V_312);
   }
 
@@ -74,7 +78,7 @@ class PythonVersionUtilsTest {
 
   @Test
   void error_while_parsing_version() {
-    assertThat(PythonVersionUtils.fromString("foo")).containsExactlyInAnyOrder(V_36, V_37, V_38, V_39, V_310, V_311, V_312);
+    assertThat(PythonVersionUtils.fromString("foo")).hasSameElementsAs(allVersions);
     assertThat(logTester.logs(Level.WARN))
       .contains("Error while parsing value of parameter 'sonar.python.version' (foo). Versions must be specified as MAJOR_VERSION.MINOR_VERSION (e.g. \"3.7, 3.8\")");
   }

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/typeshed/ClassSymbolToDescriptorConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/typeshed/ClassSymbolToDescriptorConverterTest.java
@@ -19,11 +19,17 @@
  */
 package org.sonar.python.semantic.v2.typeshed;
 
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.sonar.plugins.python.api.ProjectPythonVersion;
+import org.sonar.plugins.python.api.PythonVersionUtils;
 import org.sonar.python.index.AmbiguousDescriptor;
 import org.sonar.python.index.Descriptor;
 import org.sonar.python.index.FunctionDescriptor;
@@ -96,6 +102,84 @@ class ClassSymbolToDescriptorConverterTest {
       .extracting(FunctionDescriptor.class::cast)
       .extracting(FunctionDescriptor::isInstanceMethod)
       .containsOnly(true, true);
+  }
+
+  static Stream<Arguments> versionsToTest() {
+    return Stream.of(
+      Arguments.of(PythonVersionUtils.Version.V_312),
+      Arguments.of(PythonVersionUtils.Version.V_313)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("versionsToTest")
+  void validForPythonVersionsTest(PythonVersionUtils.Version version) {
+    var functionConverter = new FunctionSymbolToDescriptorConverter();
+    var variableConverter = new VarSymbolToDescriptorConverter();
+    var overloadedFunctionConverter = new OverloadedFunctionSymbolToDescriptorConverter(functionConverter);
+    var converter = new ClassSymbolToDescriptorConverter(variableConverter, functionConverter, overloadedFunctionConverter, Set.of(version.serializedValue()));
+
+    var symbol = SymbolsProtos.ClassSymbol.newBuilder()
+      .setName("MyClass")
+      .addAttributes(SymbolsProtos.VarSymbol.newBuilder()
+        .setName("v1")
+        .addValidFor("311")
+        .build())
+      .addAttributes(SymbolsProtos.VarSymbol.newBuilder()
+        .setName("v2")
+        .addValidFor("39")
+        .build())
+      .addMethods(SymbolsProtos.FunctionSymbol.newBuilder()
+        .setName("foo1")
+        .addValidFor("311")
+        .build())
+      .addMethods(SymbolsProtos.FunctionSymbol.newBuilder()
+        .setName("foo2")
+        .addValidFor("39")
+        .build())
+      .addOverloadedMethods(SymbolsProtos.OverloadedFunctionSymbol.newBuilder()
+        .setName("overloaded_foo1")
+        .addValidFor("311")
+        .setFullname("module.MyClass.overloaded_foo1")
+        .addDefinitions(SymbolsProtos.FunctionSymbol.newBuilder()
+          .setName("overloaded_foo1")
+          .addValidFor("311")
+          .build())
+        .addDefinitions(SymbolsProtos.FunctionSymbol.newBuilder()
+          .setName("overloaded_foo1")
+          .addValidFor("311")
+          .build())
+        .build())
+      .addOverloadedMethods(SymbolsProtos.OverloadedFunctionSymbol.newBuilder()
+        .setName("overloaded_foo2")
+        .addValidFor("39")
+        .setFullname("module.MyClass.overloaded_foo2")
+        .addDefinitions(SymbolsProtos.FunctionSymbol.newBuilder()
+          .setName("overloaded_foo2")
+          .addValidFor("39")
+          .build())
+        .addDefinitions(SymbolsProtos.FunctionSymbol.newBuilder()
+          .setName("overloaded_foo2")
+          .addValidFor("39")
+          .build())
+        .build())
+      .build();
+
+    var descriptor = converter.convert(symbol);
+
+    Assertions.assertThat(descriptor.members()).hasSize(3);
+
+    var membersByName = descriptor.members()
+      .stream()
+      .collect(Collectors.toMap(Descriptor::name, Function.identity()));
+
+    Assertions.assertThat(membersByName).hasSize(3);
+    Assertions.assertThat(membersByName.get("v1")).isInstanceOf(VariableDescriptor.class);
+    Assertions.assertThat(membersByName.get("v2")).isNull();
+    Assertions.assertThat(membersByName.get("foo1")).isInstanceOf(FunctionDescriptor.class);
+    Assertions.assertThat(membersByName.get("foo2")).isNull();
+    Assertions.assertThat(membersByName.get("overloaded_foo1")).isInstanceOf(AmbiguousDescriptor.class);
+    Assertions.assertThat(membersByName.get("overloaded_foo2")).isNull();
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/typeshed/ModuleSymbolToDescriptorConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/typeshed/ModuleSymbolToDescriptorConverterTest.java
@@ -20,8 +20,12 @@
 package org.sonar.python.semantic.v2.typeshed;
 
 import java.util.Set;
+import java.util.stream.Stream;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.sonar.plugins.python.api.PythonVersionUtils;
 import org.sonar.python.index.AmbiguousDescriptor;
 import org.sonar.python.index.ClassDescriptor;
@@ -30,7 +34,6 @@ import org.sonar.python.index.VariableDescriptor;
 import org.sonar.python.types.protobuf.SymbolsProtos;
 
 class ModuleSymbolToDescriptorConverterTest {
-
   @Test
   void test() {
     var converter = new ModuleSymbolToDescriptorConverter(PythonVersionUtils.allVersions());
@@ -90,9 +93,18 @@ class ModuleSymbolToDescriptorConverterTest {
     Assertions.assertThat(descriptor).isNull();
   }
 
-  @Test
-  void validForPythonVersionsTest() {
-    var converter = new ModuleSymbolToDescriptorConverter(Set.of(PythonVersionUtils.Version.V_312));
+
+  static Stream<Arguments> versionsToTest() {
+    return Stream.of(
+      Arguments.of(PythonVersionUtils.Version.V_312),
+      Arguments.of(PythonVersionUtils.Version.V_313)
+    );
+  }
+
+  @ParameterizedTest
+  @MethodSource("versionsToTest")
+  void validForPythonVersionsTest(PythonVersionUtils.Version requestedVersion) {
+    var converter = new ModuleSymbolToDescriptorConverter(Set.of(requestedVersion));
     var symbol = SymbolsProtos.ModuleSymbol.newBuilder()
       .setFullyQualifiedName("module")
       .addVars(SymbolsProtos.VarSymbol.newBuilder()

--- a/python-frontend/src/test/java/org/sonar/python/types/TypeShedTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/TypeShedTest.java
@@ -476,6 +476,10 @@ class TypeShedTest {
     intSymbol = TypeShed.typeShedClass("int");
     assertThat(intSymbol.resolveMember("bit_count")).isNotEmpty();
 
+    setPythonVersions(PythonVersionUtils.fromString("3.13"));
+    intSymbol = TypeShed.typeShedClass("int");
+    assertThat(intSymbol.resolveMember("bit_count")).isNotEmpty();
+
     setPythonVersions(PythonVersionUtils.allVersions());
   }
 


### PR DESCRIPTION
[SONARPY-2326](https://sonarsource.atlassian.net/browse/SONARPY-2326)



[SONARPY-2326]: https://sonarsource.atlassian.net/browse/SONARPY-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ