### PR TITLE
SONARPY-2336 Ensure ClassDescriptor and FunctionDescriptor fullyQualifiedName are not nullable

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/index/ClassDescriptor.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/ClassDescriptor.java
@@ -23,13 +23,13 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.sonar.plugins.python.api.LocationInFile;
 
 public class ClassDescriptor implements Descriptor {
 
   private final String name;
-  @Nullable
   private final String fullyQualifiedName;
   private final Collection<String> superClasses;
   private final Set<Descriptor> members;
@@ -40,7 +40,7 @@ public class ClassDescriptor implements Descriptor {
   private final String metaclassFQN;
   private final boolean supportsGenerics;
 
-  public ClassDescriptor(String name, @Nullable String fullyQualifiedName, Collection<String> superClasses, Set<Descriptor> members,
+  public ClassDescriptor(String name, String fullyQualifiedName, Collection<String> superClasses, Set<Descriptor> members,
     boolean hasDecorators, @Nullable LocationInFile definitionLocation, boolean hasSuperClassWithoutDescriptor, boolean hasMetaClass,
     @Nullable String metaclassFQN, boolean supportsGenerics) {
 
@@ -62,6 +62,7 @@ public class ClassDescriptor implements Descriptor {
   }
 
   @Override
+  @Nonnull
   public String fullyQualifiedName() {
     return fullyQualifiedName;
   }
@@ -122,7 +123,7 @@ public class ClassDescriptor implements Descriptor {
       return this;
     }
 
-    public ClassDescriptorBuilder withFullyQualifiedName(@Nullable String fullyQualifiedName) {
+    public ClassDescriptorBuilder withFullyQualifiedName(String fullyQualifiedName) {
       this.fullyQualifiedName = fullyQualifiedName;
       return this;
     }

--- a/python-frontend/src/main/java/org/sonar/python/index/DescriptorsToProtobuf.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/DescriptorsToProtobuf.java
@@ -100,6 +100,7 @@ public class DescriptorsToProtobuf {
     }
     DescriptorsProtos.ClassDescriptor.Builder builder = DescriptorsProtos.ClassDescriptor.newBuilder()
       .setName(classDescriptor.name())
+      .setFullyQualifiedName(classDescriptor.fullyQualifiedName())
       .addAllSuperClasses(classDescriptor.superClasses())
       .addAllFunctionMembers(functionMembers)
       .addAllVarMembers(variableMembers)
@@ -110,9 +111,6 @@ public class DescriptorsToProtobuf {
       .setHasMetaClass(classDescriptor.hasMetaClass())
       .setSupportsGenerics(classDescriptor.supportsGenerics());
     LocationInFile definitionLocation = classDescriptor.definitionLocation();
-    if (classDescriptor.fullyQualifiedName() != null) {
-      builder.setFullyQualifiedName(classDescriptor.fullyQualifiedName());
-    }
     if (definitionLocation != null) {
       builder.setDefinitionLocation(toProtobuf(definitionLocation));
     }
@@ -126,6 +124,7 @@ public class DescriptorsToProtobuf {
   public static DescriptorsProtos.FunctionDescriptor toProtobuf(FunctionDescriptor functionDescriptor) {
     DescriptorsProtos.FunctionDescriptor.Builder builder = DescriptorsProtos.FunctionDescriptor.newBuilder()
       .setName(functionDescriptor.name())
+      .setFullyQualifiedName(functionDescriptor.fullyQualifiedName())
       .addAllParameters(functionDescriptor.parameters().stream().map(DescriptorsToProtobuf::toProtobuf).toList())
       .setIsAsynchronous(functionDescriptor.isAsynchronous())
       .setIsInstanceMethod(functionDescriptor.isInstanceMethod())
@@ -134,10 +133,6 @@ public class DescriptorsToProtobuf {
     String annotatedReturnTypeName = functionDescriptor.annotatedReturnTypeName();
     if (annotatedReturnTypeName != null) {
       builder.setAnnotatedReturnType(annotatedReturnTypeName);
-    }
-    String fullyQualifiedName = functionDescriptor.fullyQualifiedName();
-    if (fullyQualifiedName != null) {
-      builder.setFullyQualifiedName(functionDescriptor.fullyQualifiedName());
     }
     LocationInFile definitionLocation = functionDescriptor.definitionLocation();
     if (definitionLocation != null) {
@@ -216,7 +211,7 @@ public class DescriptorsToProtobuf {
   public static ClassDescriptor fromProtobuf(DescriptorsProtos.ClassDescriptor classDescriptorProto) {
     String metaclassFQN = classDescriptorProto.hasMetaClassFQN() ? classDescriptorProto.getMetaClassFQN() : null;
     LocationInFile definitionLocation = classDescriptorProto.hasDefinitionLocation() ? fromProtobuf(classDescriptorProto.getDefinitionLocation()) : null;
-    String fullyQualifiedName = classDescriptorProto.hasFullyQualifiedName() ? classDescriptorProto.getFullyQualifiedName() : null;
+    String fullyQualifiedName = classDescriptorProto.getFullyQualifiedName();
     Set<Descriptor> members = new HashSet<>();
     classDescriptorProto.getClassMembersList().forEach(proto -> members.add(fromProtobuf(proto)));
     classDescriptorProto.getFunctionMembersList().forEach(proto -> members.add(fromProtobuf(proto)));
@@ -237,7 +232,7 @@ public class DescriptorsToProtobuf {
   }
 
   public static FunctionDescriptor fromProtobuf(DescriptorsProtos.FunctionDescriptor functionDescriptorProto) {
-    String fullyQualifiedName = functionDescriptorProto.hasFullyQualifiedName() ? functionDescriptorProto.getFullyQualifiedName() : null;
+    String fullyQualifiedName = functionDescriptorProto.getFullyQualifiedName();
     List<FunctionDescriptor.Parameter> parameters = new ArrayList<>();
     functionDescriptorProto.getParametersList().forEach(proto -> parameters.add(fromProtobuf(proto)));
     LocationInFile definitionLocation = functionDescriptorProto.hasDefinitionLocation() ? fromProtobuf(functionDescriptorProto.getDefinitionLocation()) : null;

--- a/python-frontend/src/main/java/org/sonar/python/index/FunctionDescriptor.java
+++ b/python-frontend/src/main/java/org/sonar/python/index/FunctionDescriptor.java
@@ -22,6 +22,7 @@ package org.sonar.python.index;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.sonar.plugins.python.api.LocationInFile;
 
@@ -42,12 +43,12 @@ public class FunctionDescriptor implements Descriptor {
   private final TypeAnnotationDescriptor typeAnnotationDescriptor;
 
 
-  public FunctionDescriptor(String name, @Nullable String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
+  public FunctionDescriptor(String name, String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
     boolean isInstanceMethod, List<String> decorators, boolean hasDecorators, @Nullable LocationInFile definitionLocation, @Nullable String annotatedReturnTypeName) {
     this(name, fullyQualifiedName, parameters, isAsynchronous, isInstanceMethod, decorators, hasDecorators, definitionLocation, annotatedReturnTypeName, null);
   }
 
-  public FunctionDescriptor(String name, @Nullable String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
+  public FunctionDescriptor(String name, String fullyQualifiedName, List<Parameter> parameters, boolean isAsynchronous,
     boolean isInstanceMethod, List<String> decorators, boolean hasDecorators, @Nullable LocationInFile definitionLocation,
     @Nullable String annotatedReturnTypeName, @Nullable TypeAnnotationDescriptor typeAnnotationDescriptor) {
 
@@ -69,6 +70,7 @@ public class FunctionDescriptor implements Descriptor {
   }
 
   @Override
+  @Nonnull
   public String fullyQualifiedName() {
     return fullyQualifiedName;
   }
@@ -193,7 +195,7 @@ public class FunctionDescriptor implements Descriptor {
       return this;
     }
 
-    public FunctionDescriptorBuilder withFullyQualifiedName(@Nullable String fullyQualifiedName) {
+    public FunctionDescriptorBuilder withFullyQualifiedName(String fullyQualifiedName) {
       this.fullyQualifiedName = fullyQualifiedName;
       return this;
     }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/ClassTypeBuilder.java
@@ -33,8 +33,8 @@ import org.sonar.python.types.v2.PythonType;
 
 public class ClassTypeBuilder implements TypeBuilder<ClassType> {
 
-
-  String name;
+  private final String name;
+  private final String fullyQualifiedName;
   Set<Member> members = new HashSet<>();
   List<PythonType> attributes = new ArrayList<>();
   List<TypeWrapper> superClasses = new ArrayList<>();
@@ -44,12 +44,12 @@ public class ClassTypeBuilder implements TypeBuilder<ClassType> {
 
   @Override
   public ClassType build() {
-    return new ClassType(name, members, attributes, superClasses, metaClasses, hasDecorators, definitionLocation);
+    return new ClassType(name, fullyQualifiedName, members, attributes, superClasses, metaClasses, hasDecorators, definitionLocation);
   }
 
-  public ClassTypeBuilder withName(String name) {
+  public ClassTypeBuilder(String name, String fullyQualifiedName) {
     this.name = name;
-    return this;
+    this.fullyQualifiedName = fullyQualifiedName;
   }
 
   public ClassTypeBuilder withHasDecorators(boolean hasDecorators) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/ClassDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/ClassDescriptorToPythonTypeConverter.java
@@ -29,8 +29,7 @@ import org.sonar.python.types.v2.TypeWrapper;
 public class ClassDescriptorToPythonTypeConverter implements DescriptorToPythonTypeConverter {
 
   private static PythonType convert(ConversionContext ctx, ClassDescriptor from) {
-    var typeBuilder = new ClassTypeBuilder()
-      .withName(from.name())
+    var typeBuilder = new ClassTypeBuilder(from.name(), from.fullyQualifiedName())
       .withDefinitionLocation(from.definitionLocation());
 
     from.superClasses().stream()

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverter.java
@@ -183,8 +183,8 @@ public class PythonTypeToDescriptorConverter {
   private static String typeFqn(String moduleFqn, PythonType type) {
     if (type instanceof UnknownType.UnresolvedImportType importType) {
       return importType.importPath();
-    } else if (type instanceof ClassType) {
-      return moduleFqn + "." + type.name();
+    } else if (type instanceof ClassType classType) {
+      return classType.fullyQualifiedName();
     } else if (type instanceof FunctionType functionType) {
       return functionType.fullyQualifiedName();
     }

--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/types/TrivialTypeInferenceVisitor.java
@@ -261,8 +261,8 @@ public class TrivialTypeInferenceVisitor extends BaseTreeVisitor {
 
   private ClassType buildClassType(ClassDef classDef) {
     Name className = classDef.name();
-    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder()
-      .withName(className.name())
+    String fullyQualifiedName = currentScopeFullyQualifiedName() + "." + classDef.name().name();
+    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder(className.name(), fullyQualifiedName)
       .withHasDecorators(!classDef.decorators().isEmpty())
       .withDefinitionLocation(locationInFile(className, fileId));
     resolveTypeHierarchy(classDef, classTypeBuilder);

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/ClassType.java
@@ -38,6 +38,7 @@ import org.sonar.plugins.python.api.LocationInFile;
 public final class ClassType implements PythonType {
 
   private final String name;
+  private final String fullyQualifiedName;
   private final Set<Member> members;
   private final List<PythonType> attributes;
   private final List<TypeWrapper> superClasses;
@@ -47,6 +48,7 @@ public final class ClassType implements PythonType {
 
   public ClassType(
     String name,
+    String fullyQualifiedName,
     Set<Member> members,
     List<PythonType> attributes,
     List<TypeWrapper> superClasses,
@@ -54,6 +56,7 @@ public final class ClassType implements PythonType {
     boolean hasDecorators,
     @Nullable LocationInFile locationInFile) {
     this.name = name;
+    this.fullyQualifiedName = fullyQualifiedName;
     this.members = members;
     this.attributes = attributes;
     this.superClasses = superClasses;
@@ -62,12 +65,8 @@ public final class ClassType implements PythonType {
     this.locationInFile = locationInFile;
   }
 
-  public ClassType(String name) {
-    this(name, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, null);
-  }
-
-  public ClassType(String name, @Nullable LocationInFile locationInFile) {
-    this(name, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, locationInFile);
+  public ClassType(String name, String fullyQualifiedName) {
+    this(name, fullyQualifiedName, new HashSet<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), false, null);
   }
 
   @Override
@@ -208,6 +207,10 @@ public final class ClassType implements PythonType {
   @Override
   public String name() {
     return name;
+  }
+
+  public String fullyQualifiedName() {
+    return fullyQualifiedName;
   }
 
   public Set<Member> members() {

--- a/python-frontend/src/main/protobuf/descriptors.proto
+++ b/python-frontend/src/main/protobuf/descriptors.proto
@@ -31,7 +31,7 @@ message AmbiguousDescriptor {
 
 message ClassDescriptor {
     string name = 1;
-    optional string fullyQualifiedName = 2;
+    string fullyQualifiedName = 2;
     repeated string superClasses = 3;
     repeated FunctionDescriptor functionMembers = 4;
     repeated VarDescriptor varMembers = 5;
@@ -58,7 +58,7 @@ message ParameterDescriptor {
 
 message FunctionDescriptor {
     optional string name = 1;
-    optional string fullyQualifiedName = 2;
+    string fullyQualifiedName = 2;
     repeated ParameterDescriptor parameters = 3;
     bool isAsynchronous = 4;
     bool isInstanceMethod = 5;

--- a/python-frontend/src/test/java/org/sonar/python/PythonTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/PythonTestUtils.java
@@ -28,10 +28,7 @@ import java.util.function.Predicate;
 import javax.annotation.CheckForNull;
 import org.mockito.Mockito;
 import org.sonar.plugins.python.api.PythonFile;
-import org.sonar.plugins.python.api.symbols.ClassSymbol;
 import org.sonar.plugins.python.api.symbols.FunctionSymbol;
-import org.sonar.plugins.python.api.symbols.Symbol;
-import org.sonar.plugins.python.api.tree.ClassDef;
 import org.sonar.plugins.python.api.tree.Expression;
 import org.sonar.plugins.python.api.tree.ExpressionStatement;
 import org.sonar.plugins.python.api.tree.FileInput;
@@ -175,27 +172,6 @@ public final class PythonTestUtils {
     FileInput fileInput = parse(new SymbolTableBuilder("package", pythonFile("mod")), code);
     FunctionDef functionDef = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF) && ((FunctionDef) t).name().name().equals(name));
     return TreeUtils.getFunctionSymbolFromDef(functionDef);
-  }
-
-  public static ClassSymbol lastClassSymbol(String... code) {
-    FileInput fileInput = parse(new SymbolTableBuilder("package", PythonTestUtils.pythonFile("mod")), code);
-    ClassDef classDef = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF));
-    return TreeUtils.getClassSymbolFromDef(classDef);
-  }
-
-  public static ClassSymbol lastClassSymbolWithName(String name, String... code) {
-    FileInput fileInput = parse(new SymbolTableBuilder("package", PythonTestUtils.pythonFile("mod")), code);
-    ClassDef classDef = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF) && ((ClassDef) t).name().name().equals(name));
-    return TreeUtils.getClassSymbolFromDef(classDef);
-  }
-
-  public static Symbol lastSymbolFromDef(String... code) {
-    FileInput fileInput = parse(new SymbolTableBuilder("package", pythonFile("mod")), code);
-    Tree tree = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF, Tree.Kind.CLASSDEF));
-    if (tree.is(Tree.Kind.CLASSDEF)) {
-      return ((ClassDef) tree).name().symbol();
-    }
-    return ((FunctionDef) tree).name().symbol();
   }
 
   public static List<EscapeCharPositionInfo> mapToColumnMappingList(Map<Integer, Integer> map) {

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeCheckerBuilderTest.java
@@ -54,33 +54,27 @@ class TypeCheckerBuilderTest {
     var intClassType = table.getType("int");
     var strClassType = table.getType("str");
 
-    var aClassType = new ClassTypeBuilder()
-      .withName("A")
+    var aClassType = new ClassTypeBuilder("A", "mod.A")
       .withSuperClasses(intClassType)
       .build();
 
-    var bClassType = new ClassTypeBuilder()
-      .withName("B")
+    var bClassType = new ClassTypeBuilder("B", "mod.B")
       .withSuperClasses(strClassType)
       .build();
 
-    var cClassType = new ClassTypeBuilder()
-      .withName("C")
+    var cClassType = new ClassTypeBuilder("C", "mod.C")
       .withSuperClasses(PythonType.UNKNOWN, intClassType)
       .build();
 
-    var dClassType = new ClassTypeBuilder()
-      .withName("D")
+    var dClassType = new ClassTypeBuilder("D", "mod.D")
       .withSuperClasses(PythonType.UNKNOWN, strClassType)
       .build();
 
-    var iClassType = new ClassTypeBuilder()
-      .withName("I")
+    var iClassType = new ClassTypeBuilder("I", "mod.I")
       .withSuperClasses(aClassType, intClassType)
       .build();
 
-    var jClassType = new ClassTypeBuilder()
-      .withName("J")
+    var jClassType = new ClassTypeBuilder("J", "mod.J")
       .withSuperClasses(UnionType.or(bClassType, aClassType))
       .build();
 

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/DescriptorToPythonTypeConverterTest.java
@@ -65,7 +65,8 @@ class DescriptorToPythonTypeConverterTest {
     var descriptorAlternative1 = Mockito.mock(FunctionDescriptor.class);
 
     var returnTypeName = "Returned";
-    var resolvedReturnType = new ClassTypeBuilder().withName(returnTypeName).build();
+    String fullyQualifiedName = "returned.ReturnTypeName";
+    var resolvedReturnType = new ClassTypeBuilder(returnTypeName, fullyQualifiedName).build();
     Mockito.when(lazyTypesContext.resolveLazyType(Mockito.argThat(lt -> returnTypeName.equals(lt.importPath()))))
       .thenReturn(resolvedReturnType);
 
@@ -123,7 +124,8 @@ class DescriptorToPythonTypeConverterTest {
     var descriptor = Mockito.mock(ClassDescriptor.class);
 
     var parentClassName = "Parent";
-    var resolvedParent = new ClassTypeBuilder().withName(parentClassName).build();
+    String parentClassFqn = "parent.Parent";
+    var resolvedParent = new ClassTypeBuilder(parentClassName, parentClassFqn).build();
 
     var member = Mockito.mock(AmbiguousDescriptor.class);
     Mockito.when(member.kind()).thenReturn(Descriptor.Kind.AMBIGUOUS);
@@ -161,7 +163,8 @@ class DescriptorToPythonTypeConverterTest {
     var descriptor = Mockito.mock(FunctionDescriptor.class);
 
     var returnTypeName = "Returned";
-    var resolvedReturnType = new ClassTypeBuilder().withName(returnTypeName).build();
+    String returnTypeFqn = "returned.Returned";
+    var resolvedReturnType = new ClassTypeBuilder(returnTypeName, returnTypeFqn).build();
 
     Mockito.when(descriptor.kind()).thenReturn(Descriptor.Kind.FUNCTION);
     Mockito.when(descriptor.name()).thenReturn("Sample");
@@ -211,7 +214,8 @@ class DescriptorToPythonTypeConverterTest {
     var descriptor = Mockito.mock(VariableDescriptor.class);
 
     var variableTypeName = "Returned";
-    var resolvedVariableType = new ClassTypeBuilder().withName(variableTypeName).build();
+    String variableTypeFqn = "returned.Returned";
+    var resolvedVariableType = new ClassTypeBuilder(variableTypeName, variableTypeFqn).build();
 
     Mockito.when(descriptor.kind()).thenReturn(Descriptor.Kind.VARIABLE);
     Mockito.when(descriptor.name()).thenReturn("variable");

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverterTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverterTest.java
@@ -110,7 +110,7 @@ class PythonTypeToDescriptorConverterTest {
 
   @Test
   void testConvertClassType() {
-    ClassType classType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType classType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
     Descriptor descriptor = converter.convert("foo", new SymbolV2("myClass"), Set.of(classType));
 
     assertThat(descriptor).isInstanceOf(ClassDescriptor.class);
@@ -188,8 +188,8 @@ class PythonTypeToDescriptorConverterTest {
 
   @Test
   void testConvertUnionType() {
-    ClassType classType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
-    ClassType anotherClassType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType classType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType anotherClassType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
     UnionType unionType = new UnionType(Set.of(classType, anotherClassType));
     Descriptor descriptor = converter.convert("foo", new SymbolV2("myUnionType"), Set.of(unionType));
 
@@ -206,7 +206,7 @@ class PythonTypeToDescriptorConverterTest {
 
   @Test
   void testConvertManyTypes() {
-    ClassType classType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType classType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
     FunctionType functionType = new FunctionType("functionType", "my_package.functionType", List.of(new ModuleType("bar")), List.of(), List.of(), floatTypeWrapper, TypeOrigin.LOCAL, true, false, true, false, null, location);
     Descriptor descriptor = converter.convert("foo", new SymbolV2("myUnionType"), Set.of(functionType, classType));
 
@@ -221,8 +221,8 @@ class PythonTypeToDescriptorConverterTest {
 
   @Test
   void testConvertManyTypesWithUnionType() {
-    ClassType classType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
-    ClassType anotherClassType = new ClassType("classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType classType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
+    ClassType anotherClassType = new ClassType("classType", "my_package.classType", Set.of(new Member("aMember", intTypeWrapper.type())), List.of(), List.of(floatTypeWrapper), List.of(intTypeWrapper.type()), true, location);
 
     UnionType unionType = new UnionType(Set.of(classType, anotherClassType));
     Descriptor descriptor = converter.convert("foo", new SymbolV2("myUnionType"), Set.of(unionType, classType));

--- a/python-frontend/src/test/java/org/sonar/python/types/TypeInferenceTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/TypeInferenceTest.java
@@ -43,7 +43,6 @@ import org.sonar.python.semantic.SymbolTableBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.sonar.python.PythonTestUtils.getLastDescendant;
-import static org.sonar.python.PythonTestUtils.lastClassSymbolWithName;
 import static org.sonar.python.PythonTestUtils.lastExpression;
 import static org.sonar.python.PythonTestUtils.lastExpressionInFunction;
 import static org.sonar.python.PythonTestUtils.lastStatement;
@@ -808,14 +807,15 @@ class TypeInferenceTest {
 
   @Test
   void child_class_method_call_is_a_member_of_parent_class() {
-    ClassSymbol classA = lastClassSymbolWithName("A", """
+    ClassSymbol classA = ((ClassSymbol) ((Name) lastExpression("A", """
       class A:
         def meth(self):
           return self.foo()
       class B(A):
         def foo(self): pass
+      A
       """
-    );
+    )).symbol());
     assertThat(classA.canHaveMember("foo")).isTrue();
     assertThat(classA.declaredMembers()).extracting("kind", "name")
       .containsExactlyInAnyOrder(Tuple.tuple(Symbol.Kind.FUNCTION, "meth"), Tuple.tuple(Symbol.Kind.OTHER, "foo"));

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ClassTypeTest.java
@@ -586,21 +586,13 @@ public class ClassTypeTest {
 
   @Test
   void builder() {
-    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder().withName("A");
+    ClassTypeBuilder classTypeBuilder = new ClassTypeBuilder("A", "mod.A");
     assertThat(classTypeBuilder.build()).extracting(ClassType::name).isEqualTo("A");
   }
 
   @Test
   void displayName() {
-    ClassType classType = new ClassType("...");
-    assertThat(classType.instanceDisplayName()).contains("...");
-    assertThat(classType.displayName()).contains("type");
-
-    classType = new ClassType("MyClass");
-    assertThat(classType.instanceDisplayName()).contains("MyClass");
-    assertThat(classType.displayName()).contains("type");
-
-    classType = new ClassType("mymod.MyClass");
+    ClassType classType = new ClassType("MyClass", "mymod.MyClass");
     assertThat(classType.instanceDisplayName()).contains("MyClass");
     assertThat(classType.displayName()).contains("type");
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ModuleTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ModuleTypeTest.java
@@ -50,7 +50,7 @@ class ModuleTypeTest {
   @Test
   void doNotReplaceKnownMember() {
     var a = new ModuleType("a");
-    ClassType existingMember = new ClassType("b");
+    ClassType existingMember = new ClassType("b", "mymod.b");
     a.members().put("b", TypeWrapper.of(existingMember));
     Assertions.assertThat(a.resolveMember("b")).containsSame(existingMember);
     new ModuleType("b", a);

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/ObjectTypeTest.java
@@ -172,7 +172,7 @@ class ObjectTypeTest {
 
   @Test
   void function_is_callable() {
-      ClassType classType = new ClassType("function");
+      ClassType classType = new ClassType("function", "builtins.function");
       assertThat(classType.instancesHaveMember("__call__")).isEqualTo(TriBool.TRUE);
       assertThat(classType.instancesHaveMember("other")).isEqualTo(TriBool.FALSE);
   }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypesTestUtils.java
@@ -20,7 +20,11 @@
 package org.sonar.python.types.v2;
 
 import org.sonar.plugins.python.api.PythonFile;
+import org.sonar.plugins.python.api.tree.ClassDef;
 import org.sonar.plugins.python.api.tree.FileInput;
+import org.sonar.plugins.python.api.tree.FunctionDef;
+import org.sonar.plugins.python.api.tree.Name;
+import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
@@ -46,7 +50,7 @@ public class TypesTestUtils {
   public static final PythonType EXCEPTION_TYPE = BUILTINS.resolveMember("Exception").get();
 
   public static FileInput parseAndInferTypes(String... code) {
-    return parseAndInferTypes(PythonTestUtils.pythonFile(""), code);
+    return parseAndInferTypes(PythonTestUtils.pythonFile("mod"), code);
   }
 
   public static FileInput parseAndInferTypes(PythonFile pythonFile, String... code) {
@@ -59,4 +63,26 @@ public class TypesTestUtils {
     new TypeInferenceV2(typeTable, pythonFile, symbolTable, "my_package").inferTypes(fileInput);
     return fileInput;
   }
+
+  public static ClassDef lastClassDef(String... code) {
+    FileInput fileInput = parseAndInferTypes(code);
+    return PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF));
+  }
+
+  public static FunctionDef lastFunctionDef(String... code) {
+    FileInput fileInput = parseAndInferTypes(code);
+    return PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.FUNCDEF));
+  }
+
+  public static ClassDef lastClassDefWithName(String name, String... code) {
+    FileInput fileInput = parseAndInferTypes(code);
+    return PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.CLASSDEF) && ((ClassDef) t).name().name().equals(name));
+  }
+
+  public static Name lastName(String... code) {
+    FileInput fileInput = parseAndInferTypes(code);
+    Tree tree = PythonTestUtils.getLastDescendant(fileInput, t -> t.is(Tree.Kind.NAME));
+    return (Name) tree;
+  }
+
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/UnionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/UnionTypeTest.java
@@ -144,11 +144,11 @@ class UnionTypeTest {
 
   @Test
   void unionTypeCandidatesResolution() {
-    var candidate1 = new ClassType("candidate", Set.of(
+    var candidate1 = new ClassType("candidate", "mymod.candidate", Set.of(
       new Member("a", new FunctionTypeBuilder("a").build())
     ), List.of(), List.of(), List.of(), false, null);
 
-    var candidate2 = new ClassType("candidate", Set.of(
+    var candidate2 = new ClassType("candidate", "mymod.candidate", Set.of(
       new Member("a", new FunctionTypeBuilder("a").build())
     ), List.of(), List.of(), List.of(), false, null);
 


### PR DESCRIPTION
[SONARPY-2339](https://sonarsource.atlassian.net/browse/SONARPY-2339)

Following this PR, there are possible null arguments to `ClassDescriptor#fullQualifiedName` and `FunctionDescriptor#fullQualifiedName` in `DescriptorUtils`. These methods are no longer used in production code, and are only used in tests (mostly in `ProjectLevelSymbolTableTest` through `ProjectLevelSymbolTable#from`). [SONARPY-2346](https://sonarsource.atlassian.net/browse/SONARPY-2346) has been created to handle this.

[SONARPY-2339]: https://sonarsource.atlassian.net/browse/SONARPY-2339?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONARPY-2346]: https://sonarsource.atlassian.net/browse/SONARPY-2346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ