### PR TITLE
SONARPY-2467 Fix performance bottleneck of GlobalSymbolComputation due to DjangoViewsVisitor

### DIFF
--- a/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
+++ b/python-frontend/src/test/java/org/sonar/python/semantic/ProjectLevelSymbolTableTest.java
@@ -521,7 +521,7 @@ class ProjectLevelSymbolTableTest {
       """);
     ProjectLevelSymbolTable projectLevelSymbolTable = ProjectLevelSymbolTable.empty();
     projectLevelSymbolTable.addModule(tree, "my_package", pythonFile("mod.py"));
-    assertThat(projectLevelSymbolTable.typeShedDescriptorsProvider().stubModules()).containsExactlyInAnyOrder("math", "os");
+    assertThat(projectLevelSymbolTable.typeShedDescriptorsProvider().stubModules()).containsExactlyInAnyOrder("math", "os", "django", "django.urls.conf", "django.urls");
   }
 
   @Test

--- a/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
+++ b/sonar-python-plugin/src/test/java/org/sonar/plugins/python/PythonSensorTest.java
@@ -1113,7 +1113,7 @@ class PythonSensorTest {
 
     assertThat(writeCache.getData().keySet()).containsExactlyInAnyOrder(
       "python:cache_version", "python:files", "python:descriptors:moduleKey:pass.py", "python:imports:moduleKey:pass.py",
-      "python:cpd:data:moduleKey:pass.py", "python:cpd:stringTable:moduleKey:pass.py", "python:content_hashes:moduleKey:pass.py");
+      "python:cpd:data:moduleKey:pass.py", "python:cpd:stringTable:moduleKey:pass.py", "python:content_hashes:moduleKey:pass.py", "python:typeshed_modules");
 
     byte[] tokenData = writeCache.getData().get("python:cpd:data:moduleKey:pass.py");
     byte[] stringTable = writeCache.getData().get("python:cpd:stringTable:moduleKey:pass.py");


### PR DESCRIPTION
[SONARPY-2467](https://sonarsource.atlassian.net/browse/SONARPY-2467)

This change avoids recreating the same `TypeCheckBuilder` object repeatedly when performing the Django views visit. Instead, it uses only one for each file.
This implies that we're going to load Typeshed stubs for Django on all files, even if they don't contain `CalleExpression`. While this implication should have no real-world impact, this is what changes some of the project level symbol table and sensor tests 


[SONARPY-2467]: https://sonarsource.atlassian.net/browse/SONARPY-2467?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ