### PR TITLE
SONARPY-2266 TypeAnnotationToPythonTypeConverter creates nested LazyUnionType

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class LazyUnionType implements PythonType, ResolvableType {
@@ -27,7 +28,7 @@ public class LazyUnionType implements PythonType, ResolvableType {
   private final Set<PythonType> candidates;
 
   public LazyUnionType(Set<PythonType> candidates) {
-    this.candidates = candidates.stream().flatMap(LazyUnionType::flattenLazyUnionTypes).collect(HashSet::new, HashSet::add, HashSet::addAll);
+    this.candidates = candidates.stream().flatMap(LazyUnionType::flattenLazyUnionTypes).collect(Collectors.toCollection(HashSet::new));
   }
 
   public PythonType resolve() {

--- a/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
+++ b/python-frontend/src/main/java/org/sonar/python/types/v2/LazyUnionType.java
@@ -16,15 +16,18 @@
  */
 package org.sonar.python.types.v2;
 
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 public class LazyUnionType implements PythonType, ResolvableType {
 
-  private final Set<PythonType> candidates = new HashSet<>();
+  private final Set<PythonType> candidates;
 
   public LazyUnionType(Set<PythonType> candidates) {
-    this.candidates.addAll(candidates);
+    this.candidates = candidates.stream().flatMap(LazyUnionType::flattenLazyUnionTypes).collect(HashSet::new, HashSet::add, HashSet::addAll);
   }
 
   public PythonType resolve() {
@@ -36,5 +39,17 @@ public class LazyUnionType implements PythonType, ResolvableType {
       resolvedCandidates.add(candidate);
     }
     return UnionType.or(resolvedCandidates);
+  }
+
+  private static Stream<PythonType> flattenLazyUnionTypes(PythonType type) {
+    if (type instanceof LazyUnionType lazyUnionType) {
+      return lazyUnionType.candidates.stream();
+    }
+    return Stream.of(type);
+  }
+
+  @VisibleForTesting
+  protected Set<PythonType> candidates() {
+    return Collections.unmodifiableSet(candidates);
   }
 }

--- a/python-frontend/src/test/java/org/sonar/python/types/v2/LazyUnionTypeTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/types/v2/LazyUnionTypeTest.java
@@ -19,7 +19,9 @@ package org.sonar.python.types.v2;
 import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.sonar.python.semantic.ProjectLevelSymbolTable;
 import org.sonar.python.semantic.v2.LazyTypesContext;
+import org.sonar.python.semantic.v2.ProjectLevelTypeTable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
@@ -36,5 +38,24 @@ class LazyUnionTypeTest {
     LazyUnionType lazyUnionType = new LazyUnionType(Set.of(lazyType, FLOAT_TYPE));
     UnionType unionType = (UnionType) lazyUnionType.resolve();
     assertThat(unionType.candidates()).containsExactlyInAnyOrder(INT_TYPE, FLOAT_TYPE);
+  }
+
+  @Test
+  void flattened() {
+    LazyTypesContext lazyTypesContext = Mockito.spy(new LazyTypesContext(new ProjectLevelTypeTable(ProjectLevelSymbolTable.empty())));
+
+    var lazyType1 = lazyTypeUnresolved("lazy1", lazyTypesContext);
+    var lazyType2 = lazyTypeUnresolved("lazy2", lazyTypesContext);
+    var lazyType3 = lazyTypeUnresolved("lazy3", lazyTypesContext);
+
+    var lazyUnionType1 = new LazyUnionType(Set.of(lazyType1, lazyType2, lazyType3));
+    var lazyUnionType2 = new LazyUnionType(Set.of(lazyType1, lazyType2, lazyType3, lazyUnionType1));
+    assertThat(lazyUnionType2.candidates()).containsExactlyInAnyOrder(lazyType1, lazyType2, lazyType3);
+  }
+
+  LazyType lazyTypeUnresolved(String name, LazyTypesContext lazyTypesContext) {
+    var lazyType = lazyTypesContext.getOrCreateLazyType(name);
+    when(lazyTypesContext.resolveLazyType(lazyType)).thenReturn(new UnknownType.UnresolvedImportType(name));
+    return lazyType;
   }
 }


### PR DESCRIPTION
[SONARPY-2266](https://sonarsource.atlassian.net/browse/SONARPY-2266)



[SONARPY-2266]: https://sonarsource.atlassian.net/browse/SONARPY-2266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ