### PR TITLE
SONARPY-2420 Fix crash because of mismatch between line and pythonLine

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
@@ -96,7 +96,7 @@ public class TreeUtils {
   }
 
   public static Comparator<Tree> getTreeByPositionComparator() {
-    return Comparator.comparing((Tree t) -> t.firstToken().line()).thenComparing((Tree t) -> t.firstToken().column());
+    return Comparator.comparing((Tree t) -> t.firstToken().pythonLine()).thenComparing((Tree t) -> t.firstToken().pythonColumn());
   }
 
   public static List<Token> tokens(Tree tree) {
@@ -256,8 +256,8 @@ public class TreeUtils {
     var treeToken = tree.firstToken();
     var parentToken = parent.firstToken();
 
-    if (treeToken.line() != parentToken.line()) {
-      return treeToken.column() - parentToken.column();
+    if (treeToken.pythonLine() != parentToken.pythonLine()) {
+      return treeToken.pythonColumn() - parentToken.pythonColumn();
     } else {
       return findIndentationSize(parent);
     }
@@ -477,8 +477,8 @@ public class TreeUtils {
 
   public static String treeToString(Tree tree, boolean renderMultiline) {
     if (!renderMultiline) {
-      var firstLine = tree.firstToken().line();
-      var lastLine = tree.lastToken().line();
+      var firstLine = tree.firstToken().pythonLine();
+      var lastLine = tree.lastToken().pythonLine();
 
       // We decided to not support multiline default parameters
       // because it requires indents calculation for place where the value should be copied.

--- a/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
+++ b/python-frontend/src/main/java/org/sonar/python/tree/TreeUtils.java
@@ -270,8 +270,8 @@ public class TreeUtils {
       .map(child -> {
 
         var childToken = child.firstToken();
-        if (childToken.line() > parentToken.line() && childToken.column() > parentToken.column()) {
-          return childToken.column() - parentToken.column();
+        if (childToken.pythonLine() > parentToken.pythonLine() && childToken.pythonColumn() > parentToken.pythonColumn()) {
+          return childToken.pythonColumn() - parentToken.pythonColumn();
         } else  {
           return findIndentDownTree(child);
         }


### PR DESCRIPTION
[SONARPY-2420](https://sonarsource.atlassian.net/browse/SONARPY-2420)

It solved the crash locally for me, I can't test this because we can't really analyze notebooks in tests without some more refactoring

[SONARPY-2420]: https://sonarsource.atlassian.net/browse/SONARPY-2420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ