### PR TITLE
TEST - fix uv/repox 401 in serializer-runner (do not merge, port to sonar-python-enterprise)

### DIFF
--- a/python-frontend/pom.xml
+++ b/python-frontend/pom.xml
@@ -190,6 +190,16 @@
                       <argument>--fail_fast</argument>
                       <argument>${failStubGenerationFast}</argument>
                   </arguments>
+                  <!--
+                    uv authenticates the "repox" index declared in typeshed_serializer/pyproject.toml via
+                    UV_INDEX_REPOX_USERNAME/PASSWORD. It does not read pip.conf, so the Artifactory reader
+                    credentials that config-maven already exports for the job must be re-exposed under the
+                    names uv expects, or every cache-cold package install 401s against sonarsource-pypi.
+                  -->
+                  <environmentVariables>
+                    <UV_INDEX_REPOX_USERNAME>${env.ARTIFACTORY_USERNAME}</UV_INDEX_REPOX_USERNAME>
+                    <UV_INDEX_REPOX_PASSWORD>${env.ARTIFACTORY_ACCESS_TOKEN}</UV_INDEX_REPOX_PASSWORD>
+                  </environmentVariables>
                   <useMavenLogger>true</useMavenLogger>
                 </configuration>
                 <goals>


### PR DESCRIPTION
## What

The `Build` workflow has been failing on all three matrix legs (`sqc-eu`, `sqc-us`, `next`) at the `exec-maven-plugin:exec (serializer-runner)` goal on `python-frontend`, on every run since 2026-09-02T07:33. Example: https://github.com/SonarSource/sonar-python/actions/runs/33827965343/job/100884577646

## Root cause

Commit 9e20e9ee ("SONARPY-4604 Moved from tox to uv") replaced the `tox`/`pip`-driven install of `typeshed_serializer`'s dependencies with `uv`. The new `pyproject.toml` declares:

```toml
[[tool.uv.index]]
name = "repox"
url = "https://repox.jfrog.io/artifactory/api/pypi/sonarsource-pypi/simple"
default = true
```

`uv` authenticates a named index via `UV_INDEX_<NAME>_USERNAME`/`UV_INDEX_<NAME>_PASSWORD` env vars. It does not read `pip.conf` or any other pip-style config, unlike plain `pip` (which `tox` used, and which was presumably authenticated through machine-level config on the runner image). Since the migration, no credentials are wired up for `uv`'s "repox" index, so every install of a package that isn't already warm in the local cache fails with `HTTP status client error (401)` against `sonarsource-pypi`. Because it's whichever package is cold, the specific package name in the error differs run to run (`first==2.0.2`, `mypy-extensions==1.1.0`, ...) while the underlying cause is identical.

## Fix

`config-maven` (from `SonarSource/ci-github-actions`) already exports `ARTIFACTORY_USERNAME` / `ARTIFACTORY_ACCESS_TOKEN` (Vault-issued Artifactory reader-role credentials) to the job environment for every step, including the Maven `exec` goal that shells out to `uv`. This PR re-exposes those same credentials under the env var names `uv` looks for on the `repox` index, scoped to just the `serializer-runner` execution via the `exec-maven-plugin`'s `<environmentVariables>`:

```xml
<environmentVariables>
  <UV_INDEX_REPOX_USERNAME>${env.ARTIFACTORY_USERNAME}</UV_INDEX_REPOX_USERNAME>
  <UV_INDEX_REPOX_PASSWORD>${env.ARTIFACTORY_ACCESS_TOKEN}</UV_INDEX_REPOX_PASSWORD>
</environmentVariables>
```

No changes to the shared CI action or to secrets are needed - this only rewires credentials that are already present in the job.

## This PR is for CI verification only

This repo appears to be a downstream mirror/export of `sonar-python-enterprise` - please confirm whether the actual fix needs to be authored and merged there instead, with this PR closed once the workflow run confirms the fix works. Do not merge this PR as-is.

## Test plan

- [ ] Confirm the `Build` workflow (all 3 matrix legs) passes on this branch, specifically that `exec:3.6.3:exec (serializer-runner) @ python-frontend` no longer 401s
- [ ] Port the equivalent change to `sonar-python-enterprise` and merge there
- [ ] Close/discard this PR once verified