### PR TITLE
SONARPY-4539 FP: S1313 should not report version values assigned to __version__

### DIFF
--- a/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
@@ -132,6 +132,9 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
    * @return whether the expression is named {@code __version__}
    */
   private static boolean isVersionName(Expression expression) {
+    while (expression instanceof ParenthesizedExpression parenthesizedExpression) {
+      expression = parenthesizedExpression.expression();
+    }
     return expression instanceof Name name && "__version__".equals(name.name());
   }
 

--- a/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
@@ -94,11 +94,6 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
     });
   }
 
-  /**
-   * Checks whether a literal is directly assigned to the conventional version variable.
-   * @param stringLiteral literal to inspect
-   * @return whether the literal is a direct {@code __version__} value
-   */
   private static boolean isVersionLiteral(StringLiteral stringLiteral) {
     Expression assignedValue = stringLiteral;
     while (assignedValue.parent() instanceof ParenthesizedExpression parenthesizedExpression) {
@@ -113,11 +108,6 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
       && isVersionName(assignment.variable());
   }
 
-  /**
-   * Checks whether an assignment has exactly one {@code __version__} target.
-   * @param assignment assignment to inspect
-   * @return whether the assignment has the conventional version target
-   */
   private static boolean hasVersionName(AssignmentStatement assignment) {
     if (assignment.lhsExpressions().size() != 1) {
       return false;
@@ -126,11 +116,6 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
     return lhsExpressions.expressions().size() == 1 && isVersionName(lhsExpressions.expressions().get(0));
   }
 
-  /**
-   * Checks whether an expression is the conventional version variable.
-   * @param expression expression to inspect
-   * @return whether the expression is named {@code __version__}
-   */
   private static boolean isVersionName(Expression expression) {
     return Expressions.removeParentheses(expression) instanceof Name name && "__version__".equals(name.name());
   }

--- a/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
@@ -132,10 +132,7 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
    * @return whether the expression is named {@code __version__}
    */
   private static boolean isVersionName(Expression expression) {
-    while (expression instanceof ParenthesizedExpression parenthesizedExpression) {
-      expression = parenthesizedExpression.expression();
-    }
-    return expression instanceof Name name && "__version__".equals(name.name());
+    return Expressions.removeParentheses(expression) instanceof Name name && "__version__".equals(name.name());
   }
 
   private static boolean isMultilineString(StringLiteral pyStringLiteralTree) {

--- a/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
+++ b/python-checks/src/main/java/org/sonar/python/checks/HardcodedIPCheck.java
@@ -23,6 +23,12 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.sonar.check.Rule;
 import org.sonar.plugins.python.api.PythonSubscriptionCheck;
+import org.sonar.plugins.python.api.tree.AnnotatedAssignment;
+import org.sonar.plugins.python.api.tree.AssignmentStatement;
+import org.sonar.plugins.python.api.tree.Expression;
+import org.sonar.plugins.python.api.tree.ExpressionList;
+import org.sonar.plugins.python.api.tree.Name;
+import org.sonar.plugins.python.api.tree.ParenthesizedExpression;
 import org.sonar.plugins.python.api.tree.StringLiteral;
 import org.sonar.plugins.python.api.tree.Tree;
 import org.sonar.python.checks.utils.Expressions;
@@ -63,7 +69,7 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
   public void initialize(Context context) {
     context.registerSyntaxNodeConsumer(Tree.Kind.STRING_LITERAL, ctx -> {
       StringLiteral stringLiteral = (StringLiteral) ctx.syntaxNode();
-      if (isMultilineString(stringLiteral)) {
+      if (isMultilineString(stringLiteral) || isVersionLiteral(stringLiteral)) {
         return;
       }
       String content = Expressions.unescape(stringLiteral);
@@ -86,6 +92,47 @@ public class HardcodedIPCheck extends PythonSubscriptionCheck {
           .ifPresent(ipv6 -> ctx.addIssue(stringLiteral, String.format(message, ipv6)));
       }
     });
+  }
+
+  /**
+   * Checks whether a literal is directly assigned to the conventional version variable.
+   * @param stringLiteral literal to inspect
+   * @return whether the literal is a direct {@code __version__} value
+   */
+  private static boolean isVersionLiteral(StringLiteral stringLiteral) {
+    Expression assignedValue = stringLiteral;
+    while (assignedValue.parent() instanceof ParenthesizedExpression parenthesizedExpression) {
+      assignedValue = parenthesizedExpression;
+    }
+    Tree parent = assignedValue.parent();
+    if (parent instanceof AssignmentStatement assignment) {
+      return assignment.assignedValue() == assignedValue && hasVersionName(assignment);
+    }
+    return parent instanceof AnnotatedAssignment assignment
+      && assignment.assignedValue() == assignedValue
+      && isVersionName(assignment.variable());
+  }
+
+  /**
+   * Checks whether an assignment has exactly one {@code __version__} target.
+   * @param assignment assignment to inspect
+   * @return whether the assignment has the conventional version target
+   */
+  private static boolean hasVersionName(AssignmentStatement assignment) {
+    if (assignment.lhsExpressions().size() != 1) {
+      return false;
+    }
+    ExpressionList lhsExpressions = assignment.lhsExpressions().get(0);
+    return lhsExpressions.expressions().size() == 1 && isVersionName(lhsExpressions.expressions().get(0));
+  }
+
+  /**
+   * Checks whether an expression is the conventional version variable.
+   * @param expression expression to inspect
+   * @return whether the expression is named {@code __version__}
+   */
+  private static boolean isVersionName(Expression expression) {
+    return expression instanceof Name name && "__version__".equals(name.name());
   }
 
   private static boolean isMultilineString(StringLiteral pyStringLiteralTree) {

--- a/python-checks/src/test/resources/checks/hardcodedIP.py
+++ b/python-checks/src/test/resources/checks/hardcodedIP.py
@@ -22,6 +22,13 @@ notAnIp5 = "0.256.0.0"
 fileName = "v0.0.1.200__do_something.sql" # Compliant - suffixed and prefixed
 version = "1.0.0.0-1" # Compliant - suffixed
 
+__version__ = "26.8.0.1" # Compliant
+__version__ = ("26.8.0.1") # Compliant
+__version__: str = "26.8.0.1" # Compliant
+version = "26.8.0.1" # Noncompliant
+VERSION = "26.8.0.1" # Noncompliant
+__version__ = version = "26.8.0.1" # Noncompliant
+
 "1080:0:0:0:8:800:200C:417A" # Noncompliant {{Make sure using this hardcoded IP address "1080:0:0:0:8:800:200C:417A" is safe here.}}
 "[1080::8:800:200C:417A]" # Noncompliant
 "::800:200C:417A" # Noncompliant

--- a/python-checks/src/test/resources/checks/hardcodedIP.py
+++ b/python-checks/src/test/resources/checks/hardcodedIP.py
@@ -25,6 +25,7 @@ version = "1.0.0.0-1" # Compliant - suffixed
 __version__ = "26.8.0.1" # Compliant
 __version__ = ("26.8.0.1") # Compliant
 __version__: str = "26.8.0.1" # Compliant
+(__version__) = "26.8.0.1" # Compliant
 version = "26.8.0.1" # Noncompliant
 VERSION = "26.8.0.1" # Noncompliant
 __version__ = version = "26.8.0.1" # Noncompliant

--- a/python-checks/src/test/resources/checks/hardcodedIP.py
+++ b/python-checks/src/test/resources/checks/hardcodedIP.py
@@ -29,6 +29,8 @@ __version__: str = "26.8.0.1" # Compliant
 version = "26.8.0.1" # Noncompliant
 VERSION = "26.8.0.1" # Noncompliant
 __version__ = version = "26.8.0.1" # Noncompliant
+metadata.__version__ = "26.8.0.1" # Noncompliant
+versions["__version__"] = "26.8.0.1" # Noncompliant
 
 "1080:0:0:0:8:800:200C:417A" # Noncompliant {{Make sure using this hardcoded IP address "1080:0:0:0:8:800:200C:417A" is safe here.}}
 "[1080::8:800:200C:417A]" # Noncompliant


### PR DESCRIPTION
## Summary
Avoid false positives by treating IPv4-shaped literals assigned directly to the Python __version__ variable as package versions.

## Changes
- Detect direct standard and annotated version assignments in S1313
- Preserve reporting for ordinary, uppercase, and chained assignments
- Add regression coverage for direct and parenthesized version literals