### PR TITLE
SONARPY-4544 Count terminal raises as exits

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
@@ -129,7 +129,7 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
       for (CfgBlock predecessor : branchingBlock.predecessors()) {
         if (predecessor instanceof PythonCfgBranchingBlock pythonCfgBranchingBlock) {
           collectBlocksHavingReturnBeforeExceptOrFinallyBlock(collectedBlocks, pythonCfgBranchingBlock);
-        } else if (endsWithElementKind(predecessor, Kind.RETURN_STMT)) {
+        } else if (endsWithElementKind(predecessor, Kind.RETURN_STMT) || endsWithElementKind(predecessor, Kind.RAISE_STMT)) {
           collectedBlocks.add(new LatestExecutedBlock(predecessor));
         }
       }

--- a/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
@@ -80,7 +80,11 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
 
   private static List<LatestExecutedBlock> collectLatestExecutedBlocks(ControlFlowGraph cfg) {
     List<LatestExecutedBlock> collectedBlocks = new ArrayList<>();
+    Set<CfgBlock> reachableBlocks = reachableBlocks(cfg.start());
     for (CfgBlock predecessor : cfg.end().predecessors()) {
+      if (!reachableBlocks.contains(predecessor)) {
+        continue;
+      }
       if (predecessor instanceof PythonCfgBranchingBlock pythonCfgBranchingBlock) {
         collectBranchingBlock(collectedBlocks, pythonCfgBranchingBlock);
       } else {
@@ -88,6 +92,22 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
       }
     }
     return collectedBlocks;
+  }
+
+  private static Set<CfgBlock> reachableBlocks(CfgBlock start) {
+    Set<CfgBlock> reachable = new HashSet<>();
+    Deque<CfgBlock> blockToVisit = new ArrayDeque<>();
+    blockToVisit.push(start);
+    reachable.add(start);
+    while (!blockToVisit.isEmpty()) {
+      CfgBlock block = blockToVisit.pop();
+      for (CfgBlock successor : block.successors()) {
+        if (reachable.add(successor)) {
+          blockToVisit.push(successor);
+        }
+      }
+    }
+    return reachable;
   }
 
   private static void collectBranchingBlock(List<LatestExecutedBlock> collectedBlocks, PythonCfgBranchingBlock branchingBlock) {

--- a/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
@@ -83,7 +83,7 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
     for (CfgBlock predecessor : cfg.end().predecessors()) {
       if (predecessor instanceof PythonCfgBranchingBlock pythonCfgBranchingBlock) {
         collectBranchingBlock(collectedBlocks, pythonCfgBranchingBlock);
-      } else if (!endsWithElementKind(predecessor, Kind.RAISE_STMT)) {
+      } else {
         collectedBlocks.add(new LatestExecutedBlock(predecessor));
       }
     }
@@ -211,6 +211,10 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
     return bindings.size() == 1 ? bindings.iterator().next() : null;
   }
 
+  private static boolean endsWithElementKind(CfgBlock block, Kind kind) {
+    return lastElement(block, kind) != null;
+  }
+
   @Nullable
   private static Tree findLastBinding(List<Tree> elements, Symbol identifier) {
     for (int i = elements.size() - 1; i >= 0; i--) {
@@ -249,10 +253,6 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
       return ((ForStatement) parent).expressions().contains(child);
     }
     return true;
-  }
-
-  private static boolean endsWithElementKind(CfgBlock block, Kind kind) {
-    return lastElement(block, kind) != null;
   }
 
   @Nullable

--- a/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
@@ -231,10 +231,6 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
     return bindings.size() == 1 ? bindings.iterator().next() : null;
   }
 
-  private static boolean endsWithElementKind(CfgBlock block, Kind kind) {
-    return lastElement(block, kind) != null;
-  }
-
   @Nullable
   private static Tree findLastBinding(List<Tree> elements, Symbol identifier) {
     for (int i = elements.size() - 1; i >= 0; i--) {
@@ -273,6 +269,10 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
       return ((ForStatement) parent).expressions().contains(child);
     }
     return true;
+  }
+
+  private static boolean endsWithElementKind(CfgBlock block, Kind kind) {
+    return lastElement(block, kind) != null;
   }
 
   @Nullable

--- a/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/InvariantReturnCheck.java
@@ -86,7 +86,7 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
         continue;
       }
       if (predecessor instanceof PythonCfgBranchingBlock pythonCfgBranchingBlock) {
-        collectBranchingBlock(collectedBlocks, pythonCfgBranchingBlock);
+        collectBranchingBlock(collectedBlocks, pythonCfgBranchingBlock, reachableBlocks);
       } else {
         collectedBlocks.add(new LatestExecutedBlock(predecessor));
       }
@@ -110,7 +110,7 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
     return reachable;
   }
 
-  private static void collectBranchingBlock(List<LatestExecutedBlock> collectedBlocks, PythonCfgBranchingBlock branchingBlock) {
+  private static void collectBranchingBlock(List<LatestExecutedBlock> collectedBlocks, PythonCfgBranchingBlock branchingBlock, Set<CfgBlock> reachableBlocks) {
     Tree branchingTree = branchingBlock.branchingTree();
     if (branchingTree.is(Kind.TRY_STMT)) {
       TryStatement tryStatement = (TryStatement) branchingTree;
@@ -120,15 +120,18 @@ public class InvariantReturnCheck extends PythonSubscriptionCheck {
     } else if (branchingTree.is(Kind.IF_STMT) || branchingTree instanceof Pattern) {
       collectedBlocks.add(new LatestExecutedBlock(branchingBlock));
     } else {
-      collectBlocksHavingReturnBeforeExceptOrFinallyBlock(collectedBlocks, branchingBlock);
+      collectBlocksHavingReturnBeforeExceptOrFinallyBlock(collectedBlocks, branchingBlock, reachableBlocks);
     }
   }
 
-  private static void collectBlocksHavingReturnBeforeExceptOrFinallyBlock(List<LatestExecutedBlock> collectedBlocks, PythonCfgBranchingBlock branchingBlock) {
+  private static void collectBlocksHavingReturnBeforeExceptOrFinallyBlock(List<LatestExecutedBlock> collectedBlocks, PythonCfgBranchingBlock branchingBlock, Set<CfgBlock> reachableBlocks) {
     if (branchingBlock.branchingTree().is(Kind.EXCEPT_CLAUSE, Kind.FINALLY_CLAUSE)) {
       for (CfgBlock predecessor : branchingBlock.predecessors()) {
+        if (!reachableBlocks.contains(predecessor)) {
+          continue;
+        }
         if (predecessor instanceof PythonCfgBranchingBlock pythonCfgBranchingBlock) {
-          collectBlocksHavingReturnBeforeExceptOrFinallyBlock(collectedBlocks, pythonCfgBranchingBlock);
+          collectBlocksHavingReturnBeforeExceptOrFinallyBlock(collectedBlocks, pythonCfgBranchingBlock, reachableBlocks);
         } else if (endsWithElementKind(predecessor, Kind.RETURN_STMT) || endsWithElementKind(predecessor, Kind.RAISE_STMT)) {
           collectedBlocks.add(new LatestExecutedBlock(predecessor));
         }

--- a/python-checks/src/test/resources/checks/invariantReturn.py
+++ b/python-checks/src/test/resources/checks/invariantReturn.py
@@ -453,6 +453,26 @@ def f_unreachable_raise_does_not_prevent_reporting(a, b): # Noncompliant
     return b
     raise ValueError()
 
+def f_raise_in_try_with_finally(early, invalid, value):
+    if early:
+        return value
+    try:
+        if invalid:
+            raise ValueError()
+    finally:
+        pass
+    return value
+
+def f_raise_in_try_with_except(early, invalid, value):
+    if early:
+        return value
+    try:
+        if invalid:
+            raise ValueError()
+    except TypeError:
+        cleanup()
+    return value
+
 def f_same_binding_through_multiple_paths(a): # Noncompliant
     d = 3
     try:

--- a/python-checks/src/test/resources/checks/invariantReturn.py
+++ b/python-checks/src/test/resources/checks/invariantReturn.py
@@ -447,6 +447,12 @@ def f_early_return_with_raise_guard(already_valid, invalid, self):
         raise ValueError()
     return self
 
+def f_unreachable_raise_does_not_prevent_reporting(a, b): # Noncompliant
+    if a:
+        return b
+    return b
+    raise ValueError()
+
 def f_same_binding_through_multiple_paths(a): # Noncompliant
     d = 3
     try:

--- a/python-checks/src/test/resources/checks/invariantReturn.py
+++ b/python-checks/src/test/resources/checks/invariantReturn.py
@@ -473,6 +473,17 @@ def f_raise_in_try_with_except(early, invalid, value):
         cleanup()
     return value
 
+def f_unreachable_raise_before_finally_does_not_prevent_reporting(a, b): # Noncompliant
+    try:
+        if a:
+            return b
+        else:
+            return b
+        raise ValueError()
+    finally:
+        pass
+    return b
+
 def f_same_binding_through_multiple_paths(a): # Noncompliant
     d = 3
     try:

--- a/python-checks/src/test/resources/checks/invariantReturn.py
+++ b/python-checks/src/test/resources/checks/invariantReturn.py
@@ -440,12 +440,12 @@ def f_function_exit_through_raise_prevents_reporting(a, b, c):
         raise
     return b
 
-def f_early_return_with_raise_guard(already_valid, invalid, self):
+def f_early_return_with_raise_guard(already_valid, invalid, obj):
     if already_valid:
-        return self
+        return obj
     if invalid:
         raise ValueError()
-    return self
+    return obj
 
 def f_unreachable_raise_does_not_prevent_reporting(a, b): # Noncompliant
     if a:

--- a/python-checks/src/test/resources/checks/invariantReturn.py
+++ b/python-checks/src/test/resources/checks/invariantReturn.py
@@ -433,15 +433,19 @@ def f_raise_is_not_a_return(a, b):
         raise b
     return b
 
-def f_function_exit_through_raise_should_be_ignored(a, b, c): # Noncompliant
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+def f_function_exit_through_raise_prevents_reporting(a, b, c):
     if a:
         return b
-#       ^^^^^^^^<
     if c:
         raise
     return b
-#   ^^^^^^^^<
+
+def f_early_return_with_raise_guard(already_valid, invalid, self):
+    if already_valid:
+        return self
+    if invalid:
+        raise ValueError()
+    return self
 
 def f_same_binding_through_multiple_paths(a): # Noncompliant
     d = 3


### PR DESCRIPTION
## Summary
Treat terminal `raise` CFG edges as exits for S3516, preventing reports on validator-style methods that either return a common value or raise.

## Changes
- Preserve terminal raise predecessors when collecting S3516 exit paths.
- Cover both the existing raised exit and a return/raise/return validator pattern.

## Functional Validation
Artifact: [sonarpy-4544-fv.zip](https://github.com/user-attachments/files/31142007/sonarpy-4544-fv.zip)

Once the file is attached to the PR description, unzip and run:
    ./run.sh

Expected output:
```text
******************* MASTER *******************
Analyzing "sample.py"...
Results:
    - Rule "S3516" -> L.2
****** Branch "fix/sonarpy-4544-treat-terminal-raise-as-exit" ******
Analyzing "sample.py"...
Results:
    (none)
```
