### PR TITLE
SONARPY-2438 Exclude the typeshed serializer from the Mend scan

### DIFF
--- a/wss-unified-agent.config
+++ b/wss-unified-agent.config
@@ -1,6 +1,6 @@
 # WhiteSource documentation https://whitesource.atlassian.net/wiki/spaces/WD/pages/1544880156/Unified+Agent+Configuration+Parameters
 
-excludes=**/*sources.jar **/*javadoc.jar its/sources/** its/plugin/it-python-plugin-test/projects/**
+excludes=**/*sources.jar **/*javadoc.jar its/sources/** its/plugin/it-python-plugin-test/projects/** python-frontend/typeshed_serializer/**
 fileSystemScan=False
 resolveAllDependencies=False
 


### PR DESCRIPTION
[SONARPY-2438](https://sonarsource.atlassian.net/browse/SONARPY-2438)



[SONARPY-2438]: https://sonarsource.atlassian.net/browse/SONARPY-2438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ