### PR TITLE
Fix inline Mockito mock creation

### DIFF
--- a/python-frontend/src/test/java/org/sonar/plugins/python/api/types/v2/matchers/TypeMatcherImplTest.java
+++ b/python-frontend/src/test/java/org/sonar/plugins/python/api/types/v2/matchers/TypeMatcherImplTest.java
@@ -110,7 +110,8 @@ class TypeMatcherImplTest {
   @Test
   void testIsFor() {
     SubscriptionContext ctx = mock();
-    when(ctx.typeTable()).thenReturn(mock(TypeTable.class));
+    TypeTable typeTable = mock(TypeTable.class);
+    when(ctx.typeTable()).thenReturn(typeTable);
     assertThat(typeMatcher.evaluateFor(functionExpr, ctx)).isEqualTo(TriBool.TRUE);
     assertThat(typeMatcher.evaluateFor(unknownExpr, ctx)).isEqualTo(TriBool.UNKNOWN);
     assertThat(typeMatcher.evaluateFor(objectExpr, ctx)).isEqualTo(TriBool.FALSE);
@@ -123,7 +124,8 @@ class TypeMatcherImplTest {
   @Test
   void testIsTrueFor() {
     SubscriptionContext ctx = mock(SubscriptionContext.class);
-    when(ctx.typeTable()).thenReturn(mock(TypeTable.class));
+    TypeTable typeTable = mock(TypeTable.class);
+    when(ctx.typeTable()).thenReturn(typeTable);
     assertThat(typeMatcher.isTrueFor(functionExpr, ctx)).isTrue();
     assertThat(typeMatcher.isTrueFor(unknownExpr, ctx)).isFalse();
     assertThat(typeMatcher.isTrueFor(objectExpr, ctx)).isFalse();


### PR DESCRIPTION
## Summary

Extract `TypeTable` mock creation from the two `thenReturn` calls in `TypeMatcherImplTest`. This preserves Mockito unfinished-stubbing validation and resolves the two `java:S9016` findings currently failing the Quality Gate.

## Test

- `IS_COMMUNITY=true mvn -pl python-frontend -Dtest=TypeMatcherImplTest test`