### PR TITLE
SONARPY-2463: Fix plugin_qa task

### DIFF
--- a/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
+++ b/its/plugin/it-python-plugin-test/src/test/java/com/sonar/python/it/plugin/MetricsTest.java
@@ -153,17 +153,6 @@ class MetricsTest {
     assertThat(getFileMeasureAsInt(VIOLATIONS)).isZero();
   }
 
-  @Test
-  void should_be_compatible_with_DevCockpit() {
-    // TODO probably bug in Sonar: order might depend on JVM
-    assertThat(getFileMeasure(NCLOC_DATA).getValue())
-      .doesNotContain("1=1")
-      .contains("5=1");
-    assertThat(getFileMeasure(EXECUTABLE_LINES_DATA).getValue())
-      .doesNotContain("1=1")
-      .contains("5=1");
-  }
-
   /* Helper methods */
 
   private Measure getProjectMeasure(String metricKey) {


### PR DESCRIPTION
[SONARPY-2463](https://sonarsource.atlassian.net/browse/SONARPY-2463)

This PR removes the failing test, probably due to the change made in SONAR-22876


[SONARPY-2463]: https://sonarsource.atlassian.net/browse/SONARPY-2463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ