### PR TITLE
SONARPY-2424 Document limitation on AliasDescriptor to PythonType conversion

### DIFF
--- a/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AliasDescriptorToPythonTypeConverter.java
+++ b/python-frontend/src/main/java/org/sonar/python/semantic/v2/converter/AliasDescriptorToPythonTypeConverter.java
@@ -23,7 +23,7 @@ import org.sonar.python.types.v2.PythonType;
 public class AliasDescriptorToPythonTypeConverter implements DescriptorToPythonTypeConverter {
   @Override
   public PythonType convert(ConversionContext ctx, Descriptor from) {
-    // We should try to retrieve the original type if possible, instead of recreating it
+    // SONARPY-2423: We should try to retrieve the original type if possible, instead of recreating it
     return ctx.convert(((AliasDescriptor) from).originalDescriptor());
   }
 }


### PR DESCRIPTION
[SONARPY-2424](https://sonarsource.atlassian.net/browse/SONARPY-2424)



[SONARPY-2424]: https://sonarsource.atlassian.net/browse/SONARPY-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ