### PR TITLE
SONARPY-2346 Remove usage of old ProjectLevelSymbolTable#from using V1 symbols

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/TestPythonVisitorRunner.java
+++ b/python-frontend/src/main/java/org/sonar/python/TestPythonVisitorRunner.java
@@ -81,7 +81,7 @@ public class TestPythonVisitorRunner {
   }
 
   public static ProjectLevelSymbolTable globalSymbols(List<File> files, File baseDir) {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     for (File file : files) {
       var pythonFile = new TestPythonFile(file);
       if (pythonFile.isIPython()) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
@@ -65,7 +65,7 @@ public class ProjectLevelSymbolTable {
   }
 
   public static ProjectLevelSymbolTable from(Map<String, Set<Descriptor>> globalDescriptorsByModuleName) {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     for (var entry : globalDescriptorsByModuleName.entrySet()) {
       var descriptors = entry.getValue();
@@ -75,7 +75,7 @@ public class ProjectLevelSymbolTable {
     return projectLevelSymbolTable;
   }
 
-  public ProjectLevelSymbolTable() {
+  private ProjectLevelSymbolTable() {
     this.globalDescriptorsByModuleName = new HashMap<>();
   }
 

--- a/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
@@ -61,25 +61,23 @@ public class ProjectLevelSymbolTable {
   private TypeShedDescriptorsProvider typeShedDescriptorsProvider = null;
 
   public static ProjectLevelSymbolTable empty() {
-    return new ProjectLevelSymbolTable(Collections.emptyMap());
+    return new ProjectLevelSymbolTable();
   }
 
-  public static ProjectLevelSymbolTable from(Map<String, Set<Symbol>> globalSymbolsByModuleName) {
-    return new ProjectLevelSymbolTable(globalSymbolsByModuleName);
+  public static ProjectLevelSymbolTable from(Map<String, Set<Descriptor>> globalDescriptorsByModuleName) {
+    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+
+    for (var entry : globalDescriptorsByModuleName.entrySet()) {
+      var descriptors = entry.getValue();
+      projectLevelSymbolTable.globalDescriptorsByModuleName.put(entry.getKey(), descriptors);
+      projectLevelSymbolTable.addModuleToGlobalSymbolsByFQN(descriptors);
+    }
+
+    return projectLevelSymbolTable;
   }
 
   public ProjectLevelSymbolTable() {
     this.globalDescriptorsByModuleName = new HashMap<>();
-  }
-
-  private ProjectLevelSymbolTable(Map<String, Set<Symbol>> globalSymbolsByModuleName) {
-    this.globalDescriptorsByModuleName = new HashMap<>();
-    globalSymbolsByModuleName.entrySet().forEach(entry -> {
-      String moduleName = entry.getKey();
-      Set<Symbol> symbols = entry.getValue();
-      Set<Descriptor> globalDescriptors = symbols.stream().map(DescriptorUtils::descriptor).collect(Collectors.toSet());
-      globalDescriptorsByModuleName.put(moduleName, globalDescriptors);
-    });
   }
 
   public void removeModule(String packageName, String fileName) {

--- a/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/ProjectLevelSymbolTable.java
@@ -70,7 +70,6 @@ public class ProjectLevelSymbolTable {
     for (var entry : globalDescriptorsByModuleName.entrySet()) {
       var descriptors = entry.getValue();
       projectLevelSymbolTable.globalDescriptorsByModuleName.put(entry.getKey(), descriptors);
-      projectLevelSymbolTable.addModuleToGlobalSymbolsByFQN(descriptors);
     }
 
     return projectLevelSymbolTable;

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/PythonVisitorContextTest.java
@@ -18,10 +18,7 @@ package org.sonar.plugins.python.api;
 
 import com.sonar.sslr.api.RecognitionException;
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
@@ -33,9 +30,10 @@ import org.sonar.plugins.python.api.tree.FunctionDef;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
 import org.sonar.python.caching.CacheContextImpl;
+import org.sonar.python.index.Descriptor;
+import org.sonar.python.index.VariableDescriptor;
 import org.sonar.python.parser.PythonParser;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
-import org.sonar.python.semantic.SymbolImpl;
 import org.sonar.python.tree.FileInputImpl;
 import org.sonar.python.tree.PythonTreeMaker;
 
@@ -82,9 +80,11 @@ class PythonVisitorContextTest {
     String code = "from mod import a, b";
     FileInput fileInput = new PythonTreeMaker().fileInput(PythonParser.create().parse(code));
     PythonFile pythonFile = pythonFile("my_module.py");
-    List<Symbol> modSymbols = Arrays.asList(new SymbolImpl("a", null), new SymbolImpl("b", null));
-    Map<String, Set<Symbol>> globalSymbols = Collections.singletonMap("mod", new HashSet<>(modSymbols));
-    new PythonVisitorContext(fileInput, pythonFile, null, "my_package", ProjectLevelSymbolTable.from(globalSymbols), null);
+
+    Set<Descriptor> descriptors = Set.of(new VariableDescriptor("a", "mod.a", null), new VariableDescriptor("b", "mod.b", null));
+    Map<String, Set<Descriptor>> globalDescriptors = Collections.singletonMap("mod", descriptors);
+
+    new PythonVisitorContext(fileInput, pythonFile, null, "my_package", ProjectLevelSymbolTable.from(globalDescriptors), CacheContextImpl.dummyCache());
     assertThat(fileInput.globalVariables()).extracting(Symbol::name).containsExactlyInAnyOrder("a", "b");
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/index/AmbiguousDescriptorTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/index/AmbiguousDescriptorTest.java
@@ -20,7 +20,6 @@ import java.util.Collections;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.sonar.plugins.python.api.tree.Name;
-import org.sonar.python.semantic.SymbolImpl;
 import org.sonar.python.semantic.v2.SymbolV2;
 import org.sonar.python.semantic.v2.converter.PythonTypeToDescriptorConverter;
 import org.sonar.python.types.v2.PythonType;
@@ -30,7 +29,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.sonar.python.index.ClassDescriptorTest.lastClassDescriptor;
 import static org.sonar.python.index.DescriptorToProtobufTestUtils.assertDescriptorToProtobuf;
-import static org.sonar.python.index.DescriptorUtils.descriptor;
 import static org.sonar.python.index.FunctionDescriptorTest.lastFunctionDescriptor;
 import static org.sonar.python.types.v2.TypesTestUtils.lastName;
 
@@ -110,10 +108,8 @@ class AmbiguousDescriptorTest {
 
   @Test
   void ambiguous_descriptor_creation_different_name_same_fqn() {
-    SymbolImpl foo = new SymbolImpl("foo", "mod.bar");
-    SymbolImpl bar = new SymbolImpl("bar", "mod.bar");
-    Descriptor fooDesc = descriptor(foo);
-    Descriptor barDesc = descriptor(bar);
+    Descriptor fooDesc = new VariableDescriptor("foo", "mod.bar", null, false);
+    Descriptor barDesc = new VariableDescriptor("bar", "mod.bar", null, false);
     assertThatThrownBy(() -> AmbiguousDescriptor.create(fooDesc, barDesc)).isInstanceOf(IllegalArgumentException.class);
   }
 

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
@@ -400,7 +400,7 @@ class ProjectLevelSymbolTableTest {
   }
 
   private static Set<Symbol> globalSymbols(FileInput fileInput, String packageName) {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addModule(fileInput, packageName, pythonFile("mod.py"));
     return projectLevelSymbolTable.getSymbolsFromModule(packageName.isEmpty() ? "mod" : packageName + ".mod");
   }
@@ -410,7 +410,7 @@ class ProjectLevelSymbolTableTest {
     FileInput tree = parseWithoutSymbols(
       "class A: pass"
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
     assertThat(projectLevelSymbolTable.getSymbolsFromModule("mod")).extracting(Symbol::name).containsExactlyInAnyOrder("A");
     projectLevelSymbolTable.removeModule("", "mod.py");
@@ -419,7 +419,7 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void test_insert_entry() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     VariableDescriptor variableDescriptor = new VariableDescriptor("x", "mod.x", null);
     projectLevelSymbolTable.insertEntry("mod", Set.of(variableDescriptor));
     assertThat(projectLevelSymbolTable.descriptorsForModule("mod")).containsExactly(variableDescriptor);
@@ -431,7 +431,7 @@ class ProjectLevelSymbolTableTest {
     FileInput tree = parseWithoutSymbols(
       "class A: pass"
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
     assertThat(projectLevelSymbolTable.getSymbolsFromModule("mod")).extracting(Symbol::name).containsExactlyInAnyOrder("A");
     assertThat(projectLevelSymbolTable.getSymbolsFromModule("mod2")).isNull();
@@ -452,7 +452,7 @@ class ProjectLevelSymbolTableTest {
     FileInput tree = parseWithoutSymbols(
       "import A"
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
     assertThat(projectLevelSymbolTable.importsByModule()).containsExactly(Map.entry("mod", Set.of("A")));
     assertThat(projectLevelSymbolTable.getSymbolsFromModule("mod2")).isNull();
@@ -651,7 +651,7 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void child_class_method_call_is_not_a_member_of_parent_class() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     FileInput importedFileInput = parseWithoutSymbols(
       "class A:",
       "  def meth(self): ",
@@ -797,7 +797,7 @@ class ProjectLevelSymbolTableTest {
       "class B(A): ..."
     };
 
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(foo), "", pythonFile("foo.py"));
     projectSymbolTable.addModule(parseWithoutSymbols(bar), "", pythonFile("bar.py"));
 
@@ -838,7 +838,7 @@ class ProjectLevelSymbolTableTest {
       "class A: ...",
              "class B(A): ..."
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
     Set<Symbol> mod = projectLevelSymbolTable.getSymbolsFromModule("mod");
     assertThat(mod).extracting(Symbol::name).containsExactlyInAnyOrder("A", "B");
@@ -890,7 +890,7 @@ class ProjectLevelSymbolTableTest {
     String[] bar = {
       "from foo import *\n",
     };
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(foo), "", pythonFile("foo.py"));
     projectSymbolTable.addModule(parseWithoutSymbols(bar), "", pythonFile("bar.py"));
 
@@ -914,7 +914,7 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void ambiguous_descriptor_alternatives_dont_rely_on_FQN_for_conversion() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     Set<Descriptor> descriptors = new HashSet<>();
     VariableDescriptor variableDescriptor = new VariableDescriptor("Ambiguous", "foo.Ambiguous", null);
     ClassDescriptor classDescriptor = new ClassDescriptor("Ambiguous", "foo.Ambiguous", List.of(), Set.of(), false, null, false, false, null, false);
@@ -946,7 +946,7 @@ class ProjectLevelSymbolTableTest {
       "  def my_B_other_method(param: B): ..."
     };
 
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(foo), "", pythonFile("foo.py"));
     projectSymbolTable.addModule(parseWithoutSymbols(bar), "", pythonFile("bar.py"));
 
@@ -979,7 +979,7 @@ class ProjectLevelSymbolTableTest {
       "def bar(): ..."
     };
 
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(urls), "", pythonFile("urls.py"));
 
     assertThat(projectSymbolTable.isDjangoView("views.foo")).isTrue();
@@ -1011,7 +1011,7 @@ class ProjectLevelSymbolTableTest {
       urlpatterns.append(path('bar', MyOtherClass.MyNestedClass.qix, name='bar'))
       """;
 
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(content), "my_package", pythonFile("urls.py"));
     assertThat(projectSymbolTable.isDjangoView("my_package.urls.foo")).isTrue();
     assertThat(projectSymbolTable.isDjangoView("my_package.urls.MyClass.bar")).isTrue();
@@ -1028,7 +1028,7 @@ class ProjectLevelSymbolTableTest {
         def ambiguous(): ...
       urlpatterns = [path('bar', ambiguous, name='bar')]
       """;
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(content), "my_package", pythonFile("urls.py"));
     assertThat(projectSymbolTable.isDjangoView("my_package.urls.ambiguous")).isFalse();
   }
@@ -1040,7 +1040,7 @@ class ProjectLevelSymbolTableTest {
       import views
       urlpatterns = [conf.path('foo', views.foo, name='foo'), conf.path('baz')]
       """;
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(content), "my_package", pythonFile("urls.py"));
     assertThat(projectSymbolTable.isDjangoView("views.foo")).isTrue();
   }
@@ -1057,7 +1057,7 @@ class ProjectLevelSymbolTableTest {
         def get_urlpatterns(self):
           return [path("something", self.view_method, name="something")]
       """;
-    ProjectLevelSymbolTable projectSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(content), "my_package", pythonFile("mod.py"));
     // SONARPY-2322: should be true
     assertThat(projectSymbolTable.isDjangoView("my_package.mod.ClassWithViews.view_method")).isFalse();
@@ -1086,7 +1086,7 @@ class ProjectLevelSymbolTableTest {
       class Field(MetaField()): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
 
     var descriptors = projectSymbolTable.getDescriptorsFromModule("mod");
@@ -1111,7 +1111,7 @@ class ProjectLevelSymbolTableTest {
       class Field(MetaField): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
     var symbol = (ClassSymbol) projectSymbolTable.getSymbol("mod.Field");
     assertThat(symbol.hasUnresolvedTypeHierarchy()).isTrue();
@@ -1124,7 +1124,7 @@ class ProjectLevelSymbolTableTest {
       class WithMetaclass(metaclass=ABCMeta): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
     var symbol = (ClassSymbolImpl) projectSymbolTable.getSymbol("mod.WithMetaclass");
     assertThat(symbol.metaclassFQN()).isEqualTo("abc.ABCMeta");
@@ -1137,7 +1137,7 @@ class ProjectLevelSymbolTableTest {
       class WithMetaclass(metaclass=LocalMetaClass): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
     var symbol = (ClassSymbolImpl) projectSymbolTable.getSymbol("mod.WithMetaclass");
     assertThat(symbol.metaclassFQN()).isEqualTo("mod.LocalMetaClass");
@@ -1150,7 +1150,7 @@ class ProjectLevelSymbolTableTest {
       class WithMetaclass(metaclass=UnresolvedMetaClass): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
     var symbol = (ClassSymbolImpl) projectSymbolTable.getSymbol("mod.WithMetaclass");
     assertThat(symbol.metaclassFQN()).isEqualTo("unknown.UnresolvedMetaClass");
@@ -1163,7 +1163,7 @@ class ProjectLevelSymbolTableTest {
       class WithMetaclass(metaclass=foo()): ...
       """;
 
-    var projectSymbolTable = new ProjectLevelSymbolTable();
+    var projectSymbolTable = empty();
     projectSymbolTable.addModule(parseWithoutSymbols(code), "", pythonFile("mod.py"));
     var symbol = (ClassSymbolImpl) projectSymbolTable.getSymbol("mod.WithMetaclass");
     assertThat(symbol.hasMetaClass()).isTrue();
@@ -1172,7 +1172,7 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void projectPackages() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = empty();
     projectLevelSymbolTable.addProjectPackage("first.package");
     projectLevelSymbolTable.addProjectPackage("second.package");
     projectLevelSymbolTable.addProjectPackage("third");

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
@@ -44,7 +44,6 @@ import org.sonar.python.PythonTestUtils;
 import org.sonar.python.index.AmbiguousDescriptor;
 import org.sonar.python.index.ClassDescriptor;
 import org.sonar.python.index.Descriptor;
-import org.sonar.python.index.DescriptorUtils;
 import org.sonar.python.index.FunctionDescriptor;
 import org.sonar.python.index.VariableDescriptor;
 import org.sonar.python.tree.TreeUtils;
@@ -1078,26 +1077,6 @@ class ProjectLevelSymbolTableTest {
 
     FunctionDef functionDef = (FunctionDef) fileInput.statements().statements().get(0);
     assertThat(functionDef.localVariables()).isEmpty();
-  }
-
-  @Test
-  void descriptorsForModule() {
-    FileInput tree = PythonTestUtils.parseWithoutSymbols(
-      "class A: ...",
-      "class B(A): ...",
-      "def foo(): ...",
-      "x :int = 42",
-      "def bar(): ...",
-      "bar = 24"
-    );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
-    projectLevelSymbolTable.addModule(tree, "", PythonTestUtils.pythonFile("mod.py"));
-    Set<Symbol> symbols = projectLevelSymbolTable.getSymbolsFromModule("mod");
-    Set<Descriptor> retrievedDescriptors = projectLevelSymbolTable.descriptorsForModule("mod");
-    Set<Descriptor> recomputedDescriptors = new HashSet<>();
-    assertThat(symbols).isNotNull();
-    symbols.forEach(s -> recomputedDescriptors.add(DescriptorUtils.descriptor(s)));
-    assertThat(recomputedDescriptors).usingRecursiveFieldByFieldElementComparator().containsExactlyInAnyOrderElementsOf(retrievedDescriptors);
   }
 
   @Test

--- a/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
@@ -71,7 +71,7 @@ class ProjectLevelSymbolTableTest {
       Set.of(
         new VariableDescriptor("a", "mod.a", null),
         new VariableDescriptor("b", "mod.b", null),
-        new ClassDescriptor("C", "mod.C", Set.of(), Set.of(), false, null, false, false, null, false)));
+        new ClassDescriptor.ClassDescriptorBuilder().withName("C").withFullyQualifiedName("mod.C").build()));
 
     FileInput tree = parse(
       new SymbolTableBuilder("my_package", pythonFile("my_module.py"), from(globalDescriptors)),
@@ -226,8 +226,8 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void type_hierarchy() {
-    var classADescriptor = new ClassDescriptor("A", "mod1.A", Collections.singleton("mod2.B"), Set.of(), false, null, false, false, null, false);
-    var classBDescriptor = new ClassDescriptor("B", "mod2.B", List.of(), Set.of(), false, null, false, false, null, false);
+    var classADescriptor = new ClassDescriptor.ClassDescriptorBuilder().withName("A").withFullyQualifiedName("mod1.A").withSuperClasses(Set.of("mod2.B")).build();
+    var classBDescriptor = new ClassDescriptor.ClassDescriptorBuilder().withName("B").withFullyQualifiedName("mod2.B").build();
     Map<String, Set<Descriptor>> globalDescriptors = new HashMap<>();
     globalDescriptors.put("mod1", Set.of(classADescriptor));
     globalDescriptors.put("mod2", Set.of(classBDescriptor));
@@ -297,7 +297,7 @@ class ProjectLevelSymbolTableTest {
   void builtin_symbol_in_super_class() {
     Map<String, Set<Descriptor>> globalDescriptors = Collections.singletonMap("mod1",
       Collections.singleton(
-        new ClassDescriptor("A", "mod1.A", Collections.singleton("BaseException"), Set.of(), false, null, false, false, null, false)));
+        new ClassDescriptor.ClassDescriptorBuilder().withName("A").withFullyQualifiedName("mod1.A").withSuperClasses(Set.of("BaseException")).build()));
     FileInput tree = parse(
       new SymbolTableBuilder("my_package", pythonFile("my_module.py"), from(globalDescriptors)),
       "from mod1 import A");
@@ -312,9 +312,9 @@ class ProjectLevelSymbolTableTest {
 
   @Test
   void multi_level_type_hierarchy() {
-    ClassDescriptor classADescriptor = new ClassDescriptor("A", "mod1.A", Collections.singleton("mod2.B"), Set.of(), false, null, false, false, null, false);
-    ClassDescriptor classBDescriptor = new ClassDescriptor("B", "mod2.B", Collections.singleton("mod3.C"), Set.of(), false, null, false, false, null, false);
-    ClassDescriptor classCDescriptor = new ClassDescriptor("C", "mod3.C", Set.of(), Set.of(), false, null, false, false, null, false);
+    var classADescriptor = new ClassDescriptor.ClassDescriptorBuilder().withName("A").withFullyQualifiedName("mod1.A").withSuperClasses(Set.of("mod2.B")).build();
+    var classBDescriptor = new ClassDescriptor.ClassDescriptorBuilder().withName("B").withFullyQualifiedName("mod2.B").withSuperClasses(Set.of("mod3.C")).build();
+    var classCDescriptor = new ClassDescriptor.ClassDescriptorBuilder().withName("C").withFullyQualifiedName("mod3.C").build();
 
     Map<String, Set<Descriptor>> globalDescriptors = new HashMap<>();
     globalDescriptors.put("mod1", Set.of(classADescriptor));

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/ProjectLevelTypeTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/ProjectLevelTypeTableTest.java
@@ -139,7 +139,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importingSubmodulesTest() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     FileInput libTree = parseWithoutSymbols(
       """
@@ -180,7 +180,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importingRedefinedSubmodulesTest() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     FileInput libTree = parseWithoutSymbols(
       """
@@ -224,7 +224,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importingRedefinedSubmodules2Test() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     FileInput libTree = parseWithoutSymbols(
       """
@@ -264,7 +264,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importFunctionWithDecorators() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var libTree = parseWithoutSymbols(
       """
       def lib_decorator(): ...
@@ -290,7 +290,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importFunctionWithImportedDecorators() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var libTree = parseWithoutSymbols(
       """
       def lib_decorator(): ...
@@ -321,7 +321,7 @@ class ProjectLevelTypeTableTest {
   
   @Test
   void importedFunctionDecoratorNamesTest() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var libTree = parseWithoutSymbols(
       """
       from abc import abstractmethod
@@ -353,7 +353,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void relativeImports() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     FileInput initTree = parseWithoutSymbols("");
     PythonFile initFile = pythonFile("__init__.py");
     projectLevelSymbolTable.addModule(initTree, "my_package", initFile);
@@ -384,7 +384,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void importFunctionWithUnresolvedImportParameterTypes() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var libTree = parseWithoutSymbols(
       """
       def imported_function(params: list[str]): ...
@@ -406,7 +406,7 @@ class ProjectLevelTypeTableTest {
 
   @Test
   void classTypeAndAlias() {
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var libTree = parseWithoutSymbols(
       """
       class MyClass():

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -17,8 +17,8 @@
 package org.sonar.python.semantic.v2;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -55,6 +55,7 @@ import org.sonar.plugins.python.api.tree.StatementList;
 import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.PythonTestUtils;
+import org.sonar.python.index.ClassDescriptor;
 import org.sonar.python.semantic.ClassSymbolImpl;
 import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.SymbolUtils;
@@ -400,11 +401,10 @@ public class TypeInferenceV2Test {
 
   @Test
   void testProjectLevelSymbolTableImports() {
-    var classSymbol = new ClassSymbolImpl("C", "something.known.C");
-
     ProjectLevelTypeTable projectLevelTypeTable = new ProjectLevelTypeTable(ProjectLevelSymbolTable.from(
-      Map.of("something", new HashSet<>(), "something.known", Set.of(classSymbol)))
-    );
+      Map.of("something.known", Collections.singleton(new ClassDescriptor.ClassDescriptorBuilder().withName("C").withFullyQualifiedName("something.known.C").build()), "something",
+        Set.of())));
+
     var root = inferTypes("""
       import something.known
       """, projectLevelTypeTable);

--- a/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/v2/TypeInferenceV2Test.java
@@ -699,7 +699,7 @@ public class TypeInferenceV2Test {
           b : int
         """
     );
-    var projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    var projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
 
     var symbol = (ClassSymbol) projectLevelSymbolTable.getSymbol("mod.A");
@@ -1268,7 +1268,7 @@ public class TypeInferenceV2Test {
       "class A: ...",
       "def foo2(p1: dict, p2: A): ..."
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var modFile = pythonFile("mod.py");
     projectLevelSymbolTable.addModule(tree, "", modFile);
     ProjectLevelTypeTable projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable);
@@ -2722,7 +2722,7 @@ public class TypeInferenceV2Test {
     FileInput tree = parseWithoutSymbols(
       "def foo() -> int: ..."
     );
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     projectLevelSymbolTable.addModule(tree, "", pythonFile("mod.py"));
     ProjectLevelTypeTable projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable);
 
@@ -3378,7 +3378,7 @@ public class TypeInferenceV2Test {
       def foo(): pass
       def bar(): pass
       """);
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     var modFile = pythonFile("mod.py");
     projectLevelSymbolTable.addModule(tree, "", modFile);
     ProjectLevelTypeTable projectLevelTypeTable = new ProjectLevelTypeTable(projectLevelSymbolTable);
@@ -3549,7 +3549,7 @@ public class TypeInferenceV2Test {
   }
 
   private static class TestProject {
-    private final ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    private final ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     public TestProject addModule(String moduleName, String code) {
       FileInput tree = parseWithoutSymbols(code);

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/TypeCheckerTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/TypeCheckerTest.java
@@ -272,7 +272,7 @@ class TypeCheckerTest {
 
   @Test
   void isTypeWithNameProjectNamesTest() {
-    ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+    ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
     FileInput tree = parseWithoutSymbols(
       """

--- a/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
+++ b/sonar-python-plugin/src/main/java/org/sonar/plugins/python/indexer/PythonIndexer.java
@@ -49,7 +49,7 @@ public abstract class PythonIndexer {
 
   private final Map<URI, String> packageNames = new HashMap<>();
   private final PythonParser parser = PythonParser.create();
-  private final ProjectLevelSymbolTable projectLevelSymbolTable = new ProjectLevelSymbolTable();
+  private final ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
 
   public ProjectLevelSymbolTable projectLevelSymbolTable() {
     return projectLevelSymbolTable;


### PR DESCRIPTION
[SONARPY-2394](https://sonarsource.atlassian.net/browse/SONARPY-2394)

- **SONARPY-2346 Remove usage of old ProjectLevelSymbolTable#from using V1 symbols**
- **Cleanup DescriptorUtils**


[SONARPY-2394]: https://sonarsource.atlassian.net/browse/SONARPY-2394?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ