### PR TITLE
SONARPY-4248 Add support for bandit's # nosec directive

### DIFF
--- a/python-commons/src/test/java/org/sonar/plugins/python/nosonar/NoSonarLineInfoCollectorTest.java
+++ b/python-commons/src/test/java/org/sonar/plugins/python/nosonar/NoSonarLineInfoCollectorTest.java
@@ -185,6 +185,24 @@ class NoSonarLineInfoCollectorTest {
         Set.of(1, 2, 3, 4, 5),
         "",
         ""
+      ),
+      Arguments.of("""
+          import hashlib
+          hashlib.md5(b"x").hexdigest() # nosec
+          """,
+        Map.of(2, new NoSonarLineInfo(Set.of(), "")),
+        Set.of(2),
+        "",
+        ""
+      ),
+      Arguments.of("""
+          import hashlib
+          hashlib.md5(b"x").hexdigest() # nosec B303 legacy hash
+          """,
+        Map.of(2, new NoSonarLineInfo(Set.of(), "B303 legacy hash")),
+        Set.of(2),
+        "",
+        ""
       )
     );
   }

--- a/python-frontend/src/main/java/org/sonar/plugins/python/api/nosonar/NoSonarInfoParser.java
+++ b/python-frontend/src/main/java/org/sonar/plugins/python/api/nosonar/NoSonarInfoParser.java
@@ -33,14 +33,19 @@ public class NoSonarInfoParser {
   private static final String NOQA_PATTERN_REGEX = "^#\\s*noqa(?::\\s*(.+))?(?:[\\s;:].*)?";
   private static final String NOSONAR_PREFIX_REGEX = "^#\\s*NOSONAR(\\W.*)?";
   private static final String NOSONAR_PATTERN_REGEX = "^#\\s*NOSONAR(?:\\s*\\(([^)]*)\\))?($|\\s.*)";
+  // Bandit `# nosec`. Anything after `nosec` is treated as a free-form description; rule IDs
+  // are not parsed, so every `# nosec` suppresses all issues on the line.
+  private static final String NOSEC_PATTERN_REGEX = "(?i)^#\\s*nosec\\b[:\\s]*(.*)";
   private static final String RULE_KEY_PATTERN_REGEX = "^[a-zA-Z0-9]+$";
 
   private final Pattern noSonarPattern;
   private final Pattern noQaPattern;
+  private final Pattern noSecPattern;
 
   public NoSonarInfoParser() {
     noSonarPattern = Pattern.compile(NOSONAR_PATTERN_REGEX);
     noQaPattern = Pattern.compile(NOQA_PATTERN_REGEX);
+    noSecPattern = Pattern.compile(NOSEC_PATTERN_REGEX);
   }
 
   public boolean isInvalidIssueSuppressionComment(String commentsLine) {
@@ -94,6 +99,10 @@ public class NoSonarInfoParser {
     return noSonarCommentLine.matches(NOQA_PATTERN_REGEX);
   }
 
+  public static boolean isValidNoSec(String commentLine) {
+    return commentLine.matches(NOSEC_PATTERN_REGEX);
+  }
+
   public Optional<NoSonarLineInfo> parse(String commentLine) {
     var rules = new HashSet<String>();
     StringBuilder concatenatedCommentBuilder = new StringBuilder();
@@ -132,6 +141,9 @@ public class NoSonarInfoParser {
         .filter(Predicate.not(String::isEmpty))
         .forEach(rules::add);
       comment = parseNoQaComment(commentLine);
+    } else if (isValidNoSec(commentLine)) {
+      // `# nosec` always suppresses all rules on the line; we do not parse Bandit IDs.
+      comment = parseNoSecComment(commentLine);
     } else {
       return null;
     }
@@ -172,6 +184,12 @@ public class NoSonarInfoParser {
 
   private String parseNoQaComment(String noSonarCommentLine) {
     return getTruncatedCommentString(noQaPattern, noSonarCommentLine).strip();
+  }
+
+  private String parseNoSecComment(String noSecCommentLine) {
+    var raw = getPatternGroup(1, noSecPattern, noSecCommentLine);
+    var truncated = raw.length() > MAX_COMMENT_LENGTH ? raw.substring(0, MAX_COMMENT_LENGTH) : raw;
+    return truncated.strip();
   }
 
   private static String getParamsString(Pattern pattern, String noSonarCommentLine) {

--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/nosonar/NoSonarInfoParserTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/nosonar/NoSonarInfoParserTest.java
@@ -130,6 +130,34 @@ class NoSonarInfoParserTest {
       Arguments.of(
         "# noqa; noqa; noqa; noqa; noqa",
         new NoSonarLineInfo(Set.of())
+      ),
+      Arguments.of(
+        "# nosec",
+        new NoSonarLineInfo(Set.of())
+      ),
+      Arguments.of(
+        "# nosec B101",
+        new NoSonarLineInfo(Set.of(), "B101")
+      ),
+      Arguments.of(
+        "# nosec B101, B102 reason text",
+        new NoSonarLineInfo(Set.of(), "B101, B102 reason text")
+      ),
+      Arguments.of(
+        "# nosec: it's fine",
+        new NoSonarLineInfo(Set.of(), "it's fine")
+      ),
+      Arguments.of(
+        "# NOSEC",
+        new NoSonarLineInfo(Set.of())
+      ),
+      Arguments.of(
+        "# nosec a very long comment that I don't want to keep that long because there is more than 50 characters",
+        new NoSonarLineInfo(Set.of(), "a very long comment that I don't want to keep that")
+      ),
+      Arguments.of(
+        "# some text # nosec",
+        new NoSonarLineInfo(Set.of())
       )
     );
   }


### PR DESCRIPTION
## Summary

- Extend `NoSonarInfoParser` to recognize `# nosec` comments (case-insensitive, colon or whitespace separator, trailing description allowed).
- `# nosec` produces a `NoSonarLineInfo` with an empty suppressed-rule-key set, which the existing `NoSonarIssueFilter` already interprets as "suppress all rules on this line" — no filter changes needed. As a result, `# nosec` silences e.g. S4790 on the offending line, matching bandit's own semantics.
- Tests added to `NoSonarInfoParserTest` (bare, `# nosec B101`, with reason, colon form, uppercase, length-truncated, mixed with another `#` segment) and end-to-end cases in `NoSonarLineInfoCollectorTest`.

Ticket: https://sonarsource.atlassian.net/browse/SONARPY-4248
Sibling of [SONARGO-809](https://sonarsource.atlassian.net/browse/SONARGO-809) (Go `//nolint`).

## Follow-up

Bandit also supports test IDs (`# nosec B303, B607`). The repo has no Bandit-ID → Sonar-rule mapping today, so anything after `nosec` is parsed as free-form description and BXXX IDs are not honored.

A nicer behaviour for bare `# nosec` would be to suppress only security-typed rules (71 rules with `type: VULNERABILITY` or `SECURITY_HOTSPOT` under `python-checks/.../l10n/py/rules/python/*.json`) rather than everything on the line, closer to user intent. That would require:

1. Adding a discriminator on `NoSonarLineInfo` (e.g. `SuppressionScope.SECURITY_ONLY`).
2. Pre-computing the set of security rule keys at scanner startup (the metadata is already loaded by `AbstractPythonRuleRepository` via `RuleMetadataLoader`).
3. Updating `NoSonarIssueFilter` to consult that set when the line's scope is `SECURITY_ONLY`.

Out of scope for this PR; can land as a follow-up under the same ticket.

## Test plan

- [x] `mvn test -Dtest=NoSonarInfoParserTest` in `python-frontend` (68 tests pass).
- [ ] `mvn test -Dtest=NoSonarLineInfoCollectorTest` in `python-commons` (collector test cases added but not run locally — `python-commons` needs `python-frontend` installed; CI will cover).
- [ ] Manually verify `# nosec` on a `hashlib.md5(...)` line suppresses S4790.

[SONARGO-809]: https://sonarsource.atlassian.net/browse/SONARGO-809?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SONARPY-4248]: https://sonarsource.atlassian.net/browse/SONARPY-4248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ