### PR TITLE
SONARPY-2395 Split the protobuf dependency from the rest to avoid breaking the build of "update all dependencies"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -21,6 +21,11 @@
       "groupSlug": "sq"
     },
     {
+      "matchPackageNames": ["com.google.protobuf:protobuf-java", "com.google.protobuf:protoc"],
+      "groupName": "protobuf",
+      "groupSlug": "protobuf"
+    },
+    {
       "matchPackageNames": ["org.sonarsource.parent:parent"],
       "groupName": "parent",
       "automerge": true


### PR DESCRIPTION
[SONARPY-2395](https://sonarsource.atlassian.net/browse/SONARPY-2395)



[SONARPY-2395]: https://sonarsource.atlassian.net/browse/SONARPY-2395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ