### PR TITLE
SONARPY-2405 Update Orchestrator to version 5.1

### DIFF
--- a/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/PythonPrAnalysisTest.java
@@ -45,7 +45,7 @@ import static org.sonar.python.it.RulingHelper.getOrchestrator;
 class PythonPrAnalysisTest {
 
   @RegisterExtension
-  public static final OrchestratorExtension ORCHESTRATOR = getOrchestrator(Edition.DEVELOPER);
+  public static final OrchestratorExtension ORCHESTRATOR = getOrchestrator(Edition.ENTERPRISE);
 
   private static final String PR_ANALYSIS_PROJECT_KEY = "prAnalysis";
   private static final String INCREMENTAL_ANALYSIS_PROFILE = "incrementalPrAnalysis";

--- a/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
@@ -37,7 +37,7 @@ import static java.util.Collections.singletonList;
 class RulingHelper {
 
   private static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
-  private static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
+  private static final String DEFAULT_SQ_VERSION = "DEV";
 
   static OrchestratorExtension getOrchestrator(Edition sonarEdition) {
     var builder = OrchestratorExtension.builderEnv()

--- a/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
+++ b/its/ruling/src/test/java/org/sonar/python/it/RulingHelper.java
@@ -37,7 +37,7 @@ import static java.util.Collections.singletonList;
 class RulingHelper {
 
   private static final String SQ_VERSION_PROPERTY = "sonar.runtimeVersion";
-  private static final String DEFAULT_SQ_VERSION = "DEV";
+  private static final String DEFAULT_SQ_VERSION = "LATEST_RELEASE";
 
   static OrchestratorExtension getOrchestrator(Edition sonarEdition) {
     var builder = OrchestratorExtension.builderEnv()

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     -->
     <sonar.version>10.7.0.96327</sonar.version>
     <sonar.api.version>10.14.0.2599</sonar.api.version>
-    <sonar.orchestrator.version>5.0.0.2065</sonar.orchestrator.version>
+    <sonar.orchestrator.version>5.1.0.2254</sonar.orchestrator.version>
     <sonar-analyzer-commons.version>2.16.0.3141</sonar-analyzer-commons.version>
     <sonarlint-core.version>10.10.0.79572</sonarlint-core.version>
     <sslr.version>1.24.0.633</sslr.version>


### PR DESCRIPTION
[SONARPY-2405](https://sonarsource.atlassian.net/browse/SONARPY-2405)



[SONARPY-2405]: https://sonarsource.atlassian.net/browse/SONARPY-2405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ