### PR TITLE
SONARPY-2342 Fix NPE when metaclassFQN resolved to null during a PythonType to Descriptor conversion

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/PythonTypeToDescriptorConverter.java
@@ -132,6 +132,7 @@ public class PythonTypeToDescriptorConverter {
     var metaclassFQN = type.metaClasses()
       .stream()
       .map(metaClass -> typeFqn(moduleFqn, metaClass))
+      .filter(Objects::nonNull)
       .findFirst()
       .orElse(null);
 

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
@@ -1191,6 +1191,20 @@ class ProjectLevelSymbolTableTest {
   }
 
   @Test
+  void class_wth_call_result_metaclass() {
+    var code = """
+      def foo(): ...
+      class WithMetaclass(metaclass=foo()): ...
+      """;
+
+    var projectSymbolTable = new ProjectLevelSymbolTable();
+    projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
+    var symbol = (ClassSymbolImpl) projectSymbolTable.getSymbol("mod.WithMetaclass");
+    assertThat(symbol.hasMetaClass()).isTrue();
+    assertThat(symbol.metaclassFQN()).isNull();
+  }
+
+  @Test
   void projectPackages() {
     ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
     projectLevelSymbolTable.addProjectPackage("first.package");


### PR DESCRIPTION
[SONARPY-2342](https://sonarsource.atlassian.net/browse/SONARPY-2342)



[SONARPY-2342]: https://sonarsource.atlassian.net/browse/SONARPY-2342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ